### PR TITLE
Remove e2e build tag in favor of scoped tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,12 +131,12 @@ $(BUILD_DIR)/golangci-lint:
 
 .PHONY: test-unit
 test-unit: $(BUILD_DIR) ## Run the unit tests
-	$(GO) test -ldflags '$(LDVARS)' -v -test.coverprofile=$(BUILD_DIR)/coverage.out ./...
+	$(GO) test -ldflags '$(LDVARS)' -v -test.coverprofile=$(BUILD_DIR)/coverage.out ./internal/...
 	$(GO) tool cover -html $(BUILD_DIR)/coverage.out -o $(BUILD_DIR)/coverage.html
 
 .PHONY: test-e2e
 test-e2e: ## Run the end-to-end tests
-	$(GO) test -timeout 40m -tags e2e -count=1 ./test/... -v
+	$(GO) test -timeout 40m -count=1 ./test/... -v
 
 # Generate CRD manifest
 manifests:

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -1,5 +1,3 @@
-// +build e2e
-
 /*
 Copyright 2020 The Kubernetes Authors.
 

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -1,5 +1,3 @@
-// +build e2e
-
 /*
 Copyright 2020 The Kubernetes Authors.
 

--- a/test/tc_default_profiles_test.go
+++ b/test/tc_default_profiles_test.go
@@ -1,5 +1,3 @@
-// +build e2e
-
 /*
 Copyright 2020 The Kubernetes Authors.
 

--- a/test/tc_redeploy_operator_test.go
+++ b/test/tc_redeploy_operator_test.go
@@ -1,5 +1,3 @@
-// +build e2e
-
 /*
 Copyright 2020 The Kubernetes Authors.
 

--- a/test/tc_run_pod_test.go
+++ b/test/tc_run_pod_test.go
@@ -1,5 +1,3 @@
-// +build e2e
-
 /*
 Copyright 2020 The Kubernetes Authors.
 


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
The build tag is not required since we already split the tests between
`internal` and `test` directory.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
