### PR TITLE
Add auto generate profiles use case

### DIFF
--- a/doc/user-stories.md
+++ b/doc/user-stories.md
@@ -30,6 +30,16 @@ in a certain profile. E.g. for SELinux a missing parenthesis or something of the
 sort… This is considered for SELinux in
 [an issue](https://github.com/kubernetes-sigs/security-profiles-operator/issues/223)
 
+### As an application developer, Ming would like to be able to automatically generate initial security profiles that are specific to the application.
+
+Details:
+
+* For improved profiles, users could define a process to be triggered during the profiling process (i.e. execution of E2E tests).
+* Avoid potential knowledge short falls by priming essential requirements 
+(e.g. blocked essential syscalls may cause 
+[issues](https://github.com/kubernetes/kubernetes/issues/85191) in seccomp)
+* The initial profile will need to be "manually" refined over time.
+
 ### As an application SRE, Rajesh needs to be able to see the state of the installed profile(s) and verify that it has indeed been installed on the system.
 
 ### As an application SRE, Rajesh needs to be able to do long runs of a security profile in “complain-mode” to easily identify the impact of a profile being enforced without impacting the application.


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Add new use case for auto generating security profiles for specific applications.
We need this to flash out the motivation around this feature.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

I tried to convey on the use case that the generated profiles are a starting point which will need to be manually reviewed and refined over time. 
For seccomp and AppArmor, it seems unrealistic to be able to automatically generate a profile that will consider *all* the execution path permutations for a given application, although the ability of running user provided E2E tests during the profile session may improve the results. 

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
