### PR TITLE
Run e2e test in vagrant-based GH action e2e test

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: macos-10.15
-    timeout-minutes: 30
+    timeout-minutes: 40
     env:
       RUN: ./hack/ci/run.sh
     steps:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -17,5 +17,6 @@ jobs:
           ln -sf hack/ci/Vagrantfile .
           vagrant up
       - name: Show environment information
-        run: |
-          $RUN kubectl get nodes -o wide
+        run: $RUN kubectl get nodes -o wide
+      - name: Run E2E tests
+        run: $RUN hack/ci/e2e.sh

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -24,7 +24,7 @@ patchesStrategicMerge:
           - name: security-profiles-operator
             env:
               - name: RELATED_IMAGE_NON_ROOT_ENABLER
-                value: bash:5.0
+                value: docker.io/bash:5.0
               - name: RELATED_IMAGE_SELINUXD
                 value: quay.io/jaosorior/selinuxd
 

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -533,7 +533,7 @@ spec:
         - name: RESTRICT_TO_NAMESPACE
           value: NS_REPLACE
         - name: RELATED_IMAGE_NON_ROOT_ENABLER
-          value: bash:5.0
+          value: docker.io/bash:5.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/jaosorior/selinuxd
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -530,7 +530,7 @@ spec:
         - manager
         env:
         - name: RELATED_IMAGE_NON_ROOT_ENABLER
-          value: bash:5.0
+          value: docker.io/bash:5.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/jaosorior/selinuxd
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest

--- a/hack/ci/Vagrantfile
+++ b/hack/ci/Vagrantfile
@@ -27,7 +27,9 @@ Vagrant.configure("2") do |config|
         golang-go \
         iptables \
         make \
-        openssl
+        oci-seccomp-bpf-hook \
+        openssl \
+        podman
     SHELL
   end
 

--- a/hack/ci/Vagrantfile
+++ b/hack/ci/Vagrantfile
@@ -4,7 +4,7 @@
 # Vagrant box for testing
 Vagrant.configure("2") do |config|
   config.vm.box = "fedora/33-cloud-base"
-  memory = 4096
+  memory = 6144
   cpus = 4
 
   config.vm.provider :virtualbox do |v|

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -15,4 +15,7 @@
 
 set -euo pipefail
 
-exec vagrant ssh -- sudo "bash -c 'cd /vagrant && . hack/ci/env.sh && $*'"
+export E2E_CLUSTER_TYPE=vanilla
+#export E2E_ENABLE_SELINUX=true
+
+make test-e2e

--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -16,6 +16,11 @@
 set -euo pipefail
 
 export E2E_CLUSTER_TYPE=vanilla
-#export E2E_ENABLE_SELINUX=true
+#export E2E_TEST_SELINUX=true
+
+# These are already tested in the standard e2e test.
+# No need to test them here.
+export E2E_TEST_SECCOMP=false
+export E2E_TEST_PROFILE_BINDING=false
 
 make test-e2e

--- a/hack/ci/install-cri-o.sh
+++ b/hack/ci/install-cri-o.sh
@@ -47,14 +47,6 @@ chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
 
 mkdir -p /etc/crio/crio.conf.d
 
-cat <<EOT >>/etc/crio/crio.conf.d/20-crun.conf
-[crio.runtime]
-default_runtime = "crun"
-
-[crio.runtime.runtimes.crun]
-runtime_path = "/usr/local/bin/crun"
-EOT
-
 cat <<EOT >>/etc/crio/crio.conf.d/30-cgroup-manager.conf
 [crio.runtime]
 conmon_cgroup = "pod"

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -159,12 +159,12 @@ func (e *e2e) deployOperator(manifest string) {
 	// Wait for the operator to be ready
 	e.logf("Waiting for operator to be ready")
 	// Wait for deployment
-	e.kubectlOperatorNS("wait", "--for", "condition=available", "deployment", "-l", "app=security-profiles-operator")
+	e.waitInOperatorNSFor("condition=available", "deployment", "-l", "app=security-profiles-operator")
 	// Wait for all pods in deployment
-	e.kubectlOperatorNS("wait", "--for", "condition=ready", "pod", "-l", "app=security-profiles-operator")
+	e.waitInOperatorNSFor("condition=ready", "pod", "-l", "app=security-profiles-operator")
 	// Wait for all pods in DaemonSet
 	time.Sleep(defaultWaitTime)
-	e.kubectlOperatorNS("wait", "--for", "condition=ready", "pod", "-l", "app=spod")
+	e.waitInOperatorNSFor("condition=ready", "pod", "-l", "app=spod")
 }
 
 func (e *e2e) cleanupOperator(manifest string) {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -37,6 +37,7 @@ const (
 	// migrate to a single daemonset-based implementation for the
 	// SELinux pieces.
 	defaultSelinuxOpTimeout = "360s"
+	defaultWaitTimeout      = "60s"
 	defaultWaitTime         = 5 * time.Second
 )
 

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -243,7 +243,7 @@ func (e *openShifte2e) SetupSuite() {
 	e.logf("Using deployed OpenShift cluster")
 
 	e.logf("Waiting for cluster to be ready")
-	e.kubectl("wait", "--for", "condition=ready", "nodes", "--all")
+	e.waitFor("condition=ready", "nodes", "--all")
 
 	if !e.skipPushImages {
 		e.logf("pushing SPO image to openshift registry")
@@ -392,6 +392,18 @@ func (e *e2e) kubectlFailure(args ...string) string {
 func (e *e2e) kubectlOperatorNS(args ...string) {
 	e.kubectl(
 		append([]string{"-n", config.OperatorName}, args...)...,
+	)
+}
+
+func (e *e2e) waitFor(args ...string) {
+	e.kubectl(
+		append([]string{"wait", "--timeout", defaultWaitTimeout, "--for"}, args...)...,
+	)
+}
+
+func (e *e2e) waitInOperatorNSFor(args ...string) {
+	e.kubectlOperatorNS(
+		append([]string{"wait", "--timeout", defaultWaitTimeout, "--for"}, args...)...,
 	)
 }
 

--- a/test/tc_base_profiles_test.go
+++ b/test/tc_base_profiles_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func (e *e2e) testCaseBaseProfile([]string) {
+	e.seccompOnlyTestCase()
 	const baseProfilePath = "examples/baseprofile.yaml"
 	const helloProfile = `
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/test/tc_base_profiles_test.go
+++ b/test/tc_base_profiles_test.go
@@ -85,7 +85,7 @@ spec:
 	defer e.kubectl("delete", "pod", "hello")
 
 	e.logf("Waiting for test pod to be initialized")
-	e.kubectl("wait", "--for", "condition=initialized", "pod", "hello")
+	e.waitFor("condition=initialized", "pod", "hello")
 
 	output := e.kubectl("get", "pod", "hello")
 	for strings.Contains(output, "ContainerCreating") {

--- a/test/tc_default_profiles_test.go
+++ b/test/tc_default_profiles_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func (e *e2e) testCaseDefaultAndExampleProfiles(nodes []string) {
+	e.seccompOnlyTestCase()
 	const exampleProfilePath = "examples/seccompprofile.yaml"
 	exampleProfileNames := [3]string{"profile-allow-unsafe", "profile-complain-unsafe", "profile-block-all"}
 	defaultProfileNames := [1]string{"nginx-1.19.1"}

--- a/test/tc_delete_profiles_test.go
+++ b/test/tc_delete_profiles_test.go
@@ -142,7 +142,7 @@ spec:
 		defer profileCleanup()
 		podCleanup := e.writeAndCreate(fmt.Sprintf(testCase.podManifest, namespace), "delete-pod*.yaml")
 		defer podCleanup()
-		e.kubectl("wait", "--for", "condition=ready", "pod", deletePodName)
+		e.waitFor("condition=ready", "pod", deletePodName)
 		e.logf("Ensuring profile cannot be deleted while pod is active")
 		e.kubectl("delete", "seccompprofile", deleteProfileName, "--wait=0")
 		output := e.kubectl("get", "seccompprofile", deleteProfileName)

--- a/test/tc_delete_profiles_test.go
+++ b/test/tc_delete_profiles_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func (e *e2e) testCaseDeleteProfiles(nodes []string) {
+	e.seccompOnlyTestCase()
 	const (
 		deleteProfile = `
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/test/tc_profilebindings_test.go
+++ b/test/tc_profilebindings_test.go
@@ -142,8 +142,10 @@ func (e *e2e) deployWebhook(manifest string) {
 	)
 	e.logf("Deploying webhook")
 	e.kubectl("create", "-f", manifest)
-	e.kubectlOperatorNS("wait", "--for", "condition=ready", "pod", "-l", "name=security-profiles-operator-webhook")
-	e.kubectlOperatorNS("wait", "--for", "condition=ready", "certificate", "webhook-cert")
+	e.kubectlOperatorNS("wait", "--timeout", defaultWaitTimeout,
+		"--for", "condition=ready", "pod", "-l", "name=security-profiles-operator-webhook")
+	e.kubectlOperatorNS("wait", "--timeout", defaultWaitTimeout,
+		"--for", "condition=ready", "certificate", "webhook-cert")
 }
 
 func (e *e2e) cleanupWebhook(manifest string) {

--- a/test/tc_profilebindings_test.go
+++ b/test/tc_profilebindings_test.go
@@ -24,6 +24,7 @@ import (
 )
 
 func (e *e2e) testCaseProfileBinding([]string) {
+	e.profileBindingTestCase()
 	const exampleProfilePath = "examples/seccompprofile.yaml"
 	const testBinding = `
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha1

--- a/test/tc_run_pod_test.go
+++ b/test/tc_run_pod_test.go
@@ -38,7 +38,7 @@ func (e *e2e) testCaseRunPod([]string) {
 	defer e.kubectl("delete", "-f", examplePodPath)
 
 	e.logf("Waiting for test pod to be ready")
-	e.kubectl("wait", "--for", "condition=ready", "pod", "--all")
+	e.waitFor("condition=ready", "pod", "--all")
 
 	e.logf("Testing that `rmdir` is not possible inside the pod")
 	failureOutput := e.kubectlFailure(

--- a/test/tc_run_pod_test.go
+++ b/test/tc_run_pod_test.go
@@ -19,6 +19,7 @@ package e2e_test
 import "fmt"
 
 func (e *e2e) testCaseRunPod([]string) {
+	e.seccompOnlyTestCase()
 	const (
 		examplePodPath = "examples/pod.yaml"
 		examplePodName = "test-pod"

--- a/test/tc_selinux_base_usage_test.go
+++ b/test/tc_selinux_base_usage_test.go
@@ -108,7 +108,7 @@ spec:
 	podWithPolicy := fmt.Sprintf(podWithPolicyFmt, e.getSELinuxPolicyUsage("errorlogger"))
 	e.writeAndCreate(podWithPolicy, "pod-w-policy.yml")
 
-	e.kubectl("wait", "--for", "condition=ready", "pod", "errorlogger")
+	e.waitFor("condition=ready", "pod", "errorlogger")
 
 	e.logf("the workload should be running")
 	podWithPolicyPhase := e.kubectl(

--- a/test/tc_selinux_sanity_check_test.go
+++ b/test/tc_selinux_sanity_check_test.go
@@ -48,7 +48,7 @@ spec:
 	e.logf("creating workload")
 	e.writeAndCreate(podWithoutPolicy, "pod-wo-policy.yml")
 
-	e.kubectl("wait", "--for", "condition=ready", "pod", "el-no-policy")
+	e.waitFor("condition=ready", "pod", "el-no-policy")
 
 	e.logf("the workload should have errored")
 	expectedLog := "/bin/bash: /var/log/test.log: Permission denied"


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This adds the e2e test run as part of the e2e GH action.

It introduces a "vanilla" kuberentes e2e cluster type which assumes that
a kubernetes cluster is already running and takes it into use.

Note that this also installs the oci hook for dynamically creating seccomp
profiles.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A.


#### Does this PR introduce a user-facing change?

```release-note
NONE
```

Co-Authored-By: Sascha Grunert <mail@saschagrunert.de>