### PR TITLE
Verify generated code on deployment generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,10 +105,6 @@ $(BUILD_DIR):
 $(BUILD_DIR)/$(PROJECT): $(BUILD_DIR) $(BUILD_FILES)
 	$(GO) build -ldflags '$(LDFLAGS)' -tags '$(BUILDTAGS)' -o $@ ./cmd/security-profiles-operator
 
-CONTROLLER_GEN := $(BUILD_DIR)/controller-gen
-$(CONTROLLER_GEN): ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
-	$(GO) build -o "$@" ./vendor/sigs.k8s.io/controller-tools/cmd/controller-gen
-
 .PHONY: clean
 clean: ## Clean the build directory
 	rm -rf $(BUILD_DIR)
@@ -121,7 +117,7 @@ $(BUILD_DIR)/kustomize: $(BUILD_DIR)
 		| bash -s $$VERSION $(PWD)/$(BUILD_DIR)
 
 .PHONY: deployments
-deployments: $(BUILD_DIR)/kustomize manifests ## Generate the deployment files with kustomize
+deployments: $(BUILD_DIR)/kustomize manifests generate ## Generate the deployment files with kustomize
 	$(BUILD_DIR)/kustomize build --reorder=none deploy/overlays/cluster -o deploy/operator.yaml
 	$(BUILD_DIR)/kustomize build --reorder=none deploy/overlays/namespaced -o deploy/namespace-operator.yaml
 	$(BUILD_DIR)/kustomize build --reorder=none deploy/base/webhook -o deploy/webhook.yaml
@@ -231,7 +227,7 @@ test-e2e: ## Run the end-to-end tests
 	$(GO) test -parallel 1 -timeout 80m -count=1 ./test/... -v
 
 # Generate CRD manifests
-manifests: $(CONTROLLER_GEN)
+manifests:
 	$(CONTROLLER_GEN_CMD) $(CRD_OPTIONS) paths="./api/seccompprofile/..." output:crd:stdout > deploy/base/crd.yaml
 	$(CONTROLLER_GEN_CMD) $(CRD_OPTIONS) paths="./api/selinuxpolicy/..." output:crd:stdout >> deploy/base/crd.yaml
 	$(CONTROLLER_GEN_CMD) $(CRD_OPTIONS) paths="./api/profilebinding/..." output:crd:stdout > deploy/base/webhook/crd-binding.yaml


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We now make the `deployments` target dependent on `generate`, to verify
changed code directly within the CI (via `verify-deployments`).

We also co not need the controller-gen binary target any more.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
