### PR TITLE
Automatically detect if 'podman' should be used.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ else
   LDFLAGS := -s -w -extldflags "-static" $(LDVARS)
 endif
 
-export CONTAINER_RUNTIME ?= docker
+export CONTAINER_RUNTIME ?= $(if $(shell which podman),podman,docker)
 
 ifeq ($(CONTAINER_RUNTIME), podman)
     LOGIN_PUSH_OPTS="--tls-verify=false"

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -72,6 +72,7 @@ type openShifte2e struct {
 func TestSuite(t *testing.T) {
 	t.Parallel()
 	fmt.Printf("cluster-type: %s\n", clusterType)
+	fmt.Printf("container-runtime: %s\n", containerRuntime)
 
 	switch {
 	case clusterType == "" || strings.EqualFold(clusterType, "kind"):


### PR DESCRIPTION
#### What type of PR is this?

<!--
Add one of the following kinds:
/kind cleanup

#### What this PR does / why we need it:

This makes it so that if podman is available on a running system, it'll
set the `CONTAINER_RUNTIME` variable appropraitely in the Makefile.

The podman binary is explicitly checked as the `podman` package
contains already a `docker` shim, so in both cases (docker or podman)
there will be a `docker` executable available. If the `podman` binary
isn't available, it falls back to docker as a default.

This just makes life a little easier if you're using podman (e.g. you no longer
need to always set the `CONTAINER_RUNTIME` variable.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```