### PR TITLE
Add libseccomp-static to fix container image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@
 
 FROM golang:1.15-alpine AS build
 WORKDIR /work
-RUN apk --no-cache add build-base git gcc libseccomp-dev
+RUN apk --no-cache add build-base git gcc libseccomp-dev libseccomp-static
 
 ENV USER=secuser
 ENV UID=2000


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The static library is not part of the libseccomp-dev package any more
and has been split into a dedicated one. We now add this package too to
re-enable the image builds.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
