### PR TITLE
e2e: Use fedora-based selinuxd image for e2e tests

### DIFF
--- a/hack/ci/e2e.sh
+++ b/hack/ci/e2e.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 export E2E_CLUSTER_TYPE=vanilla
-#export E2E_TEST_SELINUX=true
+export E2E_TEST_SELINUX=true
 
 # These are already tested in the standard e2e test.
 # No need to test them here.

--- a/hack/ci/install-cri-o.sh
+++ b/hack/ci/install-cri-o.sh
@@ -47,6 +47,11 @@ chcon -R -u system_u -r object_r -t var_lib_t /var/lib/kubelet
 
 mkdir -p /etc/crio/crio.conf.d
 
+cat <<EOT >>/etc/crio/crio.conf.d/30-selinux.conf
+[crio.runtime]
+selinux = true
+EOT
+
 cat <<EOT >>/etc/crio/crio.conf.d/30-cgroup-manager.conf
 [crio.runtime]
 conmon_cgroup = "pod"

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -144,6 +144,10 @@ func (e *e2e) deployOperator(manifest string) {
 		"sed", "-i", fmt.Sprintf("s;value: .*gcr.io/.*;value: %s;g", e.testImage),
 		manifest,
 	)
+	e.run(
+		"sed", "-i", fmt.Sprintf("s;value: .*quay.io/.*/selinuxd.*;value: %s;g", e.selinuxdImage),
+		manifest,
+	)
 
 	if e.selinuxEnabled {
 		e.run(

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -57,6 +57,7 @@ type e2e struct {
 	suite.Suite
 	kubectlPath        string
 	testImage          string
+	selinuxdImage      string
 	pullPolicy         string
 	selinuxEnabled     bool
 	testSeccomp        bool
@@ -102,6 +103,7 @@ func TestSuite(t *testing.T) {
 	if err != nil {
 		testProfileBinding = true
 	}
+	selinuxdImage := "quay.io/jaosorior/selinuxd"
 	switch {
 	case clusterType == "" || strings.EqualFold(clusterType, "kind"):
 		if testImage == "" {
@@ -115,6 +117,7 @@ func TestSuite(t *testing.T) {
 				selinuxEnabled:     selinuxEnabled,
 				testSeccomp:        testSeccomp,
 				testProfileBinding: testProfileBinding,
+				selinuxdImage:      selinuxdImage,
 			},
 			"", "",
 		})
@@ -137,6 +140,7 @@ func TestSuite(t *testing.T) {
 				selinuxEnabled:     selinuxEnabled,
 				testSeccomp:        testSeccomp,
 				testProfileBinding: testProfileBinding,
+				selinuxdImage:      selinuxdImage,
 			},
 			skipBuildImages,
 			skipPushImages,
@@ -145,6 +149,7 @@ func TestSuite(t *testing.T) {
 		if testImage == "" {
 			testImage = "localhost/" + config.OperatorName + ":latest"
 		}
+		selinuxdImage = "quay.io/jaosorior/selinuxd-fedora"
 		suite.Run(t, &vanilla{
 			e2e{
 				logger:             klogr.New(),
@@ -153,6 +158,7 @@ func TestSuite(t *testing.T) {
 				selinuxEnabled:     selinuxEnabled,
 				testSeccomp:        testSeccomp,
 				testProfileBinding: testProfileBinding,
+				selinuxdImage:      selinuxdImage,
 			},
 		})
 	default:
@@ -219,7 +225,7 @@ func (e *kinde2e) SetupTest() {
 		e.kindPath, "load", "docker-image", "--name="+e.clusterName, e.testImage,
 	)
 	e.run(
-		"docker", "pull", "quay.io/jaosorior/selinuxd",
+		containerRuntime, "pull", e.selinuxdImage,
 	)
 	e.run(
 		e.kindPath, "load", "docker-image", "--name="+e.clusterName, "quay.io/jaosorior/selinuxd",
@@ -350,7 +356,7 @@ func (e *vanilla) SetupTest() {
 	e.logf("Building operator container image")
 	e.run("make", "image", "IMAGE="+e.testImage)
 	e.run(
-		containerRuntime, "pull", "quay.io/jaosorior/selinuxd",
+		containerRuntime, "pull", e.selinuxdImage,
 	)
 }
 

--- a/test/tc_selinux_sanity_check_test.go
+++ b/test/tc_selinux_sanity_check_test.go
@@ -53,7 +53,7 @@ spec:
 	e.logf("the workload should have errored")
 	expectedLog := "/bin/bash: /var/log/test.log: Permission denied"
 	log := e.kubectl("logs", "el-no-policy", "-c", "errorlogger")
-	e.Equalf(log, expectedLog, "container should have returned a 'Permissions Denied' error")
+	e.Equalf(expectedLog, log, "container should have returned a 'Permissions Denied' error")
 
 	e.kubectl("delete", "pod", "el-no-policy")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The default image is CentOS-based, which works in CentOS, RHEL and
RHCOS. But our e2e tests use Fedora, which doesn't recognize the
libsemanage configuration format (and most likely the policy format
too). So, let's switch to a fedora-based image for this test

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```