### PR TITLE
Reuse deployment image to daemon set

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -49,7 +49,6 @@ import (
 const (
 	jsonFlag               string = "json"
 	selinuxFlag            string = "with-selinux"
-	operatorImageKey       string = "RELATED_IMAGE_OPERATOR"
 	nonRootEnablerImageKey string = "RELATED_IMAGE_NON_ROOT_ENABLER"
 	selinuxdImageKey       string = "RELATED_IMAGE_SELINUXD"
 	defaultWebhookPort     int    = 9443
@@ -210,12 +209,6 @@ func runManager(ctx *cli.Context) error {
 
 func getTunables() (dt spod.DaemonTunables, err error) {
 	dt.WatchNamespace = os.Getenv(config.RestrictNamespaceEnvKey)
-
-	operatorImage := os.Getenv(operatorImageKey)
-	if operatorImage == "" {
-		return dt, errors.New("invalid operator image")
-	}
-	dt.DaemonImage = operatorImage
 
 	nonRootEnableImage := os.Getenv(nonRootEnablerImageKey)
 	if nonRootEnableImage == "" {

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -23,8 +23,6 @@ patchesStrategicMerge:
         containers:
           - name: security-profiles-operator
             env:
-              - name: RELATED_IMAGE_OPERATOR
-                value: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
               - name: RELATED_IMAGE_NON_ROOT_ENABLER
                 value: bash:5.0
               - name: RELATED_IMAGE_SELINUXD

--- a/deploy/base/operator.yaml
+++ b/deploy/base/operator.yaml
@@ -27,8 +27,6 @@ spec:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
           env:
-            - name: RELATED_IMAGE_OPERATOR
-              value: security-profiles-operator
             - name: RELATED_IMAGE_NON_ROOT_ENABLER
               value: non-root-enabler
             - name: RELATED_IMAGE_SELINUXD

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -502,8 +502,6 @@ spec:
         env:
         - name: RESTRICT_TO_NAMESPACE
           value: NS_REPLACE
-        - name: RELATED_IMAGE_OPERATOR
-          value: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
         - name: RELATED_IMAGE_NON_ROOT_ENABLER
           value: bash:5.0
         - name: RELATED_IMAGE_SELINUXD

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -499,8 +499,6 @@ spec:
       - args:
         - manager
         env:
-        - name: RELATED_IMAGE_OPERATOR
-          value: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
         - name: RELATED_IMAGE_NON_ROOT_ENABLER
           value: bash:5.0
         - name: RELATED_IMAGE_SELINUXD

--- a/deploy/overlays/openshift-dev/kustomization.yaml
+++ b/deploy/overlays/openshift-dev/kustomization.yaml
@@ -22,19 +22,3 @@ images:
   - name: gcr.io/k8s-staging-sp-operator/security-profiles-operator
     newName: image-registry.openshift-image-registry.svc:5000/openshift/security-profiles-operator
     newTag: latest
-
-patchesStrategicMerge:
-- |-
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: security-profiles-operator
-    namespace: security-profiles-operator
-  spec:
-    template:
-      spec:
-        containers:
-          - name: security-profiles-operator
-            env:
-              - name: RELATED_IMAGE_OPERATOR
-                value: image-registry.openshift-image-registry.svc:5000/openshift/security-profiles-operator:latest

--- a/internal/pkg/controllers/spod/setup.go
+++ b/internal/pkg/controllers/spod/setup.go
@@ -37,7 +37,6 @@ const cmIsSPOdConfig = "security-profiles-operator/config"
 // SPOdTunables defines the parameters to tune/modify for the
 // Security-Profiles-Operator-Daemon.
 type DaemonTunables struct {
-	DaemonImage         string
 	NonRootEnablerImage string
 	SelinuxdImage       string
 	WatchNamespace      string
@@ -63,7 +62,6 @@ func getEffectiveSPOd(dt *DaemonTunables) *appsv1.DaemonSet {
 	refSPOd := bindata.Manifest.DeepCopy()
 
 	daemon := &refSPOd.Spec.Template.Spec.Containers[0]
-	daemon.Image = dt.DaemonImage
 	if dt.WatchNamespace != "" {
 		daemon.Env = append(daemon.Env, corev1.EnvVar{
 			Name:  config.RestrictNamespaceEnvKey,

--- a/internal/pkg/controllers/spod/setup_test.go
+++ b/internal/pkg/controllers/spod/setup_test.go
@@ -34,13 +34,13 @@ func Test_getEffectiveSPOd(t *testing.T) {
 	}{
 		{
 			"Should correctly set the image",
-			DaemonTunables{"foo:bar", "bar:baz", "brot:wurst", ""},
+			DaemonTunables{"foo:bar", "bar:baz", "brot:wurst"},
 			false,
 			false,
 		},
 		{
 			"Should correctly set the namespace",
-			DaemonTunables{"foo:bar", "bar:baz", "brot:wurst", "my-ns"},
+			DaemonTunables{"foo:bar", "bar:baz", "brot:wurst"},
 			true,
 			false,
 		},
@@ -50,7 +50,6 @@ func Test_getEffectiveSPOd(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := getEffectiveSPOd(&tt.dt)
-			require.Equal(t, tt.dt.DaemonImage, got.Spec.Template.Spec.Containers[0].Image)
 			require.Equal(t, tt.dt.SelinuxdImage, got.Spec.Template.Spec.Containers[1].Image)
 			require.Equal(t, tt.dt.NonRootEnablerImage, got.Spec.Template.Spec.InitContainers[0].Image)
 			var found bool


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We can retrieve the currently running image with the help of an
additional client get request. This allows us to get rid of an
additional environment variable for the daemonset container image.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
