### PR TITLE
Run as user nobody

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,18 +16,6 @@ FROM golang:1.15.7-alpine AS build
 WORKDIR /work
 RUN apk --no-cache add build-base git gcc libseccomp-dev libseccomp-static
 
-ENV USER=secuser
-ENV UID=2000
-# See https://stackoverflow.com/a/55757473/12429735
-RUN adduser \
-    --disabled-password \
-    --gecos "" \
-    --home "/nonexistent" \
-    --shell "/sbin/nologin" \
-    --no-create-home \
-    --uid "${UID}" \
-    "${USER}"
-
 COPY . /work
 
 FROM build as make
@@ -41,8 +29,8 @@ LABEL name="Security Profiles Operator" \
       description="The Security Profiles Operator makes it easier for cluster admins to manage their seccomp or AppArmor profiles and apply them to Kubernetes' workloads."
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=build /etc/passwd /etc/passwd
-COPY --from=build /etc/group /etc/group
 COPY --from=make /work/build/security-profiles-operator /
+
+USER 65535:65535
 
 ENTRYPOINT ["/security-profiles-operator"]

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -33,19 +33,8 @@ LABEL name="Security Profiles Operator" \
 
 RUN microdnf install -y shadow-utils
 
-ENV USER=secuser
-ENV UID=2000
-# See https://stackoverflow.com/a/55757473/12429735
-RUN adduser \
-    -c "" \
-    --home "/nonexistent" \
-    --shell "/sbin/nologin" \
-    --no-create-home \
-    --uid "${UID}" \
-    "${USER}"
-
 COPY --from=build /work/build/security-profiles-operator /usr/bin/
 
 ENTRYPOINT ["/usr/bin/security-profiles-operator"]
 
-USER ${UID}
+USER 65535:65535

--- a/internal/pkg/controllers/spod/bindata/spod.go
+++ b/internal/pkg/controllers/spod/bindata/spod.go
@@ -29,7 +29,7 @@ var (
 	falsely                         = false
 	truly                           = true
 	userRoot                  int64 = 0
-	userRootless              int64 = 2000
+	userRootless              int64 = 65535
 	hostCharDev                     = v1.HostPathCharDev
 	hostPathDirectory               = v1.HostPathDirectory
 	hostPathDirectoryOrCreate       = v1.HostPathDirectoryOrCreate
@@ -69,7 +69,7 @@ var Manifest = &appsv1.DaemonSet{
 					{
 						Name: "non-root-enabler",
 						// Creates directory /var/lib/security-profiles-operator,
-						// sets 2000:2000 as its owner and symlink it to
+						// sets 65535:65535 as its owner and symlink it to
 						// /var/lib/kubelet/seccomp/operator. This is required
 						// to allow the main container to run as non-root.
 						Command: []string{"bash", "-c"},
@@ -87,7 +87,7 @@ var Manifest = &appsv1.DaemonSet{
 							/bin/ln -s ` + operatorRoot + ` ` + config.ProfilesRootPath + `
 						fi
 
-						/bin/chown -R 2000:2000 ` + operatorRoot + `
+						/bin/chown -R 65535:65535 ` + operatorRoot + `
 						cp -f -v /opt/seccomp-profiles/* ` + config.KubeletSeccompRootPath + `
 					`},
 						VolumeMounts: []v1.VolumeMount{
@@ -132,11 +132,11 @@ var Manifest = &appsv1.DaemonSet{
 						Image: "quay.io/jaosorior/selinuxd",
 						// Primes the volume mount under /etc/selinux.d with the
 						// shared policies shipped by selinuxd and makes sure the volume mount
-						// is writable by 2000 in order for the controller to be able to
+						// is writable by 65535 in order for the controller to be able to
 						// write the policy files. In the future, the policy files should
 						// be shipped by selinuxd directly.
 						//
-						// The directory is writable by 2000 (the operator writes to this dir) and
+						// The directory is writable by 65535 (the operator writes to this dir) and
 						// readable by root (selinuxd reads the policies and runs as root).
 						// Explicitly allowing root makes sure no dac_override audit messages
 						// are logged even in absence of CAP_DAC_OVERRIDE.
@@ -148,7 +148,7 @@ var Manifest = &appsv1.DaemonSet{
 						Args: []string{`
 						set -x
 
-						chown 2000:0 /etc/selinux.d
+						chown 65535:0 /etc/selinux.d
 						chmod 750 /etc/selinux.d
 						cp /usr/share/udica/templates/* /etc/selinux.d
 					`},
@@ -251,7 +251,7 @@ var Manifest = &appsv1.DaemonSet{
 							"daemon",
 							"--socket-path", SelinuxdSocketPath,
 							"--socket-uid", "0",
-							"--socket-gid", "2000",
+							"--socket-gid", "65535",
 						},
 						ImagePullPolicy: v1.PullAlways,
 						VolumeMounts: []v1.VolumeMount{

--- a/test/tc_default_profiles_test.go
+++ b/test/tc_default_profiles_test.go
@@ -41,7 +41,7 @@ func (e *e2e) testCaseDefaultAndExampleProfiles(nodes []string) {
 		statOutput := e.execNode(
 			node, "stat", "-L", "-c", `%a,%u,%g`, config.ProfilesRootPath,
 		)
-		e.Contains(statOutput, "744,2000,2000")
+		e.Contains(statOutput, "744,65535,65535")
 
 		// security-profiles-operator.json init verification
 		cm := e.getConfigMap(


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Run container as `65534` (generally the default id for `nobody`), removing the need of creating a new user.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
