### PR TITLE
Remove namespace from ClusterRoleBindings

### DIFF
--- a/deploy/base/rbac.yaml
+++ b/deploy/base/rbac.yaml
@@ -74,7 +74,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: config-map-reader-binding
-  namespace: security-profiles-operator
 subjects:
 - kind: ServiceAccount
   name: security-profiles-operator

--- a/deploy/base/webhook/rbac.yaml
+++ b/deploy/base/webhook/rbac.yaml
@@ -37,7 +37,6 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: profile-manager-binding
-  namespace: security-profiles-operator
 subjects:
 - kind: ServiceAccount
   name: security-profiles-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -376,7 +376,6 @@ metadata:
   labels:
     app: security-profiles-operator
   name: config-map-reader-binding
-  namespace: security-profiles-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/webhook.yaml
+++ b/deploy/webhook.yaml
@@ -209,7 +209,6 @@ metadata:
   labels:
     app: security-profiles-operator
   name: profile-manager-binding
-  namespace: security-profiles-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

`ClusterRoleBinding` are cluster-level objects, namespaces associated to it are ignored at creation time.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
