### PR TITLE
Remove clusterRole and clusterRoleBinding overrides from namespaced-operator

### DIFF
--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -310,12 +310,12 @@ metadata:
   namespace: security-profiles-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   labels:
     app: security-profiles-operator
   name: config-map-reader
-  namespace: NS_REPLACE
+  namespace: security-profiles-operator
 rules:
 - apiGroups:
   - ""
@@ -372,15 +372,14 @@ rules:
   - patch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   labels:
     app: security-profiles-operator
   name: config-map-reader-binding
-  namespace: NS_REPLACE
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: config-map-reader
 subjects:
 - kind: ServiceAccount

--- a/deploy/overlays/namespaced/clusterrole.yaml
+++ b/deploy/overlays/namespaced/clusterrole.yaml
@@ -1,6 +1,0 @@
-- op: replace
-  path: /kind
-  value: Role
-- op: replace
-  path: /metadata/namespace
-  value: NS_REPLACE

--- a/deploy/overlays/namespaced/clusterrolebinding.yaml
+++ b/deploy/overlays/namespaced/clusterrolebinding.yaml
@@ -1,9 +1,0 @@
-- op: replace
-  path: /kind
-  value: RoleBinding
-- op: replace
-  path: /metadata/namespace
-  value: NS_REPLACE
-- op: replace
-  path: /roleRef/kind
-  value: Role

--- a/deploy/overlays/namespaced/kustomization.yaml
+++ b/deploy/overlays/namespaced/kustomization.yaml
@@ -8,18 +8,3 @@ bases:
 
 patchesStrategicMerge:
   - deployment.yaml
-
-patchesJson6902:
-  - target:
-      group: rbac.authorization.k8s.io
-      version: v1
-      kind: ClusterRole
-      name: config-map-reader
-    path: clusterrole.yaml
-
-  - target:
-      group: rbac.authorization.k8s.io
-      version: v1
-      kind: ClusterRoleBinding
-      name: config-map-reader-binding
-    path: clusterrolebinding.yaml


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The main target of this type of deployment is to have the SPO to only
liten for policies in specific namespaces. Having these overrides only
adds extra complexity, and the operator itself is able to function
without these.

Let's remove this extra complexity!

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

This is already covered by the namespace set of tests

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
The namespaced-operator deployment now relies on a ClusterRole and a ClusterRoleBinding instead of the previous Role And RoleBinding objects. It now more closely resembles the cluster-operator deployment.
```