### PR TITLE
feature - Included settings for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
#### What type of PR is this?

- Dependabot pulls down your dependency files and looks for any outdated or insecure requirements.

- Dependabot opens pull requests. If any of your dependencies are out-of-date, Dependabot opens individual pull requests to update each one.

- You review and merge. You check that your tests pass, scan the included changelog and release notes, then hit merge with confidence.


/kind cleanup


#### What this PR does / why we need it:
Updates dependencies that are out of date. For example #185  could have been automatically notified by dependabot

#### Which issue(s) this PR fixes:
Fixes #182 - indirectly 

#### Special notes for your reviewer:
https://dependabot.com/
Dependabot setting can be enabled like this.

![image](https://user-images.githubusercontent.com/172697/104531530-56a8c800-55dc-11eb-8eac-b341a92d4d0f.png)

Which has depedabot pulls with updates to dependencies. 
https://github.com/naveensrinivasan/security-profiles-operator/pulls
#### Does this PR introduce a user-facing change?
NONE


```release-note
NONE
```