### PR TITLE
Add arm64 binary cross compilation support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 .vagrant
 Vagrantfile
 build
+result

--- a/nix/default-arm64.nix
+++ b/nix/default-arm64.nix
@@ -1,0 +1,6 @@
+(import ./nixpkgs.nix {
+  crossSystem = {
+    config = "aarch64-unknown-linux-gnu";
+  };
+}).callPackage ./derivation.nix
+{ }

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -1,0 +1,1 @@
+(import ./nixpkgs.nix { }).callPackage ./derivation.nix { }

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -1,0 +1,24 @@
+{ pkgs, buildGoModule }:
+with pkgs; buildGoModule rec {
+  name = "security-profiles-operator";
+  src = ./..;
+  vendorSha256 = null;
+  doCheck = false;
+  outputs = [ "out" ];
+  nativeBuildInputs = with buildPackages; [
+    git
+    pkg-config
+    which
+  ];
+  buildInputs = [
+    glibc
+    glibc.static
+    (libseccomp.overrideAttrs (x: { dontDisableStatic = true; }))
+  ];
+  buildPhase = ''
+    make
+  '';
+  installPhase = ''
+    install -Dm755 -t $out build/security-profiles-operator
+  '';
+}

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/nixos/nixpkgs",
+  "rev": "cc0da25d94f300f9098d3c8bae2106c7997805e4",
+  "date": "2021-02-10T15:00:01+01:00",
+  "path": "/nix/store/f7xw50gii6j3f88lfb7s7crzs6sdxwxi-nixpkgs",
+  "sha256": "0xarfhl988s5npnaqjgw6291pqcpa0pswaqfp05k8gvzrixs52q0",
+  "fetchSubmodules": false,
+  "deepClone": false,
+  "leaveDotGit": false
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,8 @@
+let
+  json = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+  nixpkgs = import (builtins.fetchTarball {
+    name = "nixos-unstable";
+    url = "${json.url}/archive/${json.rev}.tar.gz";
+    inherit (json) sha256;
+  });
+in nixpkgs


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now utilize [nix](https://nixos.org) to be able to build the operator
binary in a reproducible environment. This way we're able to cross-build
the binary to any supported target architecture.

For example the new `make nix` target now builds the locally available
system binary, which should be usually x86-64:

```
> make nix
…
file result/*
result/security-profiles-operator: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, for GNU/Linux 2.6.32, Go BuildID=JPRHwsjKv1rgegLFOzeZ/MbtM6EjbKLpv2qaZ1bUS/OLZzjQg7BJIUB1yQ5x7L/aXXV7z2TB5tXSZBtwwvB, stripped
```

Cross compilation works via the `make nix-arm64` target, too:

```

> make nix-arm64
…
file result/*
result/security-profiles-operator: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, for GNU/Linux 2.6.32, Go BuildID=Vq3MhhbkzqJwPo6-4IUP/wZumN1S4dVZPxXo1vz6F/VFKjirA5ExnyxY3Nll47/JreX-K6WRUgMk3chrXSn, stripped
```

Target is to replace the container image build in a next step to utilize
both nix targets to create multi-arch container images.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes-sigs/security-profiles-operator/issues/282
#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
