### PR TITLE
Run e2e tests for namespaced deployment

### DIFF
--- a/test/tc_base_profiles_test.go
+++ b/test/tc_base_profiles_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package e2e_test
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"strings"
@@ -53,7 +54,7 @@ spec:
   securityContext:
     seccompProfile:
       type: Localhost
-      localhostProfile: operator/default/hello/hello.json
+      localhostProfile: operator/%s/hello/hello.json
   restartPolicy: Never
 `
 	e.kubectl("create", "-f", baseProfilePath)
@@ -74,7 +75,9 @@ spec:
 	helloPodFile, err := ioutil.TempFile(os.TempDir(), "hello-pod*.yaml")
 	e.Nil(err)
 	defer os.Remove(helloPodFile.Name())
-	_, err = helloPodFile.Write([]byte(helloPod))
+
+	namespace := e.getCurrentContextNamespace(defaultNamespace)
+	_, err = helloPodFile.Write([]byte(fmt.Sprintf(helloPod, namespace)))
 	e.Nil(err)
 	err = helloPodFile.Close()
 	e.Nil(err)

--- a/test/tc_default_profiles_test.go
+++ b/test/tc_default_profiles_test.go
@@ -50,14 +50,16 @@ func (e *e2e) testCaseDefaultAndExampleProfiles(nodes []string) {
 		e.verifyBaseProfileContent(node, cm)
 
 		// Default profile verification
+		namespace := e.getCurrentContextNamespace("security-profiles-operator")
 		for _, name := range defaultProfileNames {
-			sp := e.getSeccompProfile(name, "security-profiles-operator")
+			sp := e.getSeccompProfile(name, namespace)
 			e.verifyCRDProfileContent(node, sp)
 		}
 
 		// Example profile verification
+		namespace = e.getCurrentContextNamespace(defaultNamespace)
 		for _, name := range exampleProfileNames {
-			sp := e.getSeccompProfile(name, "default")
+			sp := e.getSeccompProfile(name, namespace)
 			e.verifyCRDProfileContent(node, sp)
 		}
 	}

--- a/test/tc_redeploy_operator_test.go
+++ b/test/tc_redeploy_operator_test.go
@@ -18,15 +18,16 @@ package e2e_test
 
 func (e *e2e) testCaseReDeployOperator([]string) {
 	// Clean up the operator
-	e.cleanupOperator(manifest)
+	e.cleanupOperator(manifest, defaultProfiles)
 
 	// Deploy the operator again
-	e.deployOperator(manifest)
+	e.deployOperator(manifest, defaultProfiles)
 }
 
-func (e *e2e) cleanupOperator(manifest string) {
+func (e *e2e) testCaseReDeployNamespaceOperator([]string) {
 	// Clean up the operator
-	e.logf("Cleaning up operator")
-	e.kubectl("delete", "-f", defaultProfiles)
-	e.kubectl("delete", "-f", manifest)
+	e.cleanupOperator(namespaceManifest, namespaceDefaultProfiles)
+
+	// Deploy the operator again
+	e.deployOperator(namespaceManifest, namespaceDefaultProfiles)
 }

--- a/test/tc_run_pod_test.go
+++ b/test/tc_run_pod_test.go
@@ -16,11 +16,22 @@ limitations under the License.
 
 package e2e_test
 
+import "fmt"
+
 func (e *e2e) testCaseRunPod([]string) {
 	const (
 		examplePodPath = "examples/pod.yaml"
 		examplePodName = "test-pod"
 	)
+
+	namespace := e.getCurrentContextNamespace(defaultNamespace)
+	if namespace != defaultNamespace {
+		e.run(
+			"sed", "-i", fmt.Sprintf("s/security-profiles-operator/%s/g", namespace),
+			examplePodPath,
+		)
+		defer e.run("git", "checkout", examplePodPath)
+	}
 
 	e.logf("Creating the test pod: %s", examplePodPath)
 	e.kubectl("create", "-f", examplePodPath)


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This change re-deploys the operator as a namespaced deployment and
re-runs the test cases for them. The test cases were adjusted to use a
configurable namespace instead of hardcoding "default" and
"security-profiles-operator".

#### Which issue(s) this PR fixes:

Fixes #108

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
NONE
```
