### PR TITLE
Feature - use the downward api to get the namespace

### DIFF
--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -29,6 +29,10 @@ patchesStrategicMerge:
                 value: bash:5.0
               - name: RELATED_IMAGE_SELINUXD
                 value: quay.io/jaosorior/selinuxd
+              - name: MY_POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace
 
 commonLabels:
   app: security-profiles-operator

--- a/deploy/base/operator.yaml
+++ b/deploy/base/operator.yaml
@@ -33,6 +33,10 @@ spec:
               value: non-root-enabler
             - name: RELATED_IMAGE_SELINUXD
               value: quay.io/jaosorior/selinuxd
+            - name: MY_POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
       nodeSelector:
         node-role.kubernetes.io/master: ""
       tolerations:

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -507,6 +507,10 @@ spec:
           value: bash:5.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/jaosorior/selinuxd
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
         imagePullPolicy: Always
         name: security-profiles-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -505,6 +505,10 @@ spec:
           value: bash:5.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/jaosorior/selinuxd
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
         imagePullPolicy: Always
         name: security-profiles-operator

--- a/deploy/overlays/openshift-dev/kustomization.yaml
+++ b/deploy/overlays/openshift-dev/kustomization.yaml
@@ -38,3 +38,7 @@ patchesStrategicMerge:
             env:
               - name: RELATED_IMAGE_OPERATOR
                 value: image-registry.openshift-image-registry.svc:5000/openshift/security-profiles-operator:latest
+              - name: MY_POD_NAMESPACE
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.namespace

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetOperatorNamespace(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Valid one",
+			want:    "default",
+			wantErr: false,
+		},
+		{
+			name:    "invalid one",
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.wantErr {
+				os.Unsetenv("MY_POD_NAMESPACE")
+			} else {
+				os.Setenv("MY_POD_NAMESPACE", tt.want)
+			}
+			got, err := GetOperatorNamespace()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetOperatorNamespace() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetOperatorNamespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/pkg/controllers/spod/configmap_controller.go
+++ b/internal/pkg/controllers/spod/configmap_controller.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/go-logr/logr"
+	"github.com/pkg/errors"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -61,9 +62,15 @@ func (r *ReconcileSPOd) Reconcile(request reconcile.Request) (reconcile.Result, 
 		}
 		return reconcile.Result{}, fmt.Errorf("error getting spod configuration: %w", err)
 	}
+
+	namespace, err := config.GetOperatorNamespace()
+	if err != nil {
+		return reconcile.Result{}, errors.Wrap(err, "getting operator namespace")
+	}
+
 	spodKey := types.NamespacedName{
 		Name:      r.baseSPOd.GetName(),
-		Namespace: config.GetOperatorNamespace(),
+		Namespace: namespace,
 	}
 	foundSPOd := &appsv1.DaemonSet{}
 	if getErr := r.client.Get(ctx, spodKey, foundSPOd); getErr != nil {


### PR DESCRIPTION
#### What type of PR is this?
The use downward API to get the pod namespace https://kubernetes.io/docs/tasks/inject-data-application/environment-variable-expose-pod-information/

/kind cleanup

#### What this PR does / why we need it:
The namespace was hardcoded before this. The operator could be deployed in a non-standard namespace, and this will not break if it is so.

#### Which issue(s) this PR fixes:
None


#### Special notes for your reviewer:

The code changes have unit-tests. 

#### Does this PR introduce a user-facing change?

NONE

```release-note
Utilized the downard API to get the Pod namespace for configmap controller.

```
