### PR TITLE
Restore the default tolerations

### DIFF
--- a/deploy/base/config.yaml
+++ b/deploy/base/config.yaml
@@ -7,3 +7,13 @@ metadata:
 spec:
   enableSelinux: false
   enableLogEnricher: false
+  tolerations:
+    - key: "node-role.kubernetes.io/master"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node-role.kubernetes.io/control-plane"
+      operator: "Exists"
+      effect: "NoSchedule"
+    - key: "node.kubernetes.io/not-ready"
+      operator: "Exists"
+      effect: "NoExecute"

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -768,6 +768,16 @@ metadata:
 spec:
   enableLogEnricher: false
   enableSelinux: false
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
 ---
 apiVersion: v1
 data:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -766,6 +766,16 @@ metadata:
 spec:
   enableLogEnricher: false
   enableSelinux: false
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/control-plane
+    operator: Exists
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
 ---
 apiVersion: v1
 data:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The spod_controller unconditionally copies toleratins from the spod
object. By default, the spod object had no tolerations, which resulted
in the DS scheduling pods only on worker nodes.

This patch includes the same tolerations as spod.go in the default spod
object.



#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
No

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
This is a minimal patch. I think another alternative might be "if no
tolerations are set in spod", use the default tolerations. I even suspect
this might be what the admin wants? Opinions welcome.

#### Does this PR introduce a user-facing change?
No

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```