### PR TITLE
Log cluster state before tearing down e2e test

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -172,6 +172,13 @@ func (e *kinde2e) SetupTest() {
 
 // TearDownTest stops the kind cluster.
 func (e *kinde2e) TearDownTest() {
+	e.logf("#### Snapshot of cert-manager namespace ####")
+	e.kubectl("--namespace", "cert-manager", "describe", "all")
+	e.logf("########")
+	e.logf("#### Snapshot of security-profiles-operator namespace ####")
+	e.kubectl("--namespace", "security-profiles-operator", "describe", "all")
+	e.logf("########")
+
 	e.logf("Destroying cluster")
 	e.run(
 		e.kindPath, "delete", "cluster",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

In case something goes wrong, ensure the e2e tests output the state of
the cert-manager and security-profiles-operator resources. This should
help with debugging CI failures, especially intermittent ones.

#### Which issue(s) this PR fixes:

Relates to #220 

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
NONE
```
