### PR TITLE
Handle Updates of SPOD object

### DIFF
--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -39,13 +39,15 @@ type SPODSpec struct {
 type SPODState string
 
 const (
-	// The policy is pending installation.
+	// The SPOD instance is pending installation.
 	SPODStatePending SPODState = "PENDING"
-	// The policy is being installed.
+	// The SPOD instance is being created.
 	SPODStateCreating SPODState = "CREATING"
-	// The policy was installed successfully.
+	// The SPOD instance is being updated.
+	SPODStateUpdating SPODState = "UPDATING"
+	// The SPOD instance was installed successfully.
 	SPODStateRunning SPODState = "RUNNING"
-	// The policy couldn't be installed.
+	// The SPOD instance couldn't be installed.
 	SPODStateError SPODState = "ERROR"
 )
 
@@ -93,6 +95,16 @@ func (s *SPODStatus) StatePending() {
 func (s *SPODStatus) StateCreating() {
 	s.State = SPODStateCreating
 	s.ConditionedStatus.SetConditions(rcommonv1.Creating())
+}
+
+func (s *SPODStatus) StateUpdating() {
+	s.State = SPODStateUpdating
+	s.ConditionedStatus.SetConditions(rcommonv1.Condition{
+		Type:               rcommonv1.TypeReady,
+		Status:             corev1.ConditionFalse,
+		LastTransitionTime: metav1.Now(),
+		Reason:             "Updating",
+	})
 }
 
 func (s *SPODStatus) StateRunning() {

--- a/deploy/base/role.yaml
+++ b/deploy/base/role.yaml
@@ -25,7 +25,6 @@ rules:
   - create
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -62,6 +61,7 @@ rules:
   - create
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -461,7 +461,6 @@ rules:
   - create
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -499,6 +498,7 @@ rules:
   - create
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -461,7 +461,6 @@ rules:
   - create
   - get
   - list
-  - patch
   - update
   - watch
 - apiGroups:
@@ -499,6 +498,7 @@ rules:
   - create
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -85,6 +85,10 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			"SELinux: base case (install policy, run pod and delete)",
 			e.testCaseSelinuxBaseUsage,
 		},
+		{
+			"SPOD: Update SELinux flag",
+			e.testCaseSPODUpdateSelinux,
+		},
 	}
 	for _, testCase := range testCases {
 		tc := testCase

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -423,8 +423,8 @@ func (e *e2e) kubectlFailure(args ...string) string {
 	return e.runFailure(e.kubectlPath, args...)
 }
 
-func (e *e2e) kubectlOperatorNS(args ...string) {
-	e.kubectl(
+func (e *e2e) kubectlOperatorNS(args ...string) string {
+	return e.kubectl(
 		append([]string{"-n", config.OperatorName}, args...)...,
 	)
 }

--- a/test/tc_spod_update_selinux_test.go
+++ b/test/tc_spod_update_selinux_test.go
@@ -1,0 +1,51 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import "time"
+
+func (e *e2e) testCaseSPODUpdateSelinux(nodes []string) {
+	e.selinuxtOnlyTestCase()
+
+	e.logf("assert selinux is enabled in the spod object")
+	selinuxEnabledInSPODObj := e.kubectl("get", "spod", "spod", "-o", "jsonpath={.spec.enableSelinux}")
+	e.Equal(selinuxEnabledInSPODObj, "true")
+
+	e.logf("assert selinux is enabled in the spod DS")
+	selinuxEnabledInSPODDS := e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
+	e.Contains(selinuxEnabledInSPODDS, "--with-selinux=true")
+
+	e.logf("Disable selinux from SPOD")
+	e.kubectl("patch", "spod", "spod", "-p", `{"spec":{"enableSelinux": false}}`, "--type=merge")
+
+	time.Sleep(defaultWaitTime)
+	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+
+	e.logf("assert selinux is disabled in the spod DS")
+	selinuxDisabledInSPODDS := e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
+	e.NotContains(selinuxDisabledInSPODDS, "--with-selinux=true")
+
+	e.logf("Re-enable selinux in SPOD")
+	e.kubectl("patch", "spod", "spod", "-p", `{"spec":{"enableSelinux": true}}`, "--type=merge")
+
+	time.Sleep(defaultWaitTime)
+	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+
+	e.logf("assert selinux is enabled in the spod DS")
+	selinuxEnabledInSPODDS = e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
+	e.Contains(selinuxEnabledInSPODDS, "--with-selinux=true")
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind feature

#### What this PR does / why we need it:

This PR ensures that updates to the SPOD object are handled appropriately.
Thus, when the SPOD object contains new values, such as new images, flags, or
tolerations, the DS that the SPOD object owns will get updated as well.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Yes

#### Special notes for your reviewer:

The "ready" condition now flicks with "updating" when the SPOD object is indeed
updating.

#### Does this PR introduce a user-facing change?

```release-note
Updates to the SecurityProfilesOperatorDaemon object are now reflected in the
daemonset.
```