### PR TITLE
Add Makefile targets for easy development in OpenShift

### DIFF
--- a/deploy/overlays/openshift-dev/kustomization.yaml
+++ b/deploy/overlays/openshift-dev/kustomization.yaml
@@ -1,0 +1,35 @@
+# This is the cluster wide security-profiles-operator deployment, which listens for
+# configMaps on all namespaces
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../../base
+
+patchesJson6902:
+  - target:
+      version: v1
+      kind: ConfigMap
+      name: security-profiles-operator-profile
+    path: operator-profile.yaml
+
+images:
+  - name: gcr.io/k8s-staging-sp-operator/security-profiles-operator
+    newName: image-registry.openshift-image-registry.svc:5000/openshift/security-profiles-operator
+    newTag: latest
+
+patchesStrategicMerge:
+- |-
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: security-profiles-operator
+    namespace: security-profiles-operator
+  spec:
+    template:
+      spec:
+        containers:
+          - name: security-profiles-operator
+            env:
+              - name: RELATED_IMAGE_OPERATOR
+                value: image-registry.openshift-image-registry.svc:5000/openshift/security-profiles-operator:latest

--- a/deploy/overlays/openshift-dev/operator-profile.yaml
+++ b/deploy/overlays/openshift-dev/operator-profile.yaml
@@ -1,0 +1,3 @@
+- op: replace
+  path: /metadata/namespace
+  value: security-profiles-operator


### PR DESCRIPTION
Add Makefile targets for easy development in OpenShift

This adds the following targets:

`push-openshift-dev`
--------------------

Builds the operator image based on UBI, and pushes it to the OpenShift
cluster that your current kubectl context is pointing at.

`do-deploy-openshift-dev`
-------------------------

Builds `deploy/operator.yaml` based on an `openshift-dev` overlay which
contains overrides that point to the local OpenShift container image
registry. This is then deployed and a trigger is set so any changes to
the container image get automatically taken into use by the Deployment.

`deploy-openshift-dev`
----------------------

Triggers both of the aforementioned targets.

Note
----

These targets are only usable for development purposes.

```release-note
NONE
```