### PR TITLE
Add SELinux e2e test

### DIFF
--- a/api/v1alpha1/selinuxpolicy_types.go
+++ b/api/v1alpha1/selinuxpolicy_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	rcommonv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -42,6 +43,7 @@ const (
 
 // SelinuxPolicyStatus defines the observed state of SelinuxPolicy.
 type SelinuxPolicyStatus struct {
+	rcommonv1.ConditionedStatus `json:",inline"`
 	// Represents the string that the SelinuxPolicy object can be
 	// referenced as in a pod seLinuxOptions section.
 	Usage string `json:"usage,omitempty"`

--- a/deploy/base/crd.yaml
+++ b/deploy/base/crd.yaml
@@ -245,6 +245,34 @@ spec:
           status:
             description: SelinuxPolicyStatus defines the observed state of SelinuxPolicy.
             properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True, False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               state:
                 description: 'Represents the state that the policy is in. Can be: PENDING, IN-PROGRESS, INSTALLED or ERROR'
                 type: string

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -246,6 +246,34 @@ spec:
           status:
             description: SelinuxPolicyStatus defines the observed state of SelinuxPolicy.
             properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True, False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               state:
                 description: 'Represents the state that the policy is in. Can be: PENDING, IN-PROGRESS, INSTALLED or ERROR'
                 type: string

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -246,6 +246,34 @@ spec:
           status:
             description: SelinuxPolicyStatus defines the observed state of SelinuxPolicy.
             properties:
+              conditions:
+                description: Conditions of the resource.
+                items:
+                  description: A Condition that may apply to a resource.
+                  properties:
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time this condition transitioned from one status to another.
+                      format: date-time
+                      type: string
+                    message:
+                      description: A Message containing details about this condition's last transition from one status to another, if any.
+                      type: string
+                    reason:
+                      description: A Reason for this condition's last transition from one status to another.
+                      type: string
+                    status:
+                      description: Status of this condition; is it currently True, False, or Unknown?
+                      type: string
+                    type:
+                      description: Type of this condition. At most one of each condition type may apply to a resource at any point in time.
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               state:
                 description: 'Represents the state that the policy is in. Can be: PENDING, IN-PROGRESS, INSTALLED or ERROR'
                 type: string

--- a/examples/selinuxpolicy.yaml
+++ b/examples/selinuxpolicy.yaml
@@ -2,7 +2,6 @@ apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
 kind: SelinuxPolicy
 metadata:
   name: errorlogger
-  namespace: default
 spec:
   apply: true
   policy: |

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.15
 
 require (
 	github.com/containers/common v0.29.0
-	github.com/crossplane/crossplane-runtime v0.11.0
+	github.com/crossplane/crossplane-runtime v0.12.0
 	github.com/go-logr/logr v0.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -153,8 +153,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0 h1:EoUDS0afbrsXAZ9YQ9jdu/mZ2sXgT1/2yyNng
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime v0.11.0 h1:hLDWsGYhU/CUVQ1sU7NHF5bnP6WT6wA6Nu2SaBSSe6w=
-github.com/crossplane/crossplane-runtime v0.11.0/go.mod h1:cJl5ZZONisre4v6wTmbrC8Jh3AI+erq/lNaxZzv9tnU=
+github.com/crossplane/crossplane-runtime v0.12.0 h1:GB1Pq5vVBNStPrfiEJNat56gHCQiuliidgr7pNs/FQA=
+github.com/crossplane/crossplane-runtime v0.12.0/go.mod h1:cJl5ZZONisre4v6wTmbrC8Jh3AI+erq/lNaxZzv9tnU=
 github.com/cyphar/filepath-securejoin v0.2.2/go.mod h1:FpkQEhXnPnOthhzymB7CGsFk2G9VLXONKD9G7QGMM+4=
 github.com/davecgh/go-spew v0.0.0-20151105211317-5215b55f46b2/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/pkg/controllers/selinuxpolicy/configmap_controller.go
+++ b/internal/pkg/controllers/selinuxpolicy/configmap_controller.go
@@ -86,7 +86,11 @@ func (r *ReconcileConfigMap) Reconcile(request reconcile.Request) (reconcile.Res
 		return reconcile.Result{Requeue: true}, nil
 	}
 
-	return r.reconcileInstallerPods(policy, cminstance, reqLogger)
+	// object is not being deleted
+	if cminstance.ObjectMeta.DeletionTimestamp.IsZero() {
+		return r.reconcileInstallerPods(policy, cminstance, reqLogger)
+	}
+	return reconcile.Result{}, nil
 }
 
 func (r *ReconcileConfigMap) reconcileInstallerPods(policy *spov1alpha1.SelinuxPolicy, cm *corev1.ConfigMap,

--- a/internal/pkg/controllers/selinuxpolicy/configmap_controller.go
+++ b/internal/pkg/controllers/selinuxpolicy/configmap_controller.go
@@ -172,13 +172,6 @@ func newPodForPolicy(name, ns string, node *corev1.Node) *corev1.Pod {
 					Image:   "quay.io/jaosorior/udica",
 					Command: []string{"/bin/sh"},
 					Args:    []string{"-c", "semodule -vi /tmp/policy/*.cil /usr/share/udica/templates/*cil;"},
-					Lifecycle: &corev1.Lifecycle{
-						PreStop: &corev1.Handler{
-							Exec: &corev1.ExecAction{
-								Command: []string{"/bin/sh", "-c", fmt.Sprintf("semodule -vr '%s'", GetPolicyName(name, ns))},
-							},
-						},
-					},
 					SecurityContext: &corev1.SecurityContext{
 						Privileged: &trueVal,
 					},
@@ -208,7 +201,7 @@ func newPodForPolicy(name, ns string, node *corev1.Node) *corev1.Pod {
 					// more formal registry
 					Image:   "quay.io/jaosorior/udica",
 					Command: []string{"/bin/sh"},
-					Args:    []string{"-c", "while true; do sleep 30; done;"},
+					Args:    []string{"-c", "trap 'exit 0' SIGINT SIGTERM; while true; do sleep infinity; done;"},
 					Lifecycle: &corev1.Lifecycle{
 						PreStop: &corev1.Handler{
 							Exec: &corev1.ExecAction{

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -219,9 +219,8 @@ func (e *openShifte2e) SetupSuite() {
 }
 
 func (e *openShifte2e) TearDownSuite() {
-	testImageRef := config.OperatorName + ":latest"
 	e.kubectl(
-		"delete", "imagestream", "-n", "openshift", testImageRef,
+		"delete", "imagestream", "-n", "openshift", config.OperatorName,
 	)
 }
 
@@ -287,4 +286,12 @@ func (e *e2e) kubectlOperatorNS(args ...string) string {
 
 func (e *e2e) logf(format string, a ...interface{}) {
 	e.logger.Info(fmt.Sprintf(format, a...))
+}
+
+func (e *e2e) selinuxtOnlyTestCase() {
+	// TODO(jaosorior): Come up with better way to assert if a cluster
+	// supports SELinux or not.
+	if !strings.EqualFold(clusterType, "openshift") {
+		e.T().Skip("Skipping SELinux-related test from non-OpenShift cluster")
+	}
 }

--- a/test/tc_delete_profiles_test.go
+++ b/test/tc_delete_profiles_test.go
@@ -18,8 +18,6 @@ package e2e_test
 
 import (
 	"fmt"
-	"io/ioutil"
-	"os"
 	"time"
 
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/controllers/profile"
@@ -152,16 +150,4 @@ spec:
 		e.kubectl("delete", "pod", deletePodName)
 		e.kubectlFailure("get", "seccompprofile", deleteProfileName)
 	}
-}
-
-func (e *e2e) writeAndCreate(manifest, filePattern string) func() {
-	file, err := ioutil.TempFile(os.TempDir(), filePattern)
-	fileName := file.Name()
-	e.Nil(err)
-	_, err = file.Write([]byte(manifest))
-	e.Nil(err)
-	err = file.Close()
-	e.Nil(err)
-	e.kubectl("create", "-f", fileName)
-	return func() { os.Remove(fileName) }
 }

--- a/test/tc_selinux_base_usage_test.go
+++ b/test/tc_selinux_base_usage_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"fmt"
+	"strings"
+)
+
+func (e *e2e) testCaseSelinuxBaseUsage(nodes []string) {
+	e.selinuxtOnlyTestCase()
+
+	// nolint:lll
+	const podWithPolicyFmt = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: errorlogger
+spec:
+  containers:
+  - name: errorlogger
+    image: "registry.access.redhat.com/ubi8/ubi-minimal:latest"
+    command: ["/bin/bash"]
+    args: ["-c", "set -eux; while true; do echo \"Time: $(date). Some error info.\" >> /var/log/test.log; sleep 2; done"]
+    securityContext:
+      seLinuxOptions:
+        type: %s
+    volumeMounts:
+    - name: varlog
+      mountPath: /var/log
+  restartPolicy: Never
+  volumes:
+  - name: varlog
+    hostPath:
+      path: /var/log
+      type: Directory
+`
+
+	const errorloggerPolicy = `
+apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+kind: SelinuxPolicy
+metadata:
+  name: errorlogger
+spec:
+  apply: true
+  policy: |
+    (blockinherit container)
+    (allow process var_log_t ( dir ( open read getattr lock search ioctl add_name remove_name write ))) 
+    (allow process var_log_t ( file ( getattr read write append ioctl lock map open create  ))) 
+    (allow process var_log_t ( sock_file ( getattr read write append open  ))) 
+`
+
+	e.logf("The 'errorlogger' workload should be able to use SELinux policy")
+
+	e.logf("creating policy")
+	e.writeAndCreate(errorloggerPolicy, "errorlogger-policy.yml")
+
+	// Let's wait for the policy to be processed
+	e.kubectl("wait", "--timeout", defaultSelinuxOpTimeout,
+		"--for", "condition=ready", "selinuxpolicy", "errorlogger")
+
+	rawPolicyName := e.getSELinuxPolicyName("errorlogger")
+
+	e.logf("assert policy is installed")
+	for _, node := range nodes {
+		var found bool
+		policiesRaw := e.execNode(node, "semodule", "-l")
+		for _, policy := range strings.Split(policiesRaw, "\n") {
+			if policy == rawPolicyName {
+				found = true
+				break
+			}
+		}
+		e.Truef(found, "The SelinuxPolicy errorlogger wasn't found in the %s node with the name %s",
+			node, rawPolicyName)
+	}
+
+	e.logf("creating workload")
+
+	podWithPolicy := fmt.Sprintf(podWithPolicyFmt, e.getSELinuxPolicyUsage("errorlogger"))
+	e.writeAndCreate(podWithPolicy, "pod-w-policy.yml")
+
+	e.kubectl("wait", "--for", "condition=ready", "pod", "errorlogger")
+
+	e.logf("the workload should be running")
+	podWithPolicyPhase := e.kubectl(
+		"get", "pods", "errorlogger", "-o", "jsonpath={.status.phase}")
+	e.Truef(strings.EqualFold(podWithPolicyPhase, "running"),
+		"The pod without policy's phase should be 'Running', instead it's: %s",
+		podWithPolicyPhase)
+
+	e.logf("cleaning up")
+
+	e.logf("removing workload")
+	e.kubectl("delete", "pod", "errorlogger")
+
+	e.logf("removing policy")
+	e.kubectl("delete", "selinuxpolicy", "errorlogger")
+
+	e.logf("assert policy was removed")
+	for _, node := range nodes {
+		var found bool
+		policiesRaw := e.execNode(node, "semodule", "-l")
+		for _, policy := range strings.Split(policiesRaw, "\n") {
+			if policy == rawPolicyName {
+				found = true
+				break
+			}
+		}
+		e.Falsef(found, "The SelinuxPolicy errorlogger should have been removed from %s node", node)
+	}
+}

--- a/test/tc_selinux_sanity_check_test.go
+++ b/test/tc_selinux_sanity_check_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+func (e *e2e) testCaseSelinuxSanityCheck([]string) {
+	e.selinuxtOnlyTestCase()
+
+	const podWithoutPolicy = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: el-no-policy
+spec:
+  initContainers:
+  - name: errorlogger
+    image: "registry.access.redhat.com/ubi8/ubi-minimal:latest"
+    command: ["/bin/bash"]
+    args: ["-c", "echo \"Time: $(date). Some error info.\" >> /var/log/test.log || /bin/true"]
+    volumeMounts:
+    - name: varlog
+      mountPath: /var/log
+  containers:
+  - name: pauser
+    image: "gcr.io/google_containers/pause:latest"
+  restartPolicy: Never
+  volumes:
+  - name: varlog
+    hostPath:
+      path: /var/log
+      type: Directory
+`
+	e.logf("sanity check: The 'errorlogger' workload should be blocked by SELinux")
+
+	e.logf("creating workload")
+	e.writeAndCreate(podWithoutPolicy, "pod-wo-policy.yml")
+
+	e.kubectl("wait", "--for", "condition=ready", "pod", "el-no-policy")
+
+	e.logf("the workload should have errored")
+	expectedLog := "/bin/bash: /var/log/test.log: Permission denied"
+	log := e.kubectl("logs", "el-no-policy", "-c", "errorlogger")
+	e.Equalf(log, expectedLog, "container should have returned a 'Permissions Denied' error")
+
+	e.kubectl("delete", "pod", "el-no-policy")
+}


### PR DESCRIPTION
This adds a couple of e2e test cases that verify that the base
functionality for the selinux bits work.

Each test is now prefixed with the component that's being tested.

On the other hand, to enable integration with other kube utilities (such as
`kubectl wait`) which would make testing easier, support for conditions
was added in the `SelinuxPolicy` object.

Some fixes related to object creation/deletion and status reporting had
to be done in the selinux-related controllers.

Note that the SELinux tests are being skipped for everything except
OpenShift clusters, since that's where I've been able to test this.
If someone has access to another distro that uses SELinux where we
could test this, we can integrate that too.

```release-note
Conditions were added to the SelinuxPolicy object's status.
```