### PR TITLE
Rename `go-mod` target to `update-go-mod` and vendor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,12 +111,6 @@ $(CONTROLLER_GEN): ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
 clean: ## Clean the build directory
 	rm -rf $(BUILD_DIR)
 
-.PHONY: go-mod
-go-mod: ## Cleanup and verify go modules
-	export GO111MODULE=on && \
-		$(GO) mod tidy && \
-		$(GO) mod verify
-
 $(BUILD_DIR)/kustomize: $(BUILD_DIR)
 	export \
 		VERSION=4.0.1 \
@@ -158,6 +152,13 @@ update-nixpkgs: ## Update the pinned nixpkgs to the latest master
 	@nix run -f channel:nixpkgs-unstable nix-prefetch-git -c nix-prefetch-git \
 		--no-deepClone https://github.com/nixos/nixpkgs > nix/nixpkgs.json
 
+.PHONY: update-go-mod
+update-go-mod: ## Cleanup, vendor and verify go modules
+	export GO111MODULE=on && \
+		$(GO) mod tidy && \
+		$(GO) mod vendor && \
+		$(GO) mod verify
+
 # Verification targets
 
 .PHONY: verify
@@ -173,7 +174,7 @@ $(BUILD_DIR)/verify_boilerplate.py: $(BUILD_DIR)
 	chmod +x $(BUILD_DIR)/verify_boilerplate.py
 
 .PHONY: verify-go-mod
-verify-go-mod: go-mod ## Verify the go modules
+verify-go-mod: update-go-mod ## Verify the go modules
 	hack/tree-status
 
 .PHONY: verify-deployments


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
This adds a `go mod vendor` to the go module update target. This allows
us to directly vendor dependencies while changing the `go.mod` file.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
