### PR TITLE
Add base profile example and mergeable profiles

### DIFF
--- a/api/v1alpha1/seccompprofile_types.go
+++ b/api/v1alpha1/seccompprofile_types.go
@@ -27,6 +27,10 @@ type SeccompProfileSpec struct {
 	//nolint:lll
 	TargetWorkload string `json:"targetWorkload"`
 
+	// name of base profile (in the same namespace) what will be unioned into this profile
+	//nolint:lll
+	BaseProfileName string `json:"baseProfileName,omitempty"`
+
 	// Properties from containers/common/pkg/seccomp.Seccomp type
 
 	// the default action for seccomp

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -59,6 +59,9 @@ spec:
                   - SCMP_ARCH_RISCV64
                   type: string
                 type: array
+              baseProfileName:
+                description: name of base profile (in the same namespace) what will be unioned into this profile
+                type: string
               defaultAction:
                 description: the default action for seccomp
                 enum:

--- a/examples/baseprofile.yaml
+++ b/examples/baseprofile.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+kind: SeccompProfile
+metadata:
+  name: runc-v1.0.0-rc92
+spec:
+  defaultAction: SCMP_ACT_ERRNO
+  targetWorkload: base
+  architectures:
+  - SCMP_ARCH_X86_64
+  syscalls:
+  - action: SCMP_ACT_ALLOW
+    names:
+    - capget
+    - capset
+    - chdir
+    - close
+    - epoll_ctl
+    - epoll_pwait
+    - execve
+    - fchown
+    - fcntl
+    - fstat
+    - fstatfs
+    - futex
+    - getdents64
+    - getpid
+    - getppid
+    - nanosleep
+    - newfstatat
+    - openat
+    - prctl
+    - read
+    - sched_yield
+    - setgid
+    - setgroups
+    - setuid
+    - write

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -81,6 +81,13 @@ spec:
       image: nginx
 ```
 
+#### Base syscalls for a container runtime
+
+An example of the minimum required syscalls for a runtime such as runc (tested
+on version 1.0.0-rc92) to launch a container can be found in [the
+examples](./examples/baseprofile.yaml). Use this example as a starting point for
+creating custom profiles for your application.
+
 ## Restricting to a Single Namespace
 
 The security-profiles-operator can optionally be run to watch SeccompProfiles in

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -85,8 +85,27 @@ spec:
 
 An example of the minimum required syscalls for a runtime such as runc (tested
 on version 1.0.0-rc92) to launch a container can be found in [the
-examples](./examples/baseprofile.yaml). Use this example as a starting point for
-creating custom profiles for your application.
+examples](./examples/baseprofile.yaml). You can use this example as a starting
+point for creating custom profiles for your application. You can also
+programmatically combine it with your custom profiles in order to build
+application-specific profiles that only specify syscalls that are required on
+top of the base calls needed for the container runtime. For example:
+
+```yaml
+apiVersion: v1
+kind: SeccompProfile
+metadata:
+  namespace: my-namespace
+  name: profile1
+spec:
+  defaultAction: SCMP_ACT_ERRNO
+  targetWorkload: custom-profiles
+  baseProfileName: runc-v1.0.0-rc92
+  syscalls:
+  - action: SCMP_ACT_ALLOW
+    names:
+    - exit_group
+```
 
 ## Restricting to a Single Namespace
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -52,6 +52,10 @@ func (e *e2e) TestSeccompOperator() {
 			e.testCaseRunPod,
 		},
 		{
+			"Verify base profile merge",
+			e.testCaseBaseProfile,
+		},
+		{
 			"Re-deploy the operator",
 			e.testCaseReDeployOperator,
 		},

--- a/test/tc_base_profiles_test.go
+++ b/test/tc_base_profiles_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+)
+
+func (e *e2e) testCaseBaseProfile([]string) {
+	const baseProfilePath = "examples/baseprofile.yaml"
+	const helloProfile = `
+apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+kind: SeccompProfile
+metadata:
+  name: hello
+spec:
+  defaultAction: SCMP_ACT_ERRNO
+  targetWorkload: hello
+  baseProfileName: runc-v1.0.0-rc92
+  syscalls:
+  - action: SCMP_ACT_ALLOW
+    names:
+    - arch_prctl
+    - set_tid_address
+    - exit_group
+`
+	const helloPod = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello
+spec:
+  containers:
+  - image: hello-world
+    name: hello
+    resources: {}
+  securityContext:
+    seccompProfile:
+      type: Localhost
+      localhostProfile: operator/default/hello/hello.json
+  restartPolicy: Never
+`
+	e.kubectl("create", "-f", baseProfilePath)
+	defer e.kubectl("delete", "-f", baseProfilePath)
+
+	e.logf("Creating hello profile")
+	helloProfileFile, err := ioutil.TempFile(os.TempDir(), "hello-profile*.yaml")
+	e.Nil(err)
+	defer os.Remove(helloProfileFile.Name())
+	_, err = helloProfileFile.Write([]byte(helloProfile))
+	e.Nil(err)
+	err = helloProfileFile.Close()
+	e.Nil(err)
+	e.kubectl("create", "-f", helloProfileFile.Name())
+
+	e.logf("Creating hello-world pod")
+	helloPodFile, err := ioutil.TempFile(os.TempDir(), "hello-pod*.yaml")
+	e.Nil(err)
+	defer os.Remove(helloPodFile.Name())
+	_, err = helloPodFile.Write([]byte(helloPod))
+	e.Nil(err)
+	err = helloPodFile.Close()
+	e.Nil(err)
+	e.kubectl("create", "-f", helloPodFile.Name())
+	defer e.kubectl("delete", "pod", "hello")
+
+	e.logf("Waiting for test pod to be initialized")
+	e.kubectl("wait", "--for", "condition=initialized", "pod", "hello")
+
+	output := e.kubectl("get", "pod", "hello")
+	for strings.Contains(output, "ContainerCreating") {
+		output = e.kubectl("get", "pod", "hello")
+	}
+
+	e.logf("Testing that container is launched without runtime permission errors")
+	output = e.kubectl("describe", "pod", "hello")
+	e.NotContains(output, "Error: failed to start containerd task")
+
+	e.logf("Testing that container ran successfully")
+	output = e.kubectl("logs", "hello")
+	e.Contains(output, "Hello from Docker!")
+}

--- a/test/tc_default_profiles_test.go
+++ b/test/tc_default_profiles_test.go
@@ -84,10 +84,16 @@ func (e *e2e) verifyBaseProfileContent(node string, cm *v1.ConfigMap) {
 func (e *e2e) verifyCRDProfileContent(node string, sp *v1alpha1.SeccompProfile) {
 	e.logf("Verifying %s profile on node %s", sp.Name, node)
 	name := sp.Name
-	expected, err := json.Marshal(sp.Spec)
-	e.Nil(err)
 	profilePath, err := profile.GetProfilePath(name, sp.ObjectMeta.Namespace, sp.Spec.TargetWorkload)
 	e.Nil(err)
 	catOutput := e.execNode(node, "cat", profilePath)
-	e.Contains(catOutput, string(expected))
+	output := profile.OutputProfile{}
+	err = json.Unmarshal([]byte(catOutput), &output)
+	e.Nil(err)
+	expected := profile.OutputProfile{}
+	spec, err := json.Marshal(sp.Spec)
+	e.Nil(err)
+	err = json.Unmarshal(spec, &expected)
+	e.Nil(err)
+	e.Equal(output, expected)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

This PR has two commits, one to add a base `SeccompProfile` resource containing the minimum required syscalls to launch a container on runc in kubernetes, and another to add a `BaseProfileName` attribute to the `SeccompProfile` CRD to allow users to construct profiles whose syscalls take the union of two profiles.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes #150 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added a new example `SeccompProfile` to provide a starting point on which to build custom profiles, and an attribute `BaseProfileName` to the `SeccompProfile` kind to allow merging syscalls from two profiles.
```
