### PR TITLE
Fix-included the .git and version to .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,9 +2,11 @@
 *
 
 # Allow files and directories
+!/.git
 !/go.mod
 !/go.sum
 !/Makefile
+!/VERSION
 !/tools.go
 !/api/**
 !/cmd/**


### PR DESCRIPTION



#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
The dockerignore was missing the `.git` and `VERSION` which was required for
the `make image`. Included these additional files into the
.dockerignore.

#### Which issue(s) this PR fixes:

None


#### Does this PR have test?
N?A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

```release-note
NONE
```
