### PR TITLE
Fix kustomize make target and file download

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,12 +117,15 @@ go-mod: ## Cleanup and verify go modules
 		$(GO) mod tidy && \
 		$(GO) mod verify
 
+.PHONY: $(BUILD_DIR)/kustomize
 $(BUILD_DIR)/kustomize: $(BUILD_DIR)
-	export \
-		VERSION=4.0.1 \
-		URL=https://raw.githubusercontent.com/kubernetes-sigs/kustomize && \
-	curl -sfL $$URL/master/hack/install_kustomize.sh \
-		| bash -s $$VERSION $(PWD)/$(BUILD_DIR)
+	if [ ! -f $(BUILD_DIR)/kustomize ]; then \
+		export \
+			VERSION=4.0.1 \
+			URL=https://raw.githubusercontent.com/kubernetes-sigs/kustomize && \
+		curl -sfL $$URL/master/hack/install_kustomize.sh \
+			| bash -s $$VERSION $(PWD)/$(BUILD_DIR); \
+	fi
 
 .PHONY: deployments
 deployments: $(BUILD_DIR)/kustomize manifests ## Generate the deployment files with kustomize


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
The `$(BUILD_DIR)/kustomize` did not really work because it always tried
to re-download the binary. We now fix that behavior by making the target
`PHONY` and downloading only if the file does not already locally
exists.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
