### PR TITLE
make: Deploy cert-manager before deploying the operator in OpenShift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -207,5 +207,5 @@ do-deploy-openshift-dev:
 	git checkout deploy/operator.yaml
 
 # Deploy for development into OpenShift
-.PHONY: dev-deploy-openshift
+.PHONY: deploy-openshift-dev
 deploy-openshift-dev: push-openshift-dev do-deploy-openshift-dev

--- a/Makefile
+++ b/Makefile
@@ -197,6 +197,9 @@ push-openshift-dev: set-openshift-image-params openshift-user image
 
 .PHONY: do-deploy-openshift-dev
 do-deploy-openshift-dev:
+	@echo "Deploying cert-manager"
+	oc apply -f https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
+	oc wait --for=condition=Ready pod -lapp.kubernetes.io/instance=cert-manager -ncert-manager
 	@echo "Building custom operator.yaml"
 	kustomize build --reorder=none deploy/overlays/openshift-dev -o deploy/operator.yaml
 	@echo "Deploying"


### PR DESCRIPTION
There exists the 'deploy-openshift-dev' Makefile command that deploys the 
operator in an OpenShift cluster. But since the cert-manager dependency was
added, the target didn't work as OpenShift doesn't come with cert-manager
by default. This patch adds the dependency and waits for the cert-manager
pods to come up.

/kind bug
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```