### PR TITLE
Allow setting linkmode in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,12 @@ LDVARS := \
 	-X $(GO_PROJECT)/internal/pkg/version.gitCommit=$(GIT_COMMIT) \
 	-X $(GO_PROJECT)/internal/pkg/version.gitTreeState=$(GIT_TREE_STATE) \
 	-X $(GO_PROJECT)/internal/pkg/version.version=$(VERSION)
-LDFLAGS := -s -w -linkmode external -extldflags "-static" $(LDVARS)
+LINKMODE_EXTERNAL ?= yes
+ifeq ($(LINKMODE_EXTERNAL), yes)
+  LDFLAGS := -s -w -linkmode external -extldflags "-static" $(LDVARS)
+else
+  LDFLAGS := -s -w -extldflags "-static" $(LDVARS)
+endif
 
 CONTAINER_RUNTIME ?= docker
 IMAGE ?= $(PROJECT):latest


### PR DESCRIPTION
Allow setting linkmode in Makefile

The current Makefile implementation assumes that the developer is using cgo.
This is not the case for some folks.

This change makes this optional by enabling folks to set a
`LINKMODE_EXTERNAL` environment variable when running Make. If set to anything
else than "true" (which is the default)  the go command will not pick up cgo as
the compiler implementation