### PR TITLE
Add log enrichment feature for seccomp

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -51,6 +51,7 @@ const (
 	selinuxFlag            string = "with-selinux"
 	nonRootEnablerImageKey string = "RELATED_IMAGE_NON_ROOT_ENABLER"
 	selinuxdImageKey       string = "RELATED_IMAGE_SELINUXD"
+	logEnricherImageKey    string = "RELATED_IMAGE_LOG_ENRICHER"
 	defaultWebhookPort     int    = 9443
 )
 
@@ -221,6 +222,12 @@ func getTunables() (dt spod.DaemonTunables, err error) {
 		return dt, errors.New("invalid selinuxd image")
 	}
 	dt.SelinuxdImage = selinuxdImage
+
+	logEnricherImage := os.Getenv(logEnricherImageKey)
+	if logEnricherImage == "" {
+		return dt, errors.New("invalid log enricher image")
+	}
+	dt.LogEnricherImage = logEnricherImage
 
 	return dt, nil
 }

--- a/deploy/base/config.yaml
+++ b/deploy/base/config.yaml
@@ -8,3 +8,4 @@ metadata:
     security-profiles-operator/config: ""
 data:
   EnableSelinux: "false"
+  EnableLogEnricher: "false"

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -27,6 +27,8 @@ patchesStrategicMerge:
                 value: bash:5.0
               - name: RELATED_IMAGE_SELINUXD
                 value: quay.io/jaosorior/selinuxd
+              - name: RELATED_IMAGE_LOG_ENRICHER
+                value: paulinhu/kube-audit-log-enricher
 
 commonLabels:
   app: security-profiles-operator

--- a/deploy/base/operator.yaml
+++ b/deploy/base/operator.yaml
@@ -31,6 +31,8 @@ spec:
               value: non-root-enabler
             - name: RELATED_IMAGE_SELINUXD
               value: quay.io/jaosorior/selinuxd
+            - name: RELATED_IMAGE_LOG_ENRICHER
+              value: paulinhu/kube-audit-log-enricher
       tolerations:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"

--- a/deploy/base/rbac.yaml
+++ b/deploy/base/rbac.yaml
@@ -170,3 +170,31 @@ roleRef:
   kind: Role
   name: security-profiles-operator
   apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: security-profiles-operator
+  name: security-profiles-operator-log-enricher
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: security-profiles-operator-log-enricher
+subjects:
+- kind: ServiceAccount
+  name: security-profiles-operator
+  namespace: security-profiles-operator
+roleRef:
+  kind: ClusterRole
+  name: security-profiles-operator-log-enricher
+  apiGroup: rbac.authorization.k8s.io

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -475,6 +475,36 @@ subjects:
   name: security-profiles-operator
   namespace: security-profiles-operator
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: security-profiles-operator
+  name: security-profiles-operator-log-enricher
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: security-profiles-operator
+  name: security-profiles-operator-log-enricher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: security-profiles-operator-log-enricher
+subjects:
+- kind: ServiceAccount
+  name: security-profiles-operator
+  namespace: security-profiles-operator
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -506,6 +536,8 @@ spec:
           value: bash:5.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/jaosorior/selinuxd
+        - name: RELATED_IMAGE_LOG_ENRICHER
+          value: paulinhu/kube-audit-log-enricher
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
         imagePullPolicy: Always
         name: security-profiles-operator
@@ -526,6 +558,7 @@ spec:
 ---
 apiVersion: v1
 data:
+  EnableLogEnricher: "false"
   EnableSelinux: "false"
 kind: ConfigMap
 metadata:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -474,6 +474,36 @@ subjects:
   name: security-profiles-operator
   namespace: security-profiles-operator
 ---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: security-profiles-operator
+  name: security-profiles-operator-log-enricher
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: security-profiles-operator
+  name: security-profiles-operator-log-enricher
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: security-profiles-operator-log-enricher
+subjects:
+- kind: ServiceAccount
+  name: security-profiles-operator
+  namespace: security-profiles-operator
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -503,6 +533,8 @@ spec:
           value: bash:5.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/jaosorior/selinuxd
+        - name: RELATED_IMAGE_LOG_ENRICHER
+          value: paulinhu/kube-audit-log-enricher
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
         imagePullPolicy: Always
         name: security-profiles-operator
@@ -523,6 +555,7 @@ spec:
 ---
 apiVersion: v1
 data:
+  EnableLogEnricher: "false"
   EnableSelinux: "false"
 kind: ConfigMap
 metadata:

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -54,7 +54,8 @@ var ProfileRecordingOutputPath = filepath.Join(os.TempDir(), "security-profiles-
 
 // Controller configMap keys.
 const (
-	SPOcEnableSelinux = "EnableSelinux"
+	SPOcEnableSelinux     = "EnableSelinux"
+	SPOcEnableLogEnricher = "EnableLogEnricher"
 )
 
 // GetOperatorNamespace gets the namespace that the operator is currently running on.

--- a/internal/pkg/controllers/spod/configmap_controller.go
+++ b/internal/pkg/controllers/spod/configmap_controller.go
@@ -160,6 +160,17 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 			"--with-selinux=true")
 	}
 
+	enableLogEnricher, err := strconv.ParseBool(cfg.Data[config.SPOcEnableLogEnricher])
+	if err == nil && enableLogEnricher {
+		newSPOd.Spec.Template.Spec.Containers = append(
+			newSPOd.Spec.Template.Spec.Containers,
+			r.baseSPOd.Spec.Template.Spec.Containers[2])
+
+		// HostPID is only required for the log-enricher
+		// and is used to access cgroup files to map Process IDs to Pod IDs
+		newSPOd.Spec.Template.Spec.HostPID = true
+	}
+
 	for i := range templateSpec.Containers {
 		templateSpec.Containers[i].ImagePullPolicy = pullPolicy
 	}

--- a/internal/pkg/controllers/spod/setup.go
+++ b/internal/pkg/controllers/spod/setup.go
@@ -39,6 +39,7 @@ const cmIsSPOdConfig = "security-profiles-operator/config"
 type DaemonTunables struct {
 	NonRootEnablerImage string
 	SelinuxdImage       string
+	LogEnricherImage    string
 	WatchNamespace      string
 }
 
@@ -72,6 +73,9 @@ func getEffectiveSPOd(dt *DaemonTunables) *appsv1.DaemonSet {
 
 	selinuxd := &refSPOd.Spec.Template.Spec.Containers[1]
 	selinuxd.Image = dt.SelinuxdImage
+
+	logEnricher := &refSPOd.Spec.Template.Spec.Containers[2]
+	logEnricher.Image = dt.LogEnricherImage
 
 	initcnt := &refSPOd.Spec.Template.Spec.InitContainers[0]
 	initcnt.Image = dt.NonRootEnablerImage

--- a/internal/pkg/controllers/spod/setup_test.go
+++ b/internal/pkg/controllers/spod/setup_test.go
@@ -34,13 +34,13 @@ func Test_getEffectiveSPOd(t *testing.T) {
 	}{
 		{
 			"Should correctly set the image",
-			DaemonTunables{"foo:bar", "bar:baz", "brot:wurst"},
+			DaemonTunables{"foo:bar", "bar:baz", "brot:wurst", "fuss:ball"},
 			false,
 			false,
 		},
 		{
 			"Should correctly set the namespace",
-			DaemonTunables{"foo:bar", "bar:baz", "brot:wurst"},
+			DaemonTunables{"foo:bar", "bar:baz", "brot:wurst", "fuss:ball"},
 			true,
 			false,
 		},
@@ -51,6 +51,7 @@ func Test_getEffectiveSPOd(t *testing.T) {
 			t.Parallel()
 			got := getEffectiveSPOd(&tt.dt)
 			require.Equal(t, tt.dt.SelinuxdImage, got.Spec.Template.Spec.Containers[1].Image)
+			require.Equal(t, tt.dt.LogEnricherImage, got.Spec.Template.Spec.Containers[2].Image)
 			require.Equal(t, tt.dt.NonRootEnablerImage, got.Spec.Template.Spec.InitContainers[0].Image)
 			var found bool
 			for _, env := range got.Spec.Template.Spec.Containers[0].Env {


### PR DESCRIPTION
#### What type of PR is this?
/kind feature

#### What this PR does / why we need it:
Enriches seccomp audit logs with Kubernetes information (namespace, pod and container names), allowing SPO users to easily spot what workloads are missing specific syscalls on their profiles.

To illustrate its use, I removed a few syscalls from the operator's profile and this is what I got:
![image](https://user-images.githubusercontent.com/5452977/106530753-d42d6d00-64e4-11eb-807e-fd3e2b16aea3.png)


#### Which issue(s) this PR fixes:

Relates to #244 


#### Does this PR have test?
Not yet

#### Special notes for your reviewer:
- A new RBAC role was created to isolate log enrichment requirements as this may be split from the other components in a follow-up PR.
- The best approach I could find to map PID to Pods was using `HostPID` and reading the `cgroup` file. This approach is container runtime specific and currently only supports CRI-O.
- `HostPID` is only enabled when the log enricher is enabled
- Any suggestion for a better name to replace log enricher?

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add seccomp audit log enrichment feature
```
