### PR TITLE
Change controller manager to be a Deployment

### DIFF
--- a/deploy/base/config.yaml
+++ b/deploy/base/config.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+  namespace: security-profiles-operator
+  labels:
+    security-profiles-operator/config: ""
+data:
+  SPOdImagePullPolicy: Always

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -10,8 +10,23 @@ images:
     # newName: k8s.gcr.io/security-profiles-operator/security-profiles-operator
     # newTag: v0.3.0
 
-  - name: bash
-    newTag: "5.0"
+patchesStrategicMerge:
+- |-
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: security-profiles-operator
+    namespace: security-profiles-operator
+  spec:
+    template:
+      spec:
+        containers:
+          - name: security-profiles-operator
+            env:
+              - name: RELATED_IMAGE_OPERATOR
+                value: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
+              - name: RELATED_IMAGE_NON_ROOT_ENABLER
+                value: bash:5.0
 
 commonLabels:
   app: security-profiles-operator
@@ -20,6 +35,7 @@ resources:
   - crd.yaml
   - rbac.yaml
   - operator.yaml
+  - config.yaml
 
 configMapGenerator:
   - name: security-profiles-operator-profile

--- a/deploy/base/operator.yaml
+++ b/deploy/base/operator.yaml
@@ -1,128 +1,40 @@
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: security-profiles-operator
   namespace: security-profiles-operator
 spec:
+  replicas: 3
   selector:
     matchLabels:
       name: security-profiles-operator
   template:
     metadata:
-      annotations:
-        openshift.io/scc: privileged
-        seccomp.security.alpha.kubernetes.io/pod: runtime/default
-        container.seccomp.security.alpha.kubernetes.io/security-profiles-operator: localhost/security-profiles-operator.json
       labels:
         name: security-profiles-operator
     spec:
       serviceAccountName: security-profiles-operator
-      initContainers:
-        - name: non-root-enabler
-          image: bash
-          # Creates folder /var/lib/security-profiles-operator, sets 2000:2000 as its
-          # owner and symlink it to /var/lib/kubelet/seccomp/operator. This is
-          # required to allow the main container to run as non-root.
-          command: [bash, -c]
-          args:
-            - |+
-              set -euo pipefail
-
-              if [ ! -d $KUBELET_SECCOMP_ROOT ]; then
-                /bin/mkdir -m 0744 -p $KUBELET_SECCOMP_ROOT
-              fi
-
-              /bin/mkdir -p $OPERATOR_ROOT
-              /bin/chmod 0744 $OPERATOR_ROOT
-
-              if [ ! -L $OPERATOR_SYMLINK ]; then
-                /bin/ln -s $OPERATOR_ROOT $OPERATOR_SYMLINK
-              fi
-
-              /bin/chown -R 2000:2000 $OPERATOR_ROOT
-              cp -f -v /opt/seccomp-profiles/* $KUBELET_SECCOMP_ROOT
-          env:
-            - name: KUBELET_SECCOMP_ROOT
-              value: /var/lib/kubelet/seccomp
-            - name: OPERATOR_SYMLINK
-              value: $(KUBELET_SECCOMP_ROOT)/operator
-            - name: OPERATOR_ROOT
-              value: /var/lib/security-profiles-operator
-          volumeMounts:
-            - name: host-varlib-volume
-              mountPath: /var/lib
-            - name: profile-configmap-volume
-              mountPath: /opt/seccomp-profiles
-              readOnly: true
-          securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop: ["ALL"]
-              add: ["CHOWN", "FOWNER", "FSETID", "DAC_OVERRIDE"]
-            runAsUser: 0
-            seLinuxOptions:
-              # FIXME(jaosorior): Use a more restricted selinux type
-              type: spc_t
-          resources:
-            requests:
-              memory: "32Mi"
-              cpu: "100m"
-              ephemeral-storage: "10Mi"
-            limits:
-              memory: "64Mi"
-              cpu: "250m"
-              ephemeral-storage: "50Mi"
       containers:
         - name: security-profiles-operator
           image: security-profiles-operator
+          args:
+          - manager
           imagePullPolicy: Always
-          volumeMounts:
-          - name: host-operator-volume
-            mountPath: /var/lib/kubelet/seccomp/operator
           securityContext:
-            allowPrivilegeEscalation: false
             readOnlyRootFilesystem: true
-            runAsUser: 2000
-            runAsGroup: 2000
-            capabilities:
-              drop: ["ALL"]
-            seLinuxOptions:
-              # FIXME(jaosorior): Use a more restricted selinux type
-              type: spc_t
-          resources:
-            requests:
-              memory: "64Mi"
-              cpu: "100m"
-              ephemeral-storage: "50Mi"
-            limits:
-              memory: "128Mi"
-              cpu: "300m"
-              ephemeral-storage: "200Mi"
+            allowPrivilegeEscalation: false
           env:
-            - name: NODE_NAME
-              valueFrom:
-                fieldRef:
-                  fieldPath: spec.nodeName
-      volumes:
-      # /var/lib is used as symlinks cannot be created across different volumes
-      - name: host-varlib-volume
-        hostPath:
-          path: /var/lib
-          type: Directory
-      - name: host-operator-volume
-        hostPath:
-          path: /var/lib/security-profiles-operator
-          type: DirectoryOrCreate
-      - name: profile-configmap-volume
-        configMap:
-          name: security-profiles-operator-profile
-      tolerations:
-        - effect: NoSchedule
-          key: node-role.kubernetes.io/master
-        - effect: NoExecute
-          key: node.kubernetes.io/not-ready
-          operator: Exists
+            - name: RELATED_IMAGE_OPERATOR
+              value: security-profiles-operator
+            - name: RELATED_IMAGE_NON_ROOT_ENABLER
+              value: non-root-enabler
       nodeSelector:
-        kubernetes.io/os: linux
+        node-role.kubernetes.io/master: ""
+      tolerations:
+        - key: "node-role.kubernetes.io/master"
+          operator: "Exists"
+          effect: "NoSchedule"
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoExecute"

--- a/deploy/base/rbac.yaml
+++ b/deploy/base/rbac.yaml
@@ -16,18 +16,58 @@ metadata:
   name: config-map-reader
   namespace: security-profiles-operator
 rules:
-- apiGroups: [""]
-  resources: ["configmaps", "pods", "nodes"]
-  verbs: ["get", "watch", "list"]
-- apiGroups: [""]
-  resources: ["events"]
-  verbs: ["create", "patch"]
-- apiGroups: ["security-profiles-operator.x-k8s.io"]
-  resources: ["seccompprofiles", "selinuxpolicies"]
-  verbs: ["get", "watch", "list", "update", "patch"]
-- apiGroups: ["security-profiles-operator.x-k8s.io"]
-  resources: ["seccompprofiles/status", "selinuxpolicies/status"]
-  verbs: ["get", "update", "patch"]
+- apiGroups:
+  - ""
+  resources:
+  - "configmaps"
+  - "pods"
+  - "nodes"
+  verbs:
+  - "get"
+  - "watch"
+  - "list"
+- apiGroups:
+  - ""
+  resources:
+  - "events"
+  verbs:
+  - "create"
+  - "patch"
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - "security-profiles-operator.x-k8s.io"
+  resources:
+  - "seccompprofiles"
+  - "selinuxpolicies"
+  verbs:
+  - "get"
+  - "watch"
+  - "list"
+  - "update"
+  - "patch"
+- apiGroups:
+  - "security-profiles-operator.x-k8s.io"
+  resources:
+  - "seccompprofiles/status"
+  - "selinuxpolicies/status"
+  verbs: 
+  - "get"
+  - "update"
+  - "patch"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -334,6 +334,21 @@ rules:
   - create
   - patch
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
   - seccompprofiles
@@ -460,140 +475,61 @@ subjects:
   namespace: security-profiles-operator
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   labels:
     app: security-profiles-operator
   name: security-profiles-operator
   namespace: security-profiles-operator
 spec:
+  replicas: 3
   selector:
     matchLabels:
       app: security-profiles-operator
       name: security-profiles-operator
   template:
     metadata:
-      annotations:
-        container.seccomp.security.alpha.kubernetes.io/security-profiles-operator: localhost/security-profiles-operator.json
-        openshift.io/scc: privileged
-        seccomp.security.alpha.kubernetes.io/pod: runtime/default
       labels:
         app: security-profiles-operator
         name: security-profiles-operator
     spec:
       containers:
-      - env:
+      - args:
+        - manager
+        env:
         - name: RESTRICT_TO_NAMESPACE
           value: NS_REPLACE
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
+        - name: RELATED_IMAGE_OPERATOR
+          value: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
+        - name: RELATED_IMAGE_NON_ROOT_ENABLER
+          value: bash:5.0
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
         imagePullPolicy: Always
         name: security-profiles-operator
-        resources:
-          limits:
-            cpu: 300m
-            ephemeral-storage: 200Mi
-            memory: 128Mi
-          requests:
-            cpu: 100m
-            ephemeral-storage: 50Mi
-            memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 2000
-          runAsUser: 2000
-          seLinuxOptions:
-            type: spc_t
-        volumeMounts:
-        - mountPath: /var/lib/kubelet/seccomp/operator
-          name: host-operator-volume
-      initContainers:
-      - args:
-        - |
-          set -euo pipefail
-
-          if [ ! -d $KUBELET_SECCOMP_ROOT ]; then
-            /bin/mkdir -m 0744 -p $KUBELET_SECCOMP_ROOT
-          fi
-
-          /bin/mkdir -p $OPERATOR_ROOT
-          /bin/chmod 0744 $OPERATOR_ROOT
-
-          if [ ! -L $OPERATOR_SYMLINK ]; then
-            /bin/ln -s $OPERATOR_ROOT $OPERATOR_SYMLINK
-          fi
-
-          /bin/chown -R 2000:2000 $OPERATOR_ROOT
-          cp -f -v /opt/seccomp-profiles/* $KUBELET_SECCOMP_ROOT
-        command:
-        - bash
-        - -c
-        env:
-        - name: KUBELET_SECCOMP_ROOT
-          value: /var/lib/kubelet/seccomp
-        - name: OPERATOR_SYMLINK
-          value: $(KUBELET_SECCOMP_ROOT)/operator
-        - name: OPERATOR_ROOT
-          value: /var/lib/security-profiles-operator
-        image: bash:5.0
-        name: non-root-enabler
-        resources:
-          limits:
-            cpu: 250m
-            ephemeral-storage: 50Mi
-            memory: 64Mi
-          requests:
-            cpu: 100m
-            ephemeral-storage: 10Mi
-            memory: 32Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add:
-            - CHOWN
-            - FOWNER
-            - FSETID
-            - DAC_OVERRIDE
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsUser: 0
-          seLinuxOptions:
-            type: spc_t
-        volumeMounts:
-        - mountPath: /var/lib
-          name: host-varlib-volume
-        - mountPath: /opt/seccomp-profiles
-          name: profile-configmap-volume
-          readOnly: true
       nodeSelector:
-        kubernetes.io/os: linux
+        node-role.kubernetes.io/master: ""
       serviceAccountName: security-profiles-operator
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+        operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/not-ready
         operator: Exists
-      volumes:
-      - hostPath:
-          path: /var/lib
-          type: Directory
-        name: host-varlib-volume
-      - hostPath:
-          path: /var/lib/security-profiles-operator
-          type: DirectoryOrCreate
-        name: host-operator-volume
-      - configMap:
-          name: security-profiles-operator-profile
-        name: profile-configmap-volume
+---
+apiVersion: v1
+data:
+  SPOdImagePullPolicy: Always
+kind: ConfigMap
+metadata:
+  labels:
+    app: security-profiles-operator
+    security-profiles-operator/config: ""
+  name: config
+  namespace: security-profiles-operator
 ---
 apiVersion: v1
 data:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -334,6 +334,21 @@ rules:
   - create
   - patch
 - apiGroups:
+  - apps
+  resources:
+  - deployments
+  - daemonsets
+  - replicasets
+  - statefulsets
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
   - seccompprofiles
@@ -460,138 +475,59 @@ subjects:
   namespace: security-profiles-operator
 ---
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   labels:
     app: security-profiles-operator
   name: security-profiles-operator
   namespace: security-profiles-operator
 spec:
+  replicas: 3
   selector:
     matchLabels:
       app: security-profiles-operator
       name: security-profiles-operator
   template:
     metadata:
-      annotations:
-        container.seccomp.security.alpha.kubernetes.io/security-profiles-operator: localhost/security-profiles-operator.json
-        openshift.io/scc: privileged
-        seccomp.security.alpha.kubernetes.io/pod: runtime/default
       labels:
         app: security-profiles-operator
         name: security-profiles-operator
     spec:
       containers:
-      - env:
-        - name: NODE_NAME
-          valueFrom:
-            fieldRef:
-              fieldPath: spec.nodeName
+      - args:
+        - manager
+        env:
+        - name: RELATED_IMAGE_OPERATOR
+          value: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
+        - name: RELATED_IMAGE_NON_ROOT_ENABLER
+          value: bash:5.0
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
         imagePullPolicy: Always
         name: security-profiles-operator
-        resources:
-          limits:
-            cpu: 300m
-            ephemeral-storage: 200Mi
-            memory: 128Mi
-          requests:
-            cpu: 100m
-            ephemeral-storage: 50Mi
-            memory: 64Mi
         securityContext:
           allowPrivilegeEscalation: false
-          capabilities:
-            drop:
-            - ALL
           readOnlyRootFilesystem: true
-          runAsGroup: 2000
-          runAsUser: 2000
-          seLinuxOptions:
-            type: spc_t
-        volumeMounts:
-        - mountPath: /var/lib/kubelet/seccomp/operator
-          name: host-operator-volume
-      initContainers:
-      - args:
-        - |
-          set -euo pipefail
-
-          if [ ! -d $KUBELET_SECCOMP_ROOT ]; then
-            /bin/mkdir -m 0744 -p $KUBELET_SECCOMP_ROOT
-          fi
-
-          /bin/mkdir -p $OPERATOR_ROOT
-          /bin/chmod 0744 $OPERATOR_ROOT
-
-          if [ ! -L $OPERATOR_SYMLINK ]; then
-            /bin/ln -s $OPERATOR_ROOT $OPERATOR_SYMLINK
-          fi
-
-          /bin/chown -R 2000:2000 $OPERATOR_ROOT
-          cp -f -v /opt/seccomp-profiles/* $KUBELET_SECCOMP_ROOT
-        command:
-        - bash
-        - -c
-        env:
-        - name: KUBELET_SECCOMP_ROOT
-          value: /var/lib/kubelet/seccomp
-        - name: OPERATOR_SYMLINK
-          value: $(KUBELET_SECCOMP_ROOT)/operator
-        - name: OPERATOR_ROOT
-          value: /var/lib/security-profiles-operator
-        image: bash:5.0
-        name: non-root-enabler
-        resources:
-          limits:
-            cpu: 250m
-            ephemeral-storage: 50Mi
-            memory: 64Mi
-          requests:
-            cpu: 100m
-            ephemeral-storage: 10Mi
-            memory: 32Mi
-        securityContext:
-          allowPrivilegeEscalation: false
-          capabilities:
-            add:
-            - CHOWN
-            - FOWNER
-            - FSETID
-            - DAC_OVERRIDE
-            drop:
-            - ALL
-          readOnlyRootFilesystem: true
-          runAsUser: 0
-          seLinuxOptions:
-            type: spc_t
-        volumeMounts:
-        - mountPath: /var/lib
-          name: host-varlib-volume
-        - mountPath: /opt/seccomp-profiles
-          name: profile-configmap-volume
-          readOnly: true
       nodeSelector:
-        kubernetes.io/os: linux
+        node-role.kubernetes.io/master: ""
       serviceAccountName: security-profiles-operator
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
+        operator: Exists
       - effect: NoExecute
         key: node.kubernetes.io/not-ready
         operator: Exists
-      volumes:
-      - hostPath:
-          path: /var/lib
-          type: Directory
-        name: host-varlib-volume
-      - hostPath:
-          path: /var/lib/security-profiles-operator
-          type: DirectoryOrCreate
-        name: host-operator-volume
-      - configMap:
-          name: security-profiles-operator-profile
-        name: profile-configmap-volume
+---
+apiVersion: v1
+data:
+  SPOdImagePullPolicy: Always
+kind: ConfigMap
+metadata:
+  labels:
+    app: security-profiles-operator
+    security-profiles-operator/config: ""
+  name: config
+  namespace: security-profiles-operator
 ---
 apiVersion: v1
 data:

--- a/deploy/overlays/namespaced/deployment.yaml
+++ b/deploy/overlays/namespaced/deployment.yaml
@@ -1,5 +1,5 @@
 apiVersion: apps/v1
-kind: DaemonSet
+kind: Deployment
 metadata:
   name: security-profiles-operator
   namespace: security-profiles-operator

--- a/deploy/overlays/namespaced/kustomization.yaml
+++ b/deploy/overlays/namespaced/kustomization.yaml
@@ -7,7 +7,7 @@ bases:
   - ../cluster
 
 patchesStrategicMerge:
-  - daemonset.yaml
+  - deployment.yaml
 
 patchesJson6902:
   - target:

--- a/examples/config.yaml
+++ b/examples/config.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: config
+  namespace: security-profiles-operator
+  labels:
+    security-profiles-operator/config: ""
+data: {}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -32,3 +32,16 @@ const (
 	// the name of the current node.
 	NodeNameEnvKey = "NODE_NAME"
 )
+
+// GetOperatorNamespace gets the namespace that the operator is currently running on.
+func GetOperatorNamespace() string {
+	// TODO(jaosorior): Get a method to return the current operator
+	// namespace.
+	//
+	// operatorNs, err := k8sutil.GetOperatorNamespace()
+	// if err != nil {
+	// 	return "security-profiles-operator"
+	// }
+	// return operatorNs
+	return "security-profiles-operator"
+}

--- a/internal/pkg/controllers/selinuxpolicy/configmap_controller.go
+++ b/internal/pkg/controllers/selinuxpolicy/configmap_controller.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	spov1alpha1 "sigs.k8s.io/security-profiles-operator/api/selinuxpolicy/v1alpha1"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 )
 
 // blank assignment to verify that ReconcileConfigMap implements `reconcile.Reconciler`.
@@ -179,7 +180,7 @@ func newPodForPolicy(name, ns string, node *corev1.Node) *corev1.Pod {
 	return &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetInstallerPodName(name, ns, node),
-			Namespace: GetOperatorNamespace(),
+			Namespace: config.GetOperatorNamespace(),
 			Labels:    labels,
 		},
 		Spec: corev1.PodSpec{

--- a/internal/pkg/controllers/selinuxpolicy/selinuxpolicy_controller.go
+++ b/internal/pkg/controllers/selinuxpolicy/selinuxpolicy_controller.go
@@ -35,6 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	spov1alpha1 "sigs.k8s.io/security-profiles-operator/api/selinuxpolicy/v1alpha1"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 )
 
 // The underscore is not a valid character in a pod, so we can
@@ -207,7 +208,7 @@ func (r *ReconcileSP) newConfigMapForPolicy(cr *spov1alpha1.SelinuxPolicy) *core
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      GetPolicyConfigMapName(cr.Name, cr.Namespace),
-			Namespace: GetOperatorNamespace(),
+			Namespace: config.GetOperatorNamespace(),
 			Labels:    labels,
 			Finalizers: []string{
 				metav1.FinalizerDeleteDependents,

--- a/internal/pkg/controllers/selinuxpolicy/setup.go
+++ b/internal/pkg/controllers/selinuxpolicy/setup.go
@@ -30,6 +30,7 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	spov1alpha1 "sigs.k8s.io/security-profiles-operator/api/selinuxpolicy/v1alpha1"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 )
 
 var log = logf.Log.WithName("selinuxpolicy")
@@ -75,7 +76,7 @@ func hasSELinuxLabel(obj runtime.Object) bool {
 		return false
 	}
 	// we only care about this namespace
-	if cm.GetNamespace() != GetOperatorNamespace() {
+	if cm.GetNamespace() != config.GetOperatorNamespace() {
 		return false
 	}
 	labels := cm.GetLabels()

--- a/internal/pkg/controllers/selinuxpolicy/utils.go
+++ b/internal/pkg/controllers/selinuxpolicy/utils.go
@@ -74,19 +74,6 @@ func GetPolicyConfigMapName(name, ns string) string {
 	return namePrefix + "-" + GetPolicyK8sName(name, ns)
 }
 
-// GetOperatorNamespace gets the namespace that the operator is currently running on.
-func GetOperatorNamespace() string {
-	// TODO(jaosorior): Get a method to return the current operator
-	// namespace.
-	//
-	// operatorNs, err := k8sutil.GetOperatorNamespace()
-	// if err != nil {
-	// 	return "security-profiles-operator"
-	// }
-	// return operatorNs
-	return "security-profiles-operator"
-}
-
 // SliceContainsString helper function to check if a string is in a slice of strings.
 func SliceContainsString(slice []string, s string) bool {
 	for _, item := range slice {

--- a/internal/pkg/controllers/spod/bindata/bindata.go
+++ b/internal/pkg/controllers/spod/bindata/bindata.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bindata
+
+import (
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	k8syaml "k8s.io/apimachinery/pkg/util/yaml"
+)
+
+func rawObjectToUnstructured(in string) (*unstructured.Unstructured, error) {
+	obj := &unstructured.Unstructured{}
+	dec := k8syaml.NewYAMLToJSONDecoder(strings.NewReader(in))
+	if err := dec.Decode(obj); err != nil {
+		return nil, fmt.Errorf("couldn't decode YAML: %w", err)
+	}
+	return obj, nil
+}

--- a/internal/pkg/controllers/spod/bindata/spod.go
+++ b/internal/pkg/controllers/spod/bindata/spod.go
@@ -1,0 +1,171 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bindata
+
+import (
+	"fmt"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// NOTE(jaosorior): We should switch this for a proper bindata solution.
+// nolint: lll
+const spodManifest = `---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: security-profiles-operator
+  namespace: security-profiles-operator
+spec:
+  selector:
+    matchLabels:
+      app: spod
+  template:
+    metadata:
+      annotations:
+        openshift.io/scc: privileged
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
+        container.seccomp.security.alpha.kubernetes.io/security-profiles-operator: localhost/security-profiles-operator.json
+      labels:
+        app: spod
+    spec:
+      serviceAccountName: security-profiles-operator
+      initContainers:
+        - name: non-root-enabler
+          image: bash
+          # Creates folder /var/lib/security-profiles-operator, sets 2000:2000 as its
+          # owner and symlink it to /var/lib/kubelet/seccomp/operator. This is
+          # required to allow the main container to run as non-root.
+          command: [bash, -c]
+          args:
+            - |+
+              set -euo pipefail
+
+              if [ ! -d $KUBELET_SECCOMP_ROOT ]; then
+                /bin/mkdir -m 0744 -p $KUBELET_SECCOMP_ROOT
+              fi
+
+              /bin/mkdir -p $OPERATOR_ROOT
+              /bin/chmod 0744 $OPERATOR_ROOT
+
+              if [ ! -L $OPERATOR_SYMLINK ]; then
+                /bin/ln -s $OPERATOR_ROOT $OPERATOR_SYMLINK
+              fi
+
+              /bin/chown -R 2000:2000 $OPERATOR_ROOT
+              cp -f -v /opt/seccomp-profiles/* $KUBELET_SECCOMP_ROOT
+          env:
+            - name: KUBELET_SECCOMP_ROOT
+              value: /var/lib/kubelet/seccomp
+            - name: OPERATOR_SYMLINK
+              value: $(KUBELET_SECCOMP_ROOT)/operator
+            - name: OPERATOR_ROOT
+              value: /var/lib/security-profiles-operator
+          volumeMounts:
+            - name: host-varlib-volume
+              mountPath: /var/lib
+            - name: profile-configmap-volume
+              mountPath: /opt/seccomp-profiles
+              readOnly: true
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop: ["ALL"]
+              add: ["CHOWN", "FOWNER", "FSETID", "DAC_OVERRIDE"]
+            runAsUser: 0
+            seLinuxOptions:
+              # FIXME(jaosorior): Use a more restricted selinux type
+              type: spc_t
+          resources:
+            requests:
+              memory: "32Mi"
+              cpu: "100m"
+              ephemeral-storage: "10Mi"
+            limits:
+              memory: "64Mi"
+              cpu: "250m"
+              ephemeral-storage: "50Mi"
+      containers:
+        - name: security-profiles-operator
+          image: security-profiles-operator
+          args:
+          - daemon
+          imagePullPolicy: Always
+          volumeMounts:
+          - name: host-operator-volume
+            mountPath: /var/lib/kubelet/seccomp/operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 2000
+            runAsGroup: 2000
+            capabilities:
+              drop: ["ALL"]
+            seLinuxOptions:
+              # FIXME(jaosorior): Use a more restricted selinux type
+              type: spc_t
+          resources:
+            requests:
+              memory: "64Mi"
+              cpu: "100m"
+              ephemeral-storage: "50Mi"
+            limits:
+              memory: "128Mi"
+              cpu: "300m"
+              ephemeral-storage: "200Mi"
+          env:
+            - name: NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+      volumes:
+      # /var/lib is used as symlinks cannot be created across different volumes
+      - name: host-varlib-volume
+        hostPath:
+          path: /var/lib
+          type: Directory
+      - name: host-operator-volume
+        hostPath:
+          path: /var/lib/security-profiles-operator
+          type: DirectoryOrCreate
+      - name: profile-configmap-volume
+        configMap:
+          name: security-profiles-operator-profile
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoExecute
+          key: node.kubernetes.io/not-ready
+          operator: Exists
+      nodeSelector:
+        kubernetes.io/os: linux
+`
+
+func GetReferenceSPOd() (*appsv1.DaemonSet, error) {
+	rawDS, err := rawObjectToUnstructured(spodManifest)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing DS manifest: %w", err)
+	}
+	spod := &appsv1.DaemonSet{}
+	err = runtime.DefaultUnstructuredConverter.FromUnstructured(rawDS.Object, spod)
+	if err != nil {
+		return nil, fmt.Errorf("error converting unstructured DS to implementation object: %w", err)
+	}
+	return spod, nil
+}

--- a/internal/pkg/controllers/spod/configmap_controller.go
+++ b/internal/pkg/controllers/spod/configmap_controller.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spod
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
+)
+
+// blank assignment to verify that ReconcileConfigMap implements `reconcile.Reconciler`.
+var _ reconcile.Reconciler = &ReconcileSPOd{}
+
+// ReconcileSPOd reconciles the SPOd DaemonSet object.
+type ReconcileSPOd struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client   client.Client
+	scheme   *runtime.Scheme
+	baseSPOd *appsv1.DaemonSet
+	record   event.Recorder
+	log      logr.Logger
+}
+
+// Reconcile reads that state of the cluster for a ConfigMap object and makes changes based on the state read
+// and what is in the `ConfigMap.Spec`.
+func (r *ReconcileSPOd) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	ctx := context.Background()
+	// Fetch the ConfigMap instance
+	cminstance := &corev1.ConfigMap{}
+	if err := r.client.Get(ctx, request.NamespacedName, cminstance); err != nil {
+		if kerrors.IsNotFound(err) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("error getting spod configuration: %w", err)
+	}
+	spodKey := types.NamespacedName{
+		Name:      r.baseSPOd.GetName(),
+		Namespace: config.GetOperatorNamespace(),
+	}
+	foundSPOd := &appsv1.DaemonSet{}
+	if getErr := r.client.Get(ctx, spodKey, foundSPOd); getErr != nil {
+		if kerrors.IsNotFound(getErr) {
+			return r.handleCreate(ctx, cminstance)
+		}
+		return reconcile.Result{}, fmt.Errorf("error getting spod DaemonSet: %w", getErr)
+	}
+
+	// NOTE(jaosorior): We gotta handle updates
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileSPOd) handleCreate(ctx context.Context, cfg *corev1.ConfigMap) (reconcile.Result, error) {
+	r.log.Info("Creating SPOd")
+	newSPOd := r.getConfiguredSPOd(cfg)
+
+	if err := controllerutil.SetControllerReference(cfg, newSPOd, r.scheme); err != nil {
+		return reconcile.Result{}, fmt.Errorf("error setting spod controller reference: %w", err)
+	}
+
+	if createErr := r.client.Create(ctx, newSPOd); createErr != nil {
+		if kerrors.IsAlreadyExists(createErr) {
+			return reconcile.Result{}, nil
+		}
+		return reconcile.Result{}, fmt.Errorf("error creating spod DaemonSet: %w", createErr)
+	}
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileSPOd) getConfiguredSPOd(cfg *corev1.ConfigMap) *appsv1.DaemonSet {
+	newSPOd := r.baseSPOd.DeepCopy()
+
+	imagePullPolicyStr, found := cfg.Data["SPOdImagePullPolicy"]
+	if found {
+		pullPolicy := corev1.PullPolicy(imagePullPolicyStr)
+		newSPOd.Spec.Template.Spec.Containers[0].ImagePullPolicy = pullPolicy
+	}
+	return newSPOd
+}

--- a/internal/pkg/controllers/spod/setup.go
+++ b/internal/pkg/controllers/spod/setup.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spod
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/crossplane/crossplane-runtime/pkg/event"
+	"github.com/crossplane/crossplane-runtime/pkg/resource"
+	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/controllers/spod/bindata"
+)
+
+// TODO(jaosorior): Use better method than a label constant.
+const cmIsSPOdConfig = "security-profiles-operator/config"
+
+// SPOdTunables defines the parameters to tune/modify for the
+// Security-Profiles-Operator-Daemon.
+type DaemonTunables struct {
+	DaemonImage         string
+	NonRootEnablerImage string
+	WatchNamespace      string
+}
+
+// Setup adds a controller that reconciles the SPOd DaemonSet.
+func Setup(ctx context.Context, mgr ctrl.Manager, dt DaemonTunables, l logr.Logger) error {
+	refSPOd, err := getEffectiveSPOd(dt)
+	if err != nil {
+		return err
+	}
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("spod-config").
+		For(&corev1.ConfigMap{}).
+		WithEventFilter(resource.NewPredicates(isSPOdConfig)).
+		Owns(&appsv1.DaemonSet{}).
+		Complete(&ReconcileSPOd{
+			baseSPOd: refSPOd,
+			client:   mgr.GetClient(),
+			log:      l,
+			record:   event.NewAPIRecorder(mgr.GetEventRecorderFor("spod-config")),
+			scheme:   mgr.GetScheme(),
+		})
+}
+
+func getEffectiveSPOd(dt DaemonTunables) (*appsv1.DaemonSet, error) {
+	refSPOd, err := bindata.GetReferenceSPOd()
+	if err != nil {
+		return nil, fmt.Errorf("couldn't get reference SPO DaemonSet: %w", err)
+	}
+	cnt := &refSPOd.Spec.Template.Spec.Containers[0]
+	cnt.Image = dt.DaemonImage
+	if dt.WatchNamespace != "" {
+		cnt.Env = append(cnt.Env, corev1.EnvVar{
+			Name:  "RESTRICT_TO_NAMESPACE",
+			Value: dt.WatchNamespace,
+		})
+	}
+
+	initcnt := &refSPOd.Spec.Template.Spec.InitContainers[0]
+	initcnt.Image = dt.NonRootEnablerImage
+	return refSPOd, nil
+}
+
+func isSPOdConfig(obj runtime.Object) bool {
+	cm, ok := obj.(*corev1.ConfigMap)
+	if !ok {
+		return false
+	}
+	// we only care about this namespace
+	if cm.GetNamespace() != config.GetOperatorNamespace() {
+		return false
+	}
+	if cm.GetName() != "config" {
+		return false
+	}
+	labels := cm.GetLabels()
+	if labels == nil {
+		return false
+	}
+	_, ok = labels[cmIsSPOdConfig]
+	return ok
+}

--- a/internal/pkg/controllers/spod/setup_test.go
+++ b/internal/pkg/controllers/spod/setup_test.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package spod
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_getEffectiveSPOd(t *testing.T) {
+	tests := []struct {
+		name    string
+		dt      DaemonTunables
+		nsIsSet bool
+		wantErr bool
+	}{
+		{
+			"Should correctly set the image",
+			DaemonTunables{"foo:bar", "bar:baz", ""},
+			false,
+			false,
+		},
+		{
+			"Should correctly set the namespace",
+			DaemonTunables{"foo:bar", "bar:baz", "my-ns"},
+			true,
+			false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := getEffectiveSPOd(tt.dt)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getEffectiveSPOd() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			require.Equal(t, tt.dt.DaemonImage, got.Spec.Template.Spec.Containers[0].Image)
+			require.Equal(t, tt.dt.NonRootEnablerImage, got.Spec.Template.Spec.InitContainers[0].Image)
+			var found bool
+			for _, env := range got.Spec.Template.Spec.Containers[0].Env {
+				if env.Name == "RESTRICT_TO_NAMESPACE" {
+					require.Equal(t, tt.dt.WatchNamespace, env.Value)
+					found = true
+					break
+				}
+			}
+			if tt.nsIsSet && !found {
+				t.Errorf("RESTRICT_TO_NAMESPACE env variable wasn't set")
+			}
+		})
+	}
+}

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -278,8 +278,8 @@ func (e *e2e) kubectlFailure(args ...string) string {
 	return e.runFailure(e.kubectlPath, args...)
 }
 
-func (e *e2e) kubectlOperatorNS(args ...string) string {
-	return e.kubectl(
+func (e *e2e) kubectlOperatorNS(args ...string) {
+	e.kubectl(
 		append([]string{"-n", config.OperatorName}, args...)...,
 	)
 }


### PR DESCRIPTION
Change controller manager to be a Deployment

Why?
====

While the current approach of deploying a DaemonSet directly works, it
has some limitations:

* It's not trivial to customize what to deploy (e.g. if we want to
  disable AppArmor)

* It's not directly supported by some operator catalogs (e.g.
  via the Operator Lifecycle Manager)

This instead proposes the usage of a Deployment.

This Deployment listens for a Configuration called "config", which
will allow us to customize the DaemonSet (e.g. enable/disable
features).

On the other hand, with we'll be able to use this Deployment to serve
webhooks (like the one that's currently missing to validate the SELinux
policy namespaces).

What's missing?
===============

Actually add configuration options
----------------------------------

Currently the controller only deploys the DaemonSet... only configuration
is taken into account: `SPOdImagePullPolicy`.

This was required for the kind-based e2e tests.

Handle configuration updates
----------------------------

Once we have configurations, we need to handle updates.

Better bindata management
-------------------------

Currently the DaemonSet is a hardcoded string, it would be better to
have an appropriate bindata solution which would read a yaml file and
update go code to handle it automatically.

Separate RBAC roles
----------------------------

Currently, both the controller manager and the daemon use the same ServiceAccount
with the same role. It would be ideal to separate them.

Merge SELinux to the DaemonSet
------------------------------

Currently SELinux works on a cluster level, and so it's part of the main
Deployment. This needs to be changed so SELinux module installation
should be done as part of the DaemonSet instead. This will require us to
change the inner workings of the SELinux bits (probably using selinuxd
[1])

Discussion
========

* How do folks feel about the configuration being a ConfigMap. Is that fine for everybody?
  or would folks prefer to have a dedicated CustomResource for this?

[1] https://github.com/JAORMX/selinuxd

```release-note
The main deployment method is now a Deployment object that requires a ConfigMap
called "config".
```