### PR TITLE
Re-enable SELinux by default on OCP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -272,6 +272,7 @@ do-deploy-openshift-dev: $(BUILD_DIR)/kustomize
 	oc wait --for=condition=Ready pod -lapp.kubernetes.io/instance=cert-manager -ncert-manager
 	@echo "Building custom operator.yaml"
 	$(BUILD_DIR)/kustomize build --reorder=none deploy/overlays/openshift-dev -o deploy/operator.yaml
+	sed -i 's/enableSelinux: false/enableSelinux: true/' deploy/operator.yaml
 	@echo "Deploying"
 	oc apply -f deploy/operator.yaml
 	@echo "Setting triggers to track image"

--- a/deploy/overlays/openshift-dev/enable-selinux.yaml
+++ b/deploy/overlays/openshift-dev/enable-selinux.yaml
@@ -1,3 +1,0 @@
-- op: replace
-  path: /spec/enableSelinux
-  value: "true"

--- a/deploy/overlays/openshift-dev/kustomization.yaml
+++ b/deploy/overlays/openshift-dev/kustomization.yaml
@@ -12,11 +12,6 @@ patchesJson6902:
       kind: ConfigMap
       name: security-profiles-operator-profile
     path: operator-profile.yaml
-  - target:
-      version: security-profiles-operator.x-k8s.io/v1alpha1
-      kind: SecurityProfilesOperatorDaemon
-      name: spod
-    path: enable-selinux.yaml
 
 images:
   - name: gcr.io/k8s-staging-sp-operator/security-profiles-operator


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Prior to using CRDs, we were using kustomize to change the enableSelinux
key of the config CM to true. This no longer works since we switched to
CRD as it appears that kustomize doesn't handle CRD:
    https://github.com/kubernetes-sigs/kustomize/blob/1d4b3fa36c8918ad884c7aaa6a055fa2d0fa9bf9/examples/transformerconfigs/crd/README.md

Let's re-enable SELinux by default on OpenShift by just using sed.
Long-term we want to switch to auto-detect the capabilities anyway.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE

```