### PR TITLE
Simplify operator init container by using internal vars

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -38,7 +38,6 @@ import (
 
 const (
 	jsonFlag               string = "json"
-	restrictNSKey          string = "RESTRICT_TO_NAMESPACE"
 	operatorImageKey       string = "RELATED_IMAGE_OPERATOR"
 	nonRootEnablerImageKey string = "RELATED_IMAGE_NON_ROOT_ENABLER"
 )
@@ -168,22 +167,21 @@ func runManager(ctx *cli.Context) error {
 	return nil
 }
 
-func getTunables() (spod.DaemonTunables, error) {
-	var dt spod.DaemonTunables
-	restrictNS := os.Getenv(restrictNSKey)
+func getTunables() (dt spod.DaemonTunables, err error) {
+	dt.WatchNamespace = os.Getenv(config.RestrictNamespaceEnvKey)
+
 	operatorImage := os.Getenv(operatorImageKey)
 	if operatorImage == "" {
 		return dt, errors.New("invalid operator image")
 	}
+	dt.DaemonImage = operatorImage
 
 	nonRootEnableImage := os.Getenv(nonRootEnablerImageKey)
 	if nonRootEnableImage == "" {
 		return dt, errors.New("invalid non-root enabler image")
 	}
-
-	dt.DaemonImage = operatorImage
 	dt.NonRootEnablerImage = nonRootEnableImage
-	dt.WatchNamespace = restrictNS
+
 	return dt, nil
 }
 
@@ -201,8 +199,8 @@ func runDaemon(ctx *cli.Context) error {
 		SyncPeriod: &sync,
 	}
 
-	if os.Getenv(restrictNSKey) != "" {
-		ctrlOpts.Namespace = os.Getenv(restrictNSKey)
+	if os.Getenv(config.RestrictNamespaceEnvKey) != "" {
+		ctrlOpts.Namespace = os.Getenv(config.RestrictNamespaceEnvKey)
 	}
 
 	mgr, err := ctrl.NewManager(cfg, ctrlOpts)

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -31,6 +31,10 @@ const (
 	// NodeNameEnvKey is the default environment variable key for retrieving
 	// the name of the current node.
 	NodeNameEnvKey = "NODE_NAME"
+
+	// RestrictNamespaceEnvKey is the environment variable key for restricting
+	// the operator to work on only a single Kubernetes namespace.
+	RestrictNamespaceEnvKey = "RESTRICT_TO_NAMESPACE"
 )
 
 // GetOperatorNamespace gets the namespace that the operator is currently running on.

--- a/internal/pkg/controllers/spod/setup.go
+++ b/internal/pkg/controllers/spod/setup.go
@@ -62,9 +62,10 @@ func getEffectiveSPOd(dt DaemonTunables) *appsv1.DaemonSet {
 	refSPOd := bindata.Manifest.DeepCopy()
 	cnt := &refSPOd.Spec.Template.Spec.Containers[0]
 	cnt.Image = dt.DaemonImage
+
 	if dt.WatchNamespace != "" {
 		cnt.Env = append(cnt.Env, corev1.EnvVar{
-			Name:  "RESTRICT_TO_NAMESPACE",
+			Name:  config.RestrictNamespaceEnvKey,
 			Value: dt.WatchNamespace,
 		})
 	}

--- a/internal/pkg/controllers/spod/setup_test.go
+++ b/internal/pkg/controllers/spod/setup_test.go
@@ -20,6 +20,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 )
 
 func Test_getEffectiveSPOd(t *testing.T) {
@@ -49,14 +51,14 @@ func Test_getEffectiveSPOd(t *testing.T) {
 			require.Equal(t, tt.dt.NonRootEnablerImage, got.Spec.Template.Spec.InitContainers[0].Image)
 			var found bool
 			for _, env := range got.Spec.Template.Spec.Containers[0].Env {
-				if env.Name == "RESTRICT_TO_NAMESPACE" {
+				if env.Name == config.RestrictNamespaceEnvKey {
 					require.Equal(t, tt.dt.WatchNamespace, env.Value)
 					found = true
 					break
 				}
 			}
 			if tt.nsIsSet && !found {
-				t.Errorf("RESTRICT_TO_NAMESPACE env variable wasn't set")
+				t.Errorf("%s env variable wasn't set", config.RestrictNamespaceEnvKey)
 			}
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
If we programmatically create the DaemonSet then we can also use internal variables directly without having a need to set them via Kubernetes environment variables. This patch also clarifies/simplifies some code paths inherited by this change.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
