### PR TITLE
Update golangci-lint and run tests in parallel

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,10 @@
 ---
 run:
   build-tags:
-    - netgo
     - e2e
+    - netgo
+    - osusergo
+    - seccomp
   concurrency: 6
   deadline: 5m
 linters:
@@ -41,18 +43,23 @@ linters:
     - ineffassign
     - interfacer
     - lll
+    - makezero
     - maligned
     - misspell
     - nakedret
     - nestif
     - noctx
     - nolintlint
+    - paralleltest
     - prealloc
+    - predeclared
     - rowserrcheck
+    - scopelint
     - sqlclosecheck
     - staticcheck
     - structcheck
     - stylecheck
+    - thelper
     - tparallel
     - typecheck
     - unconvert
@@ -62,10 +69,10 @@ linters:
     - whitespace
     - wrapcheck
     # - exhaustivestruct
+    # - forbidigo
     # - funlen
     # - gochecknoglobals
     # - nlreturn
-    # - scopelint
     # - testpackage
     # - wsl
 linters-settings:

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ VERSION := $(shell cat VERSION)
 ifneq ($(shell uname -s), Darwin)
 BUILDTAGS := netgo osusergo seccomp
 else
-BUILDTAGS := netgo osusergo 
+BUILDTAGS := netgo osusergo
 endif
 BUILD_FILES := $(shell find . -type f -name '*.go' -or -name '*.mod' -or -name '*.sum' -not -name '*_test.go')
 export GOFLAGS?=-mod=mod
@@ -60,7 +60,7 @@ IMAGE ?= $(PROJECT):latest
 
 CRD_OPTIONS ?= "crd:crdVersions=v1"
 
-GOLANGCI_LINT_VERSION = v1.32.0
+GOLANGCI_LINT_VERSION = v1.35.2
 REPO_INFRA_VERSION = v0.1.2
 
 export E2E_CLUSTER_TYPE ?= kind
@@ -154,12 +154,12 @@ $(BUILD_DIR)/golangci-lint:
 
 .PHONY: test-unit
 test-unit: $(BUILD_DIR) ## Run the unit tests
-	$(GO) test -ldflags '$(LDVARS)' -tags '$(BUILDTAGS)' -v -test.coverprofile=$(BUILD_DIR)/coverage.out ./internal/...
+	$(GO) test -ldflags '$(LDVARS)' -tags '$(BUILDTAGS)' -race -v -test.coverprofile=$(BUILD_DIR)/coverage.out ./internal/...
 	$(GO) tool cover -html $(BUILD_DIR)/coverage.out -o $(BUILD_DIR)/coverage.html
 
 .PHONY: test-e2e
 test-e2e: ## Run the end-to-end tests
-	$(GO) test -timeout 40m -count=1 ./test/... -v
+	$(GO) test -race -timeout 40m -count=1 ./test/... -v
 
 # Generate CRD manifests
 manifests:
@@ -196,7 +196,7 @@ push-openshift-dev: set-openshift-image-params openshift-user image
 		$(CONTAINER_RUNTIME) push $(LOGIN_PUSH_OPTS) localhost/$(IMAGE) $${IMAGE_REGISTRY_HOST}/openshift/$(IMAGE)
 
 .PHONY: do-deploy-openshift-dev
-do-deploy-openshift-dev: 
+do-deploy-openshift-dev:
 	@echo "Building custom operator.yaml"
 	kustomize build --reorder=none deploy/overlays/openshift-dev -o deploy/operator.yaml
 	@echo "Deploying"

--- a/hack/pull-security-profiles-operator-verify
+++ b/hack/pull-security-profiles-operator-verify
@@ -3,7 +3,7 @@ set -euo pipefail
 
 # assume a Debian based golang image, like: golang:1.15
 apt-get update
-apt-get install -y python3
+apt-get install -y libseccomp-dev python3
 
 # install kustomize
 pushd /usr/bin

--- a/internal/pkg/controllers/spod/setup_test.go
+++ b/internal/pkg/controllers/spod/setup_test.go
@@ -25,6 +25,7 @@ import (
 )
 
 func Test_getEffectiveSPOd(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name    string
 		dt      DaemonTunables
@@ -45,7 +46,9 @@ func Test_getEffectiveSPOd(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			got := getEffectiveSPOd(tt.dt)
 			require.Equal(t, tt.dt.DaemonImage, got.Spec.Template.Spec.Containers[0].Image)
 			require.Equal(t, tt.dt.NonRootEnablerImage, got.Spec.Template.Spec.InitContainers[0].Image)

--- a/internal/pkg/version/version_test.go
+++ b/internal/pkg/version/version_test.go
@@ -23,6 +23,8 @@ import (
 )
 
 func TestVersionText(t *testing.T) {
+	t.Parallel()
+
 	sut := Get()
 	require.NotEmpty(t, sut.BuildDate)
 	require.NotEmpty(t, sut.Compiler)
@@ -35,6 +37,8 @@ func TestVersionText(t *testing.T) {
 }
 
 func TestVersionJSON(t *testing.T) {
+	t.Parallel()
+
 	sut, err := Get().JSONString()
 	require.Nil(t, err)
 	require.NotEmpty(t, sut)

--- a/internal/pkg/webhooks/binding/webhook_test.go
+++ b/internal/pkg/webhooks/binding/webhook_test.go
@@ -24,15 +24,20 @@ import (
 )
 
 func TestNewContainerMap(t *testing.T) {
-	cases := map[string]struct {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
 		podSpec *corev1.PodSpec
 		want    containerMap
 	}{
-		"NoContainers": {
+		{
+			name:    "NoContainers",
 			podSpec: &corev1.PodSpec{},
 			want:    map[string][]*corev1.Container{},
 		},
-		"OnlyContainers": {
+		{
+			name: "OnlyContainers",
 			podSpec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
@@ -60,7 +65,8 @@ func TestNewContainerMap(t *testing.T) {
 				},
 			},
 		},
-		"OnlyInitContainers": {
+		{
+			name: "OnlyInitContainers",
 			podSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{
 					{
@@ -88,7 +94,8 @@ func TestNewContainerMap(t *testing.T) {
 				},
 			},
 		},
-		"ContainersAndInitContainers": {
+		{
+			name: "ContainersAndInitContainers",
 			podSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{{
 					Name:  "init",
@@ -114,7 +121,8 @@ func TestNewContainerMap(t *testing.T) {
 				},
 			},
 		},
-		"DuplicateImages": {
+		{
+			name: "DuplicateImages",
 			podSpec: &corev1.PodSpec{
 				InitContainers: []corev1.Container{{
 					Name:  "init",
@@ -140,8 +148,11 @@ func TestNewContainerMap(t *testing.T) {
 		},
 	}
 
-	for name, tc := range cases {
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
 			result := newContainerMap(tc.podSpec)
 			for k, v := range result {
 				require.Equal(t, tc.want[k], v)

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -65,6 +65,7 @@ type openShifte2e struct {
 }
 
 func TestSuite(t *testing.T) {
+	t.Parallel()
 	fmt.Printf("cluster-type: %s\n", clusterType)
 
 	switch {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We now enable additional linters with the bump of golangci-lint. The
tests are now using the t.Parallel() method to let them executed
simultaneously.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
