### PR TITLE
Revert fixes to dockerignore file

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,11 +2,9 @@
 *
 
 # Allow files and directories
-!/.git
 !/go.mod
 !/go.sum
 !/Makefile
-!/VERSION
 !/tools.go
 !/api/**
 !/cmd/**

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,12 +1,1 @@
-# Ignore everything
-*
-
-# Allow files and directories
-!/go.mod
-!/go.sum
-!/Makefile
-!/tools.go
-!/api/**
-!/cmd/**
-!/internal/**
-!/vendor/** 
+build


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fix the UBI container build.

The changes that happened in the dockerignore files break the UBI build with
podman. It was ignoring the Makefile and was unable to build.

#### Does this PR have test?

N/A.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```