### PR TITLE
Print pod selector on wide profilerecording output

### DIFF
--- a/api/profilerecording/v1alpha1/profilerecording_types.go
+++ b/api/profilerecording/v1alpha1/profilerecording_types.go
@@ -41,6 +41,7 @@ type ProfileRecordingStatus struct {
 
 // ProfileRecording is the Schema for the profilerecordings API.
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="PodSelector",type=string,priority=10,JSONPath=`.spec.podSelector`
 type ProfileRecording struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/deploy/base/webhook/crd-recording.yaml
+++ b/deploy/base/webhook/crd-recording.yaml
@@ -16,7 +16,12 @@ spec:
     singular: profilerecording
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.podSelector
+      name: PodSelector
+      priority: 10
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ProfileRecording is the Schema for the profilerecordings API.

--- a/deploy/webhook.yaml
+++ b/deploy/webhook.yaml
@@ -92,7 +92,12 @@ spec:
     singular: profilerecording
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .spec.podSelector
+      name: PodSelector
+      priority: 10
+      type: string
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: ProfileRecording is the Schema for the profilerecordings API.

--- a/internal/pkg/controllers/spod/setup.go
+++ b/internal/pkg/controllers/spod/setup.go
@@ -34,7 +34,7 @@ import (
 // TODO(jaosorior): Use better method than a label constant.
 const cmIsSPOdConfig = "security-profiles-operator/config"
 
-// SPOdTunables defines the parameters to tune/modify for the
+// DaemonTunables defines the parameters to tune/modify for the
 // Security-Profiles-Operator-Daemon.
 type DaemonTunables struct {
 	NonRootEnablerImage string

--- a/profiles
+++ b/profiles
@@ -1,1 +1,0 @@
-deploy/base/profiles


### PR DESCRIPTION

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
This way we're able to print the pod selector on wide kubectl output
like this:

```
> kubectl get profilerecording -o wide
NAME             PODSELECTOR
test-recording   {"matchLabels":{"app":"alpine"}}
```

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
