### PR TITLE
Fix intermittent issue with E2E tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.15-alpine AS build
+FROM golang:1.15.7-alpine AS build
 WORKDIR /work
 RUN apk --no-cache add build-base git gcc libseccomp-dev libseccomp-static
 


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

The `libseccomp-static` package only exists from alpine `v3.13` onwards, but the initial `golang:1.15-alpine` tag used `v3.12` and later on updated to `v3.13`. The base image `golang:1.15.7-alpine` uses that alpine branch.

Here's my locally cached `golang:1.15-alpine` and the new image:
![image](https://user-images.githubusercontent.com/5452977/106520150-39c52d80-64d4-11eb-921d-cd1ede6757b0.png)

After removing `golang:1.15-alpine` locally and trying again the result is different:
![image](https://user-images.githubusercontent.com/5452977/106520428-b22bee80-64d4-11eb-9960-6aa385d67288.png)

Therefore it looks like when the e2e works successfuly is because it has a fresher version of the `golang:1.15-alpine` tag. 
Yet another reason to love mutable tags. :smile: 


#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A


#### Special notes for your reviewer:

![image](https://user-images.githubusercontent.com/5452977/106519952-fb2f7300-64d3-11eb-9c91-958a44b58793.png)
![image](https://user-images.githubusercontent.com/5452977/106519919-f1a60b00-64d3-11eb-9bac-a6fa8211fbbf.png)

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
