### PR TITLE
Add multi-container recording support

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -107,6 +107,7 @@ func (e *e2e) TestSecurityProfilesOperator() {
 	e.Run("cluster-wide: Seccomp: Verify profile recording", func() {
 		e.testCaseProfileRecordingStaticPod()
 		e.testCaseProfileRecordingKubectlRun()
+		e.testCaseProfileRecordingMultiContainer()
 	})
 
 	e.cleanupWebhook(webhookManifest)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This adds support for multi container recording via the OCI seccomp BPF
hook. To not confuse users, we now require the (unreleased) version of
CRI-O v1.21.0. We always suffix the recording by the container name,
which allows the user to distinguish the profiles in a sane way.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
Yes
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
