### PR TITLE
Add operator deployment to GH actions e2e test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,5 +17,6 @@ jobs:
           ln -sf hack/ci/Vagrantfile .
           vagrant up
       - name: Show environment information
-        run: |
-          $RUN kubectl get nodes -o wide
+        run: $RUN kubectl get nodes -o wide
+      - name: Deploy the operator
+        run: $RUN hack/ci/deploy-operator.sh

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -24,7 +24,7 @@ patchesStrategicMerge:
           - name: security-profiles-operator
             env:
               - name: RELATED_IMAGE_NON_ROOT_ENABLER
-                value: bash:5.0
+                value: docker.io/bash:5.0
               - name: RELATED_IMAGE_SELINUXD
                 value: quay.io/jaosorior/selinuxd
 

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -533,7 +533,7 @@ spec:
         - name: RESTRICT_TO_NAMESPACE
           value: NS_REPLACE
         - name: RELATED_IMAGE_NON_ROOT_ENABLER
-          value: bash:5.0
+          value: docker.io/bash:5.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/jaosorior/selinuxd
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -530,7 +530,7 @@ spec:
         - manager
         env:
         - name: RELATED_IMAGE_NON_ROOT_ENABLER
-          value: bash:5.0
+          value: docker.io/bash:5.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/jaosorior/selinuxd
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest

--- a/hack/ci/Vagrantfile
+++ b/hack/ci/Vagrantfile
@@ -27,7 +27,9 @@ Vagrant.configure("2") do |config|
         golang-go \
         iptables \
         make \
-        openssl
+        oci-seccomp-bpf-hook \
+        openssl \
+        podman
     SHELL
   end
 

--- a/hack/ci/deploy-operator.sh
+++ b/hack/ci/deploy-operator.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+echo Building the container image
+make image
+
+echo Preparing the deployment
+sed -i 's;gcr.io/k8s-staging-sp-operator;localhost;g' \
+    deploy/operator.yaml deploy/webhook.yaml
+
+sed -i 's;imagePullPolicy: Always;imagePullPolicy: Never;g' \
+    deploy/operator.yaml deploy/webhook.yaml
+
+echo Deploying the operator and its dependencies
+
+echo Deploying cert-manager
+CERTMGR=https://github.com/jetstack/cert-manager/releases/download/v1.1.0/cert-manager.yaml
+kubectl create -f $CERTMGR
+kubectl -n cert-manager wait --for condition=ready pod --all
+
+echo Deploying operator
+kubectl create -f deploy/operator.yaml
+
+kubectl -n security-profiles-operator wait \
+    --for condition=available deployment \
+    -l app=security-profiles-operator
+
+kubectl -n security-profiles-operator wait \
+    --for condition=ready pod -l app=security-profiles-operator
+
+sleep 5
+kubectl -n security-profiles-operator wait \
+    --for condition=ready pod -l app=spod
+
+echo Deploying operator webhook
+kubectl create -f deploy/webhook.yaml
+
+kubectl -n security-profiles-operator wait \
+    --for condition=ready pod --all

--- a/hack/ci/run.sh
+++ b/hack/ci/run.sh
@@ -15,4 +15,4 @@
 
 set -euo pipefail
 
-exec vagrant ssh -- sudo "bash -c '. /vagrant/hack/ci/env.sh && $*'"
+exec vagrant ssh -- sudo "bash -c 'cd /vagrant && . hack/ci/env.sh && $*'"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
The oci hook works out of the box by the provided package. One thing we
have to consider is building the image locally as well as deploying the
operator based on that one. This is now going to be achieved with this
patch.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
