### PR TITLE
Move images used for e2e testing away from dockerhub

### DIFF
--- a/test/tc_base_profiles_test.go
+++ b/test/tc_base_profiles_test.go
@@ -56,7 +56,7 @@ metadata:
   name: hello
 spec:
   containers:
-  - image: hello-world:linux
+  - image: quay.io/security-profiles-operator/test-hello-world:latest
     name: hello
     resources: {}
   securityContext:

--- a/test/tc_delete_profiles_test.go
+++ b/test/tc_delete_profiles_test.go
@@ -72,7 +72,7 @@ metadata:
 spec:
   initContainers:
   - name: init-container
-    image: busybox:latest
+    image: registry.fedoraproject.org/fedora-minimal:latest
     securityContext:
       seccompProfile:
         type: Localhost

--- a/test/tc_delete_profiles_test.go
+++ b/test/tc_delete_profiles_test.go
@@ -44,7 +44,7 @@ metadata:
 spec:
   containers:
   - name: test-container
-    image: nginx:1.19.1
+    image: quay.io/security-profiles-operator/test-nginx:1.19.1
   securityContext:
     seccompProfile:
       type: Localhost
@@ -58,7 +58,7 @@ metadata:
 spec:
   containers:
   - name: test-container
-    image: nginx:1.19.1
+    image: quay.io/security-profiles-operator/test-nginx:1.19.1
     securityContext:
       seccompProfile:
         type: Localhost
@@ -79,7 +79,7 @@ spec:
         localhostProfile: operator/%s/example-profiles/delete-me.json
   containers:
   - name: test-container
-    image: nginx:1.19.1
+    image: quay.io/security-profiles-operator/test-nginx:1.19.1
 `
 		deletePodSecurityContextInAnnotation = `
 apiVersion: v1
@@ -91,7 +91,7 @@ metadata:
 spec:
   containers:
   - name: test-container
-    image: nginx:1.19.1
+    image: quay.io/security-profiles-operator/test-nginx:1.19.1
 `
 		deletePodName = "test-pod"
 	)

--- a/test/tc_profilebindings_test.go
+++ b/test/tc_profilebindings_test.go
@@ -35,7 +35,7 @@ spec:
   profileRef:
     kind: SeccompProfile
     name: profile-allow-unsafe
-  image: hello-world:linux
+  image: quay.io/security-profiles-operator/test-hello-world:latest
 `
 	const testPod = `
 apiVersion: v1
@@ -44,7 +44,7 @@ metadata:
   name: hello
 spec:
   containers:
-  - image: hello-world:linux
+  - image: quay.io/security-profiles-operator/test-hello-world:latest
     name: hello
     resources: {}
   restartPolicy: Never


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This moves our test images away from using dockerhub to using less restrictive
registries.

The hello-world image was replaced with one that we host in the
security-profile-operator's quay.io org called test-hello-world (note the
"test-" prefix which indicates that the image is used for testing).

The busybox image was replaced with a fedora-minimal image (coming from
Fedora's registry).


#### Does this PR have test?

N/A.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```