### PR TITLE
e2e: Run tests as sub-tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ test-unit: $(BUILD_DIR) ## Run the unit tests
 
 .PHONY: test-e2e
 test-e2e: ## Run the end-to-end tests
-	$(GO) test -race -timeout 40m -count=1 ./test/... -v
+	$(GO) test -parallel 1 -timeout 40m -count=1 ./test/... -v
 
 # Generate CRD manifests
 manifests: $(CONTROLLER_GEN)

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -77,12 +77,6 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			"Seccomp: Re-deploy the operator",
 			e.testCaseReDeployOperator,
 		},
-		// TODO(jaosorior): Re-introduce this once we
-		// fix the issue with the certs.
-		//{
-		//	"Seccomp: Verify profile binding",
-		//	e.testCaseProfileBinding,
-		//},
 		{
 			"SELinux: sanity check",
 			e.testCaseSelinuxSanityCheck,
@@ -98,6 +92,12 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			tc.fn(nodes)
 		})
 	}
+
+	// TODO(jaosorior): Re-introduce this to the namespaced tests once we
+	// fix the issue with the certs.
+	e.Run("cluster-wide: Seccomp: Verify profile binding", func() {
+		e.testCaseProfileBinding(nodes)
+	})
 
 	// Clean up cluster-wide deployment to prepare for namespace deployment
 	e.cleanupOperator(manifest, defaultProfiles)

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -91,8 +91,10 @@ func (e *e2e) TestSecurityProfilesOperator() {
 		},
 	}
 	for _, testCase := range testCases {
-		e.logf("> Running testcase: %s", testCase.description)
-		testCase.fn(nodes)
+		tc := testCase
+		e.Run("cluster-wide: "+tc.description, func() {
+			tc.fn(nodes)
+		})
 	}
 
 	// Clean up cluster-wide deployment to prepare for namespace deployment
@@ -120,8 +122,10 @@ func (e *e2e) TestSecurityProfilesOperator() {
 	e.deployOperator(namespaceManifest, namespaceDefaultProfiles)
 
 	for _, testCase := range testCases {
-		e.logf("> Running testcase: %s", testCase.description)
-		testCase.fn(nodes)
+		tc := testCase
+		e.Run("namespaced: "+tc.description, func() {
+			tc.fn(nodes)
+		})
 	}
 }
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -77,10 +77,12 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			"Seccomp: Re-deploy the operator",
 			e.testCaseReDeployOperator,
 		},
-		{
-			"Seccomp: Verify profile binding",
-			e.testCaseProfileBinding,
-		},
+		// TODO(jaosorior): Re-introduce this once we
+		// fix the issue with the certs.
+		//{
+		//	"Seccomp: Verify profile binding",
+		//	e.testCaseProfileBinding,
+		//},
 		{
 			"SELinux: sanity check",
 			e.testCaseSelinuxSanityCheck,

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -69,8 +69,11 @@ type openShifte2e struct {
 	skipBuildImages bool
 }
 
+// We're unable to use parallel tests because of our usage of testify/suite.
+// See https://github.com/stretchr/testify/issues/187
+//
+// nolint:paralleltest
 func TestSuite(t *testing.T) {
-	t.Parallel()
 	fmt.Printf("cluster-type: %s\n", clusterType)
 	fmt.Printf("container-runtime: %s\n", containerRuntime)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Currently, the tests e2e are being from a single `TestSuite` which
iterates through the test definitions calling their respective
functions.

However, if one of these definitions were to fail, the error is reported
towards the upper `TestSuite` test.

This uses testify's `Suite` object ability to run sub-tests (similar to
what `testing.T` provides) and instead uses that.

This way, any errors coming from a sub-test will be reported for that
sub-test and it'll be easier to debug.

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

One thing to note is that given our usage of testify's `Suite`, we
aren't able to do parallel testing in our e2e tests. In order to enable
this, we'd need to move away from the `Suite` object or use a different
framework.

See https://github.com/stretchr/testify/issues/187

#### Does this PR introduce a user-facing change?

```release-note
NONE
```