### PR TITLE
Expand on seccomp example profiles

### DIFF
--- a/examples/pod.yaml
+++ b/examples/pod.yaml
@@ -8,7 +8,7 @@ metadata:
     # Or one example within this directory
     # Please note the syntax:
     # `localhost/operator/{namespace}/{configmap-name}/{profile-name}`
-    # seccomp.security.alpha.kubernetes.io/pod: 'localhost/operator/default/example-profiles/profile-allow.json'
+    # seccomp.security.alpha.kubernetes.io/pod: 'localhost/operator/default/generic/profile-allow-unsafe.json'
 spec:
   containers:
   - name: test-container

--- a/examples/profilebinding.yaml
+++ b/examples/profilebinding.yaml
@@ -6,5 +6,5 @@ metadata:
 spec:
   profileRef:
     kind: SeccompProfile
-    name: profile-allow
+    name: profile-allow-unsafe
   image: nginx:1.19.1

--- a/examples/seccompprofile.yaml
+++ b/examples/seccompprofile.yaml
@@ -2,23 +2,101 @@
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
 kind: SeccompProfile
 metadata:
-  name: profile-block
+  name: profile-block-all
+  annotations:
+    description: "Blocks all syscalls."
 spec:
   defaultAction: "SCMP_ACT_ERRNO"
-  targetWorkload: "example-profiles"
+  targetWorkload: "generic"
 ---
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
 kind: SeccompProfile
 metadata:
-  name: profile-complain
+  name: profile-complain-unsafe
+  annotations:
+    description: "UNSAFE: Allows all syscalls whilst logging their use. Similar to running as unconfined in terms of enforcement."
 spec:
   defaultAction: "SCMP_ACT_LOG"
-  targetWorkload: "example-profiles"
+  targetWorkload: "generic"
 ---
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
 kind: SeccompProfile
 metadata:
-  name: profile-allow
+  name: profile-allow-unsafe
+  annotations:
+    description: "UNSAFE: Allows all syscalls. Similar to running as unconfined as it provides no enforcement."
 spec:
   defaultAction: "SCMP_ACT_ALLOW"
-  targetWorkload: "example-profiles"
+  targetWorkload: "generic"
+---
+apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+kind: SeccompProfile
+metadata:
+  name: profile-complain-block-high-risk
+  annotations:
+    description: "Enables complain mode whilst blocking high-risk syscalls. Some essential syscalls are allowed to decrease log noise."
+spec:
+  defaultAction: SCMP_ACT_LOG
+  targetWorkload: "generic"
+  architectures:
+  - SCMP_ARCH_X86_64
+  syscalls:
+  - action: SCMP_ACT_ALLOW
+    names:
+    - exit
+    - exit_group
+    - futex
+    - nanosleep
+
+  - action: SCMP_ACT_ERRNO
+    names:
+    - acct
+    - add_key
+    - bpf
+    - clock_adjtime
+    - clock_settime
+    - create_module
+    - delete_module
+    - finit_module
+    - get_kernel_syms
+    - get_mempolicy
+    - init_module
+    - ioperm
+    - iopl
+    - kcmp
+    - kexec_file_load
+    - kexec_load
+    - keyctl
+    - lookup_dcookie
+    - mbind
+    - mount
+    - move_pages
+    - name_to_handle_at
+    - nfsservctl
+    - open_by_handle_at
+    - perf_event_open
+    - personality
+    - pivot_root
+    - process_vm_readv
+    - process_vm_writev
+    - ptrace
+    - query_module
+    - quotactl
+    - reboot
+    - request_key
+    - set_mempolicy
+    - setns
+    - settimeofday
+    - stime
+    - swapoff
+    - swapon
+    - _sysctl
+    - sysfs
+    - umount2
+    - umount
+    - unshare
+    - uselib
+    - userfaultfd
+    - ustat
+    - vm86old
+    - vm86

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -177,7 +177,7 @@ name matches the binding:
 
 ```sh
 $ kubectl get pod test-pod -o jsonpath='{.spec.containers[*].securityContext.seccompProfile}'
-{"localhostProfile":"operator/default/example-profiles/profile-complain.json","type":"Localhost"}
+{"localhostProfile":"operator/default/generic/profile-complain-unsafe.json","type":"Localhost"}
 ```
 
 #### Record profiles from workloads with ProfileRecordings

--- a/test/tc_default_profiles_test.go
+++ b/test/tc_default_profiles_test.go
@@ -29,7 +29,7 @@ import (
 
 func (e *e2e) testCaseDefaultAndExampleProfiles(nodes []string) {
 	const exampleProfilePath = "examples/seccompprofile.yaml"
-	exampleProfileNames := [3]string{"profile-allow", "profile-complain", "profile-block"}
+	exampleProfileNames := [3]string{"profile-allow-unsafe", "profile-complain-unsafe", "profile-block-all"}
 	defaultProfileNames := [1]string{"nginx-1.19.1"}
 	e.kubectl("create", "-f", exampleProfilePath)
 	defer e.kubectl("delete", "-f", exampleProfilePath)

--- a/test/tc_profilebindings_test.go
+++ b/test/tc_profilebindings_test.go
@@ -33,7 +33,7 @@ metadata:
 spec:
   profileRef:
     kind: SeccompProfile
-    name: profile-allow
+    name: profile-allow-unsafe
   image: hello-world
 `
 	const testPod = `
@@ -103,7 +103,7 @@ spec:
 		"get", "pod", "hello",
 		"--output", "jsonpath={.spec.containers[0].securityContext.seccompProfile.localhostProfile}",
 	)
-	e.Equal(fmt.Sprintf("operator/%s/example-profiles/profile-allow.json", namespace), output)
+	e.Equal(fmt.Sprintf("operator/%s/generic/profile-allow-unsafe.json", namespace), output)
 
 	e.logf("Testing that profile binding has pod reference")
 	output = e.kubectl("get", "profilebinding", "hello-binding", "--output", "jsonpath={.status.activeWorkloads[0]}")
@@ -112,9 +112,13 @@ spec:
 	e.Equal("active-workload-lock", output)
 
 	e.logf("Testing that profile has pod reference")
-	output = e.kubectl("get", "seccompprofile", "profile-allow", "--output", "jsonpath={.status.activeWorkloads[0]}")
+	output = e.kubectl("get", "seccompprofile", "profile-allow-unsafe",
+		"--output", "jsonpath={.status.activeWorkloads[0]}")
+
 	e.Equal(fmt.Sprintf("%s/hello", namespace), output)
-	output = e.kubectl("get", "seccompprofile", "profile-allow", "--output", "jsonpath={.metadata.finalizers}")
+	output = e.kubectl("get", "seccompprofile", "profile-allow-unsafe",
+		"--output", "jsonpath={.metadata.finalizers}")
+
 	e.Contains(output, "in-use-by-active-pods")
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

- Create a seccomp profile that is safer for production workloads. It is slightly more restrictive than the docker default and also auto allows essential calls to reduce log noise. This can also be used as template for users to test their seccomp profiles in production before setting in the enforcer mode.
- Change `targetWorkload` from seccomp profile examples to `generic`. A point of discussion here would be to ship them in by default in the future.
- Add description to each profile to clarify their meaning and highlight unsafe profiles.

#### Which issue(s) this PR fixes:

None


#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Add complain-mode seccomp profile that is safer to run in production workloads
```
