### PR TITLE
Add profile recording `kubectl run` test

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -105,7 +105,8 @@ func (e *e2e) TestSecurityProfilesOperator() {
 	})
 
 	e.Run("cluster-wide: Seccomp: Verify profile recording", func() {
-		e.testCaseProfileRecording(nodes)
+		e.testCaseProfileRecordingStaticPod()
+		e.testCaseProfileRecordingKubectlRun()
 	})
 
 	e.cleanupWebhook(webhookManifest)


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
This test validates that the latest `kubectl run --restart=Never` fix
still applies. A profile has to be recorded even if the container never
reaches a visible `running` state.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
Yes
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
