### PR TITLE
Reuse manager imagePullPolicy for all other workloads

### DIFF
--- a/deploy/base/config.yaml
+++ b/deploy/base/config.yaml
@@ -7,5 +7,4 @@ metadata:
   labels:
     security-profiles-operator/config: ""
 data:
-  SPOdImagePullPolicy: Always
   EnableSelinux: "false"

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -527,7 +527,6 @@ spec:
 apiVersion: v1
 data:
   EnableSelinux: "false"
-  SPOdImagePullPolicy: Always
 kind: ConfigMap
 metadata:
   labels:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -524,7 +524,6 @@ spec:
 apiVersion: v1
 data:
   EnableSelinux: "false"
-  SPOdImagePullPolicy: Always
 kind: ConfigMap
 metadata:
   labels:

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -57,11 +57,6 @@ const (
 	SPOcEnableSelinux = "EnableSelinux"
 )
 
-// DaemonSet configMap keys.
-const (
-	SPOdImagePullPolicy = "SPOdImagePullPolicy"
-)
-
 // GetOperatorNamespace gets the namespace that the operator is currently running on.
 func GetOperatorNamespace() string {
 	// TODO(jaosorior): Get a method to return the current operator

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -133,10 +133,6 @@ func (e *e2e) deployOperator(manifest string) {
 		fmt.Sprintf("s;imagePullPolicy: Always;imagePullPolicy: %s;g", e.pullPolicy),
 		manifest,
 	)
-	e.run(
-		"sed", "-i", fmt.Sprintf("s;SPOdImagePullPolicy: Always;SPOdImagePullPolicy: %s;g", e.pullPolicy),
-		manifest,
-	)
 
 	// Update the image name to match the test image
 	e.run(


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
We now reuse the provided pull policy from the manager for all other
created workloads. This simplifies the configuration overhead and
deployment complexity.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
