### PR TITLE
Use Downward API to get operator namespace

### DIFF
--- a/deploy/base/operator.yaml
+++ b/deploy/base/operator.yaml
@@ -29,6 +29,10 @@ spec:
           env:
             - name: RELATED_IMAGE_SELINUXD
               value: quay.io/jaosorior/selinuxd
+            - name: OPERATOR_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
       tolerations:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -740,6 +740,10 @@ spec:
           value: NS_REPLACE
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/jaosorior/selinuxd
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
         imagePullPolicy: Always
         name: security-profiles-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -738,6 +738,10 @@ spec:
         env:
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/jaosorior/selinuxd
+        - name: OPERATOR_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
         imagePullPolicy: Always
         name: security-profiles-operator

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -85,13 +85,3 @@ func TryToGetOperatorNamespace() (string, error) {
 	}
 	return operatorNS, nil
 }
-
-// GetEnvDefault returns the value of the given environment variable or a
-// default value if the given environment variable is not set.
-func GetEnvDefault(variable, defaultVal string) string {
-	envVar, exists := os.LookupEnv(variable)
-	if !exists {
-		return defaultVal
-	}
-	return envVar
-}

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetOperatorNamespace(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:    "Valid one",
+			want:    "default",
+			wantErr: false,
+		},
+		{
+			name:    "invalid one",
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if tt.wantErr {
+				os.Unsetenv("OPERATOR_NAMESPACE")
+			} else {
+				os.Setenv("OPERATOR_NAMESPACE", tt.want)
+			}
+			got, err := TryToGetOperatorNamespace()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetOperatorNamespace() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GetOperatorNamespace() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This uses the downward API to fetch the operator's namespace.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A.

#### Special notes for your reviewer:

This was based on #228

Credit to @naveensrinivasan for starting this work. Thanks!

#### Does this PR introduce a user-facing change?

```release-note
NONE
```