### PR TITLE
Remove nodeSelector from deployment and webhook

### DIFF
--- a/deploy/base/operator.yaml
+++ b/deploy/base/operator.yaml
@@ -33,8 +33,6 @@ spec:
               value: non-root-enabler
             - name: RELATED_IMAGE_SELINUXD
               value: quay.io/jaosorior/selinuxd
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       tolerations:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"

--- a/deploy/base/webhook/deployment.yaml
+++ b/deploy/base/webhook/deployment.yaml
@@ -39,8 +39,6 @@ spec:
         secret:
           defaultMode: 420
           secretName: webhook-server-cert
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       tolerations:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -514,8 +514,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       serviceAccountName: security-profiles-operator
       tolerations:
       - effect: NoSchedule

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -511,8 +511,6 @@ spec:
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       serviceAccountName: security-profiles-operator
       tolerations:
       - effect: NoSchedule

--- a/deploy/webhook.yaml
+++ b/deploy/webhook.yaml
@@ -289,8 +289,6 @@ spec:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert
           readOnly: true
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
       serviceAccountName: security-profiles-operator
       tolerations:
       - effect: NoSchedule


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
The `nodeSelector` value `node-role.kubernetes.io/master` seems to be
only set by nodes which are created via kubeadm (and others). If the
node does not have the label at all, then the operator will not be
scheduled there. This can be reproduced by the usage of the
`hack/local-up-cluster.sh` script within k/k.

I think we should be safe removing the selector since we already have
the tolerations in place.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
