### PR TITLE
Make crun the default runtime for CRI-O tests

### DIFF
--- a/hack/ci/install-cri-o.sh
+++ b/hack/ci/install-cri-o.sh
@@ -53,6 +53,14 @@ conmon_cgroup = "pod"
 cgroup_manager = "cgroupfs"
 EOT
 
+cat <<EOT >>/etc/crio/crio.conf.d/20-crun.conf
+[crio.runtime]
+default_runtime = "crun"
+
+[crio.runtime.runtimes.crun]
+runtime_path = "/usr/local/bin/crun"
+EOT
+
 chcon -R -u system_u -r object_r -t container_config_t \
     /etc/crio \
     /etc/crio/crio.conf \


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We can now switch back to crun (instead of using runc) for the vagrant
based tests since the nginx profile fix got merged and we scope the
tests to only a subset of features which are avilable on Fedora/CRI-O.

#### Which issue(s) this PR fixes:
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
