### PR TITLE
Enable UBI-based image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,8 @@ REPO_INFRA_VERSION = v0.1.2
 
 export E2E_CLUSTER_TYPE ?= kind
 
+DOCKERFILE ?= Dockerfile
+
 # Utility targets
 
 all: $(BUILD_DIR)/$(PROJECT) ## Build the security-profiles-operator binary
@@ -99,7 +101,7 @@ deployments: manifests ## Generate the deployment files with kustomize
 
 .PHONY: image
 image: ## Build the container image
-	$(CONTAINER_RUNTIME) build --build-arg version=$(VERSION) -t $(IMAGE) .
+	$(CONTAINER_RUNTIME) build -f $(DOCKERFILE) --build-arg version=$(VERSION) -t $(IMAGE) .
 
 # Verification targets
 


### PR DESCRIPTION
Enable UBI-based image

This enables the deployment of a UBI-based image which can optionally be
used instead of the default scratch one.

It also introduces an variable in the Makefile called `DOCKERFILE` which
one can use to specify the Dockerfile to use.

#### What type of PR is this?

/kind feature

```release-note
Adds UBI-based Dockerfile.
```