### PR TITLE
Fix post-security-profiles-operator-push-image job

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ RUN wget https://nixos.org/releases/nix/nix-${NIX_VERSION}/nix-${NIX_VERSION}-$(
     groupadd -r -g 30000 nixbld && \
     for i in $(seq 1 30); do useradd -rM -u $((30000 + i)) -G nixbld nixbld$i ; done && \
     mkdir -m 0755 /etc/nix && \
-    echo 'sandbox = false' > /etc/nix/nix.conf && \
+    printf "sandbox = false\nfilter-syscalls = false\n" > /etc/nix/nix.conf && \
     mkdir -m 0755 /nix && \
     USER=root sh nix-${NIX_VERSION}-$(uname -m)-linux/install && \
     ln -s /nix/var/nix/profiles/default/etc/profile.d/nix.sh /etc/profile.d


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
The job fails because of the error message:

```
error: while setting up the build environment: \
    unable to load seccomp BPF program: Invalid argument
```

See: https://prow.k8s.io/view/gs/kubernetes-jenkins/logs/post-security-profiles-operator-push-image/1361650313655750656

Setting the option `filter-syscalls = false` in `nix.conf` seems to
solve the issue.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/NixOS/nix/issues/2651
#### Does this PR have test?
Manual test:
```
> gcloud builds submit --verbosity info --config cloudbuild.yaml --substitutions _GIT_TAG=v20210216-v0.2.0-130-g9c2567b --project k8s-staging-sp-operator --gcs-log-dir gs://k8s-staging-sp-operator-gcb/logs --gcs-source-staging-dir gs://k8s-staging-sp-operator-gcb/source
```
https://console.cloud.google.com/cloud-build/builds/e32d23ff-228a-4df1-b38f-e05b8f0c3239?project=448637284062
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
