### PR TITLE
WIP: Move non-root-enabler into own image

### DIFF
--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,21 @@
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM docker.io/nixos/nix:2.3.6
+WORKDIR /work
+
+COPY . /work
+
+ARG target=nix
+RUN nix-build $target

--- a/Dockerfile.non-root-enabler
+++ b/Dockerfile.non-root-enabler
@@ -1,4 +1,4 @@
-# Copyright 2020 The Kubernetes Authors.
+# Copyright 2021 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,13 +15,12 @@
 FROM scratch
 
 ARG version
-LABEL name="Security Profiles Operator" \
+LABEL name="Security Profiles Operator non root enabler" \
       version=$version \
-      description="The Security Profiles Operator makes it easier for cluster admins to manage their seccomp or AppArmor profiles and apply them to Kubernetes' workloads."
+      description="Helper image to allow running the operator as non root"
 
-COPY --from=security-profiles-operator-build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=security-profiles-operator-build /work/result/security-profiles-operator /
+COPY --from=security-profiles-operator-build /work/result/non-root-enabler /
 
-USER 65535:65535
+ENTRYPOINT ["/non-root-enabler"]
 
-ENTRYPOINT ["/security-profiles-operator"]
+# vim:set ft=dockerfile:

--- a/cmd/non-root-enabler/main.go
+++ b/cmd/non-root-enabler/main.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/pkg/errors"
+	"k8s.io/release/pkg/util"
+
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
+)
+
+func main() {
+	log.Printf("Enabling non root capabilities for operator")
+	if err := run(); err != nil {
+		log.Fatalf("Unable to run non root enabler: %v", err)
+	}
+	log.Printf("Done")
+}
+
+func run() error {
+	const dirPermissions os.FileMode = 0o744
+
+	if err := os.MkdirAll(
+		config.KubeletSeccompRootPath, dirPermissions,
+	); err != nil {
+		return errors.Wrapf(
+			err, "create seccomp root path %s", config.KubeletSeccompRootPath,
+		)
+	}
+
+	if err := os.MkdirAll(
+		config.OperatorRoot, dirPermissions,
+	); err != nil {
+		return errors.Wrapf(
+			err, "create operator root path %s", config.KubeletSeccompRootPath,
+		)
+	}
+
+	if _, err := os.Stat(config.ProfilesRootPath); os.IsNotExist(err) {
+		if err := os.Symlink(
+			config.OperatorRoot, config.ProfilesRootPath,
+		); err != nil {
+			return errors.Wrap(err, "link profiles root path")
+		}
+	}
+
+	if err := os.Chown(
+		config.OperatorRoot, config.UserRootless, config.UserRootless,
+	); err != nil {
+		return errors.Wrap(err, "change operator root permissions")
+	}
+
+	if err := util.CopyDirContentsLocal(
+		"/opt/seccomp-profiles", config.KubeletSeccompRootPath,
+	); err != nil {
+		return errors.Wrap(err, "copy local seccomp profiles")
+	}
+
+	return nil
+}

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -6,7 +6,7 @@ images:
   - name: security-profiles-operator
     newName: gcr.io/k8s-staging-sp-operator/security-profiles-operator
     newTag: latest
-    # For images to be released:
+    # For images to be released, use the `k8s.gcr.io` registry:
     # newName: k8s.gcr.io/security-profiles-operator/security-profiles-operator
     # newTag: v0.3.0
 
@@ -24,7 +24,9 @@ patchesStrategicMerge:
           - name: security-profiles-operator
             env:
               - name: RELATED_IMAGE_NON_ROOT_ENABLER
-                value: docker.io/bash:5.0
+                # For images to be released, use the `k8s.gcr.io` registry:
+                # value: k8s.gcr.io/security-profiles-operator/non-root-enabler:v0.3.0
+                value: gcr.io/k8s-staging-sp-operator/non-root-enabler:latest
               - name: RELATED_IMAGE_SELINUXD
                 value: quay.io/jaosorior/selinuxd
 

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -532,7 +532,7 @@ spec:
         - name: RESTRICT_TO_NAMESPACE
           value: NS_REPLACE
         - name: RELATED_IMAGE_NON_ROOT_ENABLER
-          value: docker.io/bash:5.0
+          value: gcr.io/k8s-staging-sp-operator/non-root-enabler:latest
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/jaosorior/selinuxd
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -530,7 +530,7 @@ spec:
         - manager
         env:
         - name: RELATED_IMAGE_NON_ROOT_ENABLER
-          value: docker.io/bash:5.0
+          value: gcr.io/k8s-staging-sp-operator/non-root-enabler:latest
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/jaosorior/selinuxd
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -25,6 +25,12 @@ const (
 	// OperatorName is the name when referring to the operator.
 	OperatorName = "security-profiles-operator"
 
+	// OperatorRoot is the root directory of the operator.
+	OperatorRoot = "/var/lib/security-profiles-operator"
+
+	// UserRootless is the user which runs the operator.
+	UserRootless = 65535
+
 	// KubeletSeccompRootPath specifies the path where all kubelet seccomp
 	// profiles are stored.
 	KubeletSeccompRootPath = "/var/lib/kubelet/seccomp"

--- a/internal/pkg/controllers/spod/bindata/spod.go
+++ b/internal/pkg/controllers/spod/bindata/spod.go
@@ -29,14 +29,13 @@ var (
 	falsely                         = false
 	truly                           = true
 	userRoot                  int64 = 0
-	userRootless              int64 = 65535
+	userRootless                    = int64(config.UserRootless)
 	hostCharDev                     = v1.HostPathCharDev
 	hostPathDirectory               = v1.HostPathDirectory
 	hostPathDirectoryOrCreate       = v1.HostPathDirectoryOrCreate
 )
 
 const (
-	operatorRoot         = "/var/lib/security-profiles-operator"
 	SelinuxDropDirectory = "/etc/selinux.d"
 	SelinuxdSocketDir    = "/var/run/selinuxd"
 	SelinuxdSocketPath   = SelinuxdSocketDir + "/selinuxd.sock"
@@ -68,28 +67,6 @@ var Manifest = &appsv1.DaemonSet{
 				InitContainers: []v1.Container{
 					{
 						Name: "non-root-enabler",
-						// Creates directory /var/lib/security-profiles-operator,
-						// sets 65535:65535 as its owner and symlink it to
-						// /var/lib/kubelet/seccomp/operator. This is required
-						// to allow the main container to run as non-root.
-						Command: []string{"bash", "-c"},
-						Args: []string{`
-						set -euo pipefail
-
-						if [ ! -d ` + config.KubeletSeccompRootPath + ` ]; then
-							/bin/mkdir -m 0744 -p ` + config.KubeletSeccompRootPath + `
-						fi
-
-						/bin/mkdir -p ` + operatorRoot + `
-						/bin/chmod 0744 ` + operatorRoot + `
-
-						if [ ! -L ` + config.ProfilesRootPath + ` ]; then
-							/bin/ln -s ` + operatorRoot + ` ` + config.ProfilesRootPath + `
-						fi
-
-						/bin/chown -R 65535:65535 ` + operatorRoot + `
-						cp -f -v /opt/seccomp-profiles/* ` + config.KubeletSeccompRootPath + `
-					`},
 						VolumeMounts: []v1.VolumeMount{
 							{
 								Name:      "host-varlib-volume",

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -19,6 +19,6 @@ with pkgs; buildGoModule rec {
     make
   '';
   installPhase = ''
-    install -Dm755 -t $out build/security-profiles-operator
+    install -Dm755 -t $out build/*
   '';
 }

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -231,6 +231,9 @@ func (e *kinde2e) SetupTest() {
 		e.kindPath, "load", "docker-image", "--name="+e.clusterName, e.testImage,
 	)
 	e.run(
+		e.kindPath, "load", "docker-image", "--name="+e.clusterName, "non-root-enabler",
+	)
+	e.run(
 		containerRuntime, "pull", e.selinuxdImage,
 	)
 	e.run(


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
Target of this change is to be independent from external images as well as providing a toolchain which allows us creating multiple images from distinguishable binaries.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
Things to be done:

- [ ] Check if e2e testing and image substitution still works
- [ ] Change hack/image-cross.sh to push the non-root-enabler image

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed `non-root-enabler` to be independent from `docker.io/bash:5`,
because the image is now shipped with the operator release.
```
