### PR TITLE
Fix controller-gen `go` command within Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ $(BUILD_DIR)/$(PROJECT): $(BUILD_DIR) $(BUILD_FILES)
 
 CONTROLLER_GEN := $(BUILD_DIR)/controller-gen
 $(CONTROLLER_GEN): ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
-	go build -o "$@" ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
+	$(GO) build -o "$@" ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
 
 .PHONY: clean
 clean: ## Clean the build directory


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
We usually should reference `$(GO)` instead of the `go` one. This is now
fixed with this patch.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
