### PR TITLE
Fix UBI Dockerfile

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -12,9 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.access.redhat.com/ubi8/go-toolset:latest AS build
+FROM registry.fedoraproject.org/fedora-minimal:latest AS build
 USER root
 WORKDIR /work
+
+RUN microdnf install -y make golang-bin libseccomp-static glibc-static
 
 # Speed up build by leveraging docker layer caching
 COPY go.mod go.sum ./
@@ -23,7 +25,6 @@ RUN go mod download
 ADD . /work
 RUN mkdir -p build
 
-ENV LINKMODE_EXTERNAL=no
 RUN make
 
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest


### PR DESCRIPTION
Fix UBI Dockerfile

A recent commit added the seccomp tag to the build [1], however, it
missed to add it to the UBI build. This fixes that. Note that since the
seccomp-static package is not available in UBI, we switched the
build-base to be fedora, and it'll eventually copy the binary to a UBI
based container.

[1] f504483024c68b621f6e43170de59e1cd2f47216

```release-note
NONE
```