### PR TITLE
Enable e2e tests to run on OpenShift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,13 +43,15 @@ else
   LDFLAGS := -s -w -extldflags "-static" $(LDVARS)
 endif
 
-CONTAINER_RUNTIME ?= docker
+export CONTAINER_RUNTIME ?= docker
 IMAGE ?= $(PROJECT):latest
 
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 
 GOLANGCI_LINT_VERSION = v1.32.0
 REPO_INFRA_VERSION = v0.1.2
+
+export E2E_CLUSTER_TYPE ?= kind
 
 # Utility targets
 

--- a/deploy/base/operator.yaml
+++ b/deploy/base/operator.yaml
@@ -88,6 +88,9 @@ spec:
             runAsGroup: 2000
             capabilities:
               drop: ["ALL"]
+            seLinuxOptions:
+              # FIXME(jaosorior): Use a more restricted selinux type
+              type: spc_t
           resources:
             requests:
               memory: "64Mi"

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -481,6 +481,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsGroup: 2000
           runAsUser: 2000
+          seLinuxOptions:
+            type: spc_t
         volumeMounts:
         - mountPath: /var/lib/kubelet/seccomp/operator
           name: host-operator-volume

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -479,6 +479,8 @@ spec:
           readOnlyRootFilesystem: true
           runAsGroup: 2000
           runAsUser: 2000
+          seLinuxOptions:
+            type: spc_t
         volumeMounts:
         - mountPath: /var/lib/kubelet/seccomp/operator
           name: host-operator-volume

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -109,13 +109,14 @@ func (e *e2e) deployOperator(manifest, profiles string) {
 	// ones from the nodes
 	e.logf("Setting imagePullPolicy to 'Never' in manifest: %s", manifest)
 	e.run(
-		"sed", "-i", "s;imagePullPolicy: Always;imagePullPolicy: Never;g",
+		"sed", "-i",
+		fmt.Sprintf("s;imagePullPolicy: Always;imagePullPolicy: %s;g", e.pullPolicy),
 		manifest,
 	)
 
 	// Update the image name to match the test image
 	e.run(
-		"sed", "-i", fmt.Sprintf("s;image: .*gcr.io/.*;image: %s;g", testImage),
+		"sed", "-i", fmt.Sprintf("s;image: .*gcr.io/.*;image: %s;g", e.testImage),
 		manifest,
 	)
 


### PR DESCRIPTION
Enable e2e tests to run on OpenShift

This changes the e2e tests to not only run on a kind cluster, but to
also be able to run on a running OpenShift cluster.

To enable this, there is now the `E2E_CLUTER_TYPE` environment variable
which the Makefile can take into use and that will be taken into account
by the test itself.

Note that in order for the security-profiles-operator to work on
OpenShift, I temporarily added spc_t as the SELinux type. This ensures
that the operator is allowed to place files on the folder it's trying to
access. This is a placeholder while we work on a better mechanism to
consume both workload and bootstrap SELinux policies [1]. This mechanism
will eventually replace the tiny workloads that we currently spawn to
install policies and will be included as part of the main daemonset.

[1] https://github.com/JAORMX/selinuxd

#### What this PR does / why we need it:

This allows us to run the e2e tests on an OpenShift cluster. We can
subsequently enable the OpenShift infrastructure to run tests here and thus get
coverage there as well.

```release-note
NONE
```