### PR TITLE
Re-add runtime/default seccomp profile to operator deployment

### DIFF
--- a/deploy/base/operator.yaml
+++ b/deploy/base/operator.yaml
@@ -11,6 +11,8 @@ spec:
       name: security-profiles-operator
   template:
     metadata:
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
       labels:
         name: security-profiles-operator
     spec:

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -489,6 +489,8 @@ spec:
       name: security-profiles-operator
   template:
     metadata:
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
       labels:
         app: security-profiles-operator
         name: security-profiles-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -489,6 +489,8 @@ spec:
       name: security-profiles-operator
   template:
     metadata:
+      annotations:
+        seccomp.security.alpha.kubernetes.io/pod: runtime/default
       labels:
         app: security-profiles-operator
         name: security-profiles-operator


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
We now re-add the runtime seccomp profile for the deployments to
increase its security footprint.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes-sigs/security-profiles-operator/issues/201
#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
