### PR TITLE
e2e: Enable SELinux through an environment variable

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -144,7 +144,7 @@ func (e *e2e) deployOperator(manifest string) {
 		manifest,
 	)
 
-	if e.platformSupportsSelinux() {
+	if e.selinuxEnabled {
 		e.run(
 			"sed", "-i", "s/EnableSelinux: \"false\"/EnableSelinux: \"true\"/",
 			manifest,


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This changes the enabling/disabling of the SELinux features in the e2e
tests from being set based on the platform, to being set from an
environment variable.

With the new e2e test being added (which uses vanilla kube), we can't rely on
the kube distro for enabling/disable SELinux. Let's do it instead from an env
variable, this way it's easy for folks to set that up or turn it off when
needed.

Note that the feature is still off by default and can be enabled through the
`E2E_ENABLE_SELINUX` environment variable

#### Does this PR introduce a user-facing change?

```release-note
NONE
```