### PR TITLE
Add cachix GitHub action to speedup CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,19 +1,27 @@
-name: macosbuild
-on: [push, pull_request]
+name: build
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 jobs:
-  validate:
-    name: Validate 
+  macos:
     runs-on: macos-latest
-    # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository
     steps:
-      - name: Clone the code
-        uses: actions/checkout@v2
-      - name: Setup Go
-        uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
         with:
-          go-version: '^1.15'
-      - name: unit test
-        run: make test-unit
-      - name: verify
-        run: make verify-go-lint
+          go-version: '1.15'
+      - run: make test-unit
+      - run: make verify-go-lint
+
+  nix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
+      - uses: cachix/cachix-action@v8
+        with:
+          name: security-profiles-operator
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - run: make nix nix-arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,10 @@ WORKDIR /work
 COPY . /work
 
 FROM build as make
+
+RUN nix-env -iA cachix -f https://cachix.org/api/v1/install
+RUN cachix use security-profiles-operator
+
 ARG target=nix
 RUN nix-build $target
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This allows us to cache the static libseccomp build and speedup the CI.
The cache has been setup there and should be populated with the first master run of the GitHub action:
https://app.cachix.org/cache/security-profiles-operator

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
