### PR TITLE
Use k8s.gcr.io debian-base image for container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/nixos/nix:2.3.6 AS build
+FROM k8s.gcr.io/build-image/debian-base:buster-v1.4.0 AS build
 WORKDIR /work
+
+RUN apt-get update && apt-get install -y wget xz-utils
+
+ARG NIX_VERSION=2.3.10
+RUN wget https://nixos.org/releases/nix/nix-${NIX_VERSION}/nix-${NIX_VERSION}-$(uname -m)-linux.tar.xz && \
+    tar xf nix-${NIX_VERSION}-$(uname -m)-linux.tar.xz && \
+    groupadd -r -g 30000 nixbld && \
+    for i in $(seq 1 30); do useradd -rM -u $((30000 + i)) -G nixbld nixbld$i ; done && \
+    mkdir -m 0755 /etc/nix && \
+    echo 'sandbox = false' > /etc/nix/nix.conf && \
+    mkdir -m 0755 /nix && \
+    USER=root sh nix-${NIX_VERSION}-$(uname -m)-linux/install && \
+    ln -s /nix/var/nix/profiles/default/etc/profile.d/nix.sh /etc/profile.d
+
+ENV ENV=/etc/profile \
+    USER=root \
+    PATH=/nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:/bin:/sbin:/usr/bin:/usr/sbin \
+    GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt \
+    NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \
+    NIX_PATH=/nix/var/nix/profiles/per-user/root/channels
 
 COPY . /work
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
This means that we now have to install nix manually which will blow up
our Dockerfile. The benefit of this approach is being independent from
Docker Hub rate limiting.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
