### PR TITLE
spod: Lower the selinuxd CPU requests and limits

### DIFF
--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -272,12 +272,12 @@ var Manifest = &appsv1.DaemonSet{
 						Resources: v1.ResourceRequirements{
 							Requests: v1.ResourceList{
 								v1.ResourceMemory:           resource.MustParse("512Mi"),
-								v1.ResourceCPU:              resource.MustParse("1000m"),
+								v1.ResourceCPU:              resource.MustParse("100m"),
 								v1.ResourceEphemeralStorage: resource.MustParse("200Mi"),
 							},
 							Limits: v1.ResourceList{
 								v1.ResourceMemory:           resource.MustParse("1024Mi"),
-								v1.ResourceCPU:              resource.MustParse("2000m"),
+								v1.ResourceCPU:              resource.MustParse("1000m"),
 								v1.ResourceEphemeralStorage: resource.MustParse("400Mi"),
 							},
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The CPU requests and limits were way too high for the selinuxd container,
which was causing the DS pods to not be scheduled on clusters with low
CPU core nodes.

When I was setting the limits earlier, I was stupid and set even the CPU
/request/ based on what I saw in top and set a higher limit..well, that's
wrong because a process can function well with much less (unlike memory).

This time I did better experimenting with the different limits --
setting anything more than 1000m of CPU doesn't really make sense as a
limit, because rarely there is more than one process executing (always
selinuxdctl, sometimes there's an added setfilecontext helper).

With different CPU limits the selinuxd initialization took, until the
READY signal approximately:
 - with 300m CPU: 9 minutes
 - with 500m CPU: 6 minutes
 - with 1000m CPU or more: about 3 minutes
So the times scale linearly, but there's really no point in setting a
full core request (the process runs fine with much less) and no point in
setting a double-core limit (the process never uses them).

With memory, we unfortunately need to stick to the high values, I tested
setting request to 256Mi but got OOMKilled. So maybe 384 might work as
the lowest request, but I'm afraid it might not with complex policies.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None

```