### PR TITLE
Stick to x86_64 nix binaries for image builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,19 +17,19 @@ WORKDIR /work
 
 RUN apt-get update && apt-get install -y wget xz-utils
 
+ENV USER=root
+
 ARG NIX_VERSION=2.3.10
-RUN wget https://nixos.org/releases/nix/nix-${NIX_VERSION}/nix-${NIX_VERSION}-$(uname -m)-linux.tar.xz && \
-    tar xf nix-${NIX_VERSION}-$(uname -m)-linux.tar.xz && \
+RUN wget https://nixos.org/releases/nix/nix-${NIX_VERSION}/nix-${NIX_VERSION}-x86_64-linux.tar.xz && \
+    tar xf nix-${NIX_VERSION}-x86_64-linux.tar.xz && \
     groupadd -r -g 30000 nixbld && \
     for i in $(seq 1 30); do useradd -rM -u $((30000 + i)) -G nixbld nixbld$i ; done && \
-    mkdir -m 0755 /etc/nix && \
+    mkdir -m 0755 /etc/nix /nix && \
     printf "sandbox = false\nfilter-syscalls = false\n" > /etc/nix/nix.conf && \
-    mkdir -m 0755 /nix && \
-    USER=root sh nix-${NIX_VERSION}-$(uname -m)-linux/install && \
+    nix-${NIX_VERSION}-x86_64-linux/install && \
     ln -s /nix/var/nix/profiles/default/etc/profile.d/nix.sh /etc/profile.d
 
 ENV ENV=/etc/profile \
-    USER=root \
     PATH=/nix/var/nix/profiles/default/bin:/nix/var/nix/profiles/default/sbin:/bin:/sbin:/usr/bin:/usr/sbin \
     GIT_SSL_CAINFO=/etc/ssl/certs/ca-certificates.crt \
     NIX_SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt \


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test

#### What this PR does / why we need it:
We cross-compile via nix, so there is no need to use the `$(uname -m)`,
which will cause the `docker buildx` builds to download the arm binaries
instead of the x86_64 ones. This will result in cache poisoning on
cachix and will make the CI fail due to a timeout on the master branch.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
