### PR TITLE
Add personas and user story documents

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -9,3 +9,17 @@ labels: kind/feature
 #### What would you like to be added:
 
 #### Why is this needed:
+
+#### User story covered
+
+<!-- Please add a reference to the user story that this feature would cover
+
+The existing user stories exist in docs/user-stores.md
+
+If the user story doesn't exist yet, please add it to the main document
+to help people understand what the feature is trying to solve and how it's
+meant to help the target personas.
+
+If this would help a target persona that's not currently listed, please add it
+to the document in docs/personas.md
+ -->

--- a/README.md
+++ b/README.md
@@ -36,6 +36,16 @@ the Kubernetes world:
 [5]: https://github.com/openshift/machine-config-operator/tree/master/docs
 [6]: https://github.com/UKHomeOffice/seccomp-config
 
+## Personas & User Stories
+
+As any other piece of software, this operator is meant to help people. Thus,
+the target personas have been reflected in [a document in this repo](doc/personas.md).
+
+The functionality that this operator is meant to enable is captured
+[as user stories](doc/user-stories.md). If you feel that a user story is not captured
+properly, feel free to submit a Pull Request. The team will be more than happy
+to review and help you reflect the requirement.
+
 ## Roadmap
 
 The project tries to not overlap with those existing implementations to provide

--- a/doc/personas.md
+++ b/doc/personas.md
@@ -1,0 +1,63 @@
+# Personas
+
+These personas are the potential users of the security-profiles-operator.
+The intent of the operator is to address the needs of these personas, and so,
+user stories and feature enhancements shall be targetted at helping them.
+
+## Infrastructure SRE  (infra/host)
+
+**_Kirsti_**
+
+Responsible for Day 1 and Day 2 operations for the infrastructure:
+
+* This includes security operations
+
+* Has a more technical dashboard view of the state of security
+
+* Wants compartmentalization verification
+
+  - Namespaces, Seccomp, and SELinux technical reports
+
+## Application SRE  (tenant/workload)
+
+**_Rajesh_**
+
+Responsible for:
+
+* Application deployment, maintenance, and monitoring.
+
+Interacts with:
+
+* Application developer for...
+
+* Infra SRE for... 
+
+Desires:
+
+* No security events/breaches related to managed applications.
+
+* Easy way to ensure the applications they are responsible for are configured securely.
+
+## Application Developer
+
+**_Ming_**
+
+Responsible for:
+
+* Development of new container-native applications.
+
+* Modernizing legacy applications to be moved from bare-metal or virtualized environments to container platforms.
+
+* Developing applications that meet the security requirement.
+
+Interacts with:
+
+* Application SRE to support application deployment, maintenance, and development of new functionality.
+
+* PM, Compliance Officer, or someone else to understand security requirements imposed on their application(s) for the target deployment environment(s).
+
+Desires:
+
+* Easily meet security requirements that are built into the development process without requiring expertise in security components.
+
+* Development environments that mimic production from a security perspective to avoid surprises when applications are deployed into production.

--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -1,0 +1,109 @@
+# User Stories
+
+These user stories are the scenarios that the security-profiles-operator enables
+to cover the needs of [target personas](personas.md).
+
+The intent of this document is to present the features the operator should enable
+in a humanized manner that shows how this software helps people do their jobs.
+
+### As an application SRE, Rajesh would like to deploy a Seccomp profile and an SELinux or AppArmor profiles to secure their application.
+
+Details:
+
+* This would also apply to Ming, as an application developer would be deploying to a development environment.
+
+### As an application developer, Ming would like to be able to debug and develop their security profiles using similar tools as would be used to deploy the app in production.
+
+Details:
+
+* Ming needs to be able to try out different profiles and get appropriate error
+  messages if the profile is badly formatted. Where possible, invalid profiles
+  should be rejected with user-friendly validation error messages and not applied
+  to the system.
+
+### As an application developer, Ming would like to be able to debug syntax errors in a given profile.
+
+Details:
+
+* The operator should be able to clearly point out syntax errors that might appear
+in a certain profile. E.g. for SELinux a missing parenthesis or something of the
+sort… This is considered for SELinux in
+[an issue](https://github.com/kubernetes-sigs/security-profiles-operator/issues/223)
+
+### As an application SRE, Rajesh needs to be able to see the state of the installed profile(s) and verify that it has indeed been installed on the system.
+
+### As an application SRE, Rajesh needs to be able to do long runs of a security profile in “complain-mode” to easily identify the impact of a profile being enforced without impacting the application.
+
+Details:
+
+* In Seccomp, profiles can be affected by the underlying system and therefore
+  a profile that worked in an environment may break on another. Having the
+  ability to securely use a profile in a secure “complain-mode” may decrease
+  the risk of breaking production workloads.
+
+* The same complain mode can be used for AppArmor.
+
+### As an application SRE, Rajesh needs to easily be able to link a security profile to a pod or set of pods.
+
+Details:
+
+* Automatically link and apply profiles to Public workloads (kubernetes dashboard,
+  nginx, etc) based on target image
+
+### As an infrastructure SRE, Kirsti wants to make sure that no security profiles are in an errored state
+
+Open questions:
+
+* Should we start issuing metrics on errored policies?
+
+### As an application SRE, Rajesh needs to make sure that when rolling out a new version of the app, a new version of the security profile is taken into use by the app (and not the old one).
+
+Details:
+
+* Conversely, for rollbacks, we need to make sure that the old profile is taken
+  into use again
+
+Open questions:
+
+* Does this actually work? We should have a test
+
+### As an infrastructure SRE, Kirsti wants to make sure that common profiles are available to all users, so folks can deploy applications securely.
+
+Details:
+
+* Web-servers are a very common type of application, so we should enable folks to
+  use profiles specialized for this so that all pods using web server images can
+  make use of the common policy
+
+### As an infrastructure SRE, Kirsti wants to make sure that pods are running with the profiles that were set to them.
+
+Details:
+
+* In SELinux, is the pod using the type from the policy, or is it using `spc_t`?
+
+Open questions:
+
+* Same policy in terms of name or content?
+
+* What if the target node does not support the profile type (apparmor, selinux)?
+
+### As an infrastructure SRE, Kirsti wants to make sure that only pods on a certain namespace, can use certain less restrictive profiles.
+
+Details:
+
+* E.g. there is an SELinux policy that gives the pod access to the nodes' logs, and
+  so it should only be usable in an approved namespace where a log
+  forwarding application is deployed.
+
+Open Questions:
+
+* What’s the overlap with PodSecurityPolicy’s?
+
+* Integration with OPA/Gatekeeper?
+
+* Does this only impact Profiles created through SPO (i.e. can a user just use `runtime/default`)?
+
+Terminology
+===========
+
+**Security profile**: A Seccomp profile, SELinux profile, or AppArmor profile.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

This adds persona definitions and user stories for the operator.
These came from our original discussion in a document [1], and are meant
to represent the actual people that this operator would help (the
personas) and the ways that the operator would help these people (as
user stories).

Thus, for future features added to this operator, they should be aimed
at helping one of the personas listed, or at improving or addressing one
of the user stories listed. New personas and user stories can be added,
and doing so will help clarify new functionality proposed to the
operator.

A section to the GitHub templates has been added to include references
to the user stories and personas.

[1] https://docs.google.com/document/d/1x0kS1Mzxcw0k3aq_27QK0OBHSea6apD-WMVwURYZsU4/edit?usp=sharing

#### Does this PR have test?

N/A.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

Co-Authored-By: @pjbgf 
Co-Authored-By: @saschagrunert 
Co-Authored-By: @cmurphy 
Co-Authored-By: @jhrozek