### PR TITLE
Remove targetWorkload field from seccomp profiles

### DIFF
--- a/api/seccompprofile/v1alpha1/seccompprofile_types.go
+++ b/api/seccompprofile/v1alpha1/seccompprofile_types.go
@@ -23,10 +23,6 @@ import (
 
 // SeccompProfileSpec defines the desired state of SeccompProfile.
 type SeccompProfileSpec struct {
-	// the type of application workload for which the profile is targeted. Will be a subdirectory in the profile path on disk.
-	//nolint:lll
-	TargetWorkload string `json:"targetWorkload"`
-
 	// name of base profile (in the same namespace) what will be unioned into this profile
 	BaseProfileName string `json:"baseProfileName,omitempty"`
 

--- a/deploy/base/crd.yaml
+++ b/deploy/base/crd.yaml
@@ -319,13 +319,8 @@ spec:
                   - names
                   type: object
                 type: array
-              targetWorkload:
-                description: the type of application workload for which the profile
-                  is targeted. Will be a subdirectory in the profile path on disk.
-                type: string
             required:
             - defaultAction
-            - targetWorkload
             type: object
           status:
             description: SeccompProfileStatus contains status of the deployed SeccompProfile.

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -278,12 +278,8 @@ spec:
                   - names
                   type: object
                 type: array
-              targetWorkload:
-                description: the type of application workload for which the profile is targeted. Will be a subdirectory in the profile path on disk.
-                type: string
             required:
             - defaultAction
-            - targetWorkload
             type: object
           status:
             description: SeccompProfileStatus contains status of the deployed SeccompProfile.

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -278,12 +278,8 @@ spec:
                   - names
                   type: object
                 type: array
-              targetWorkload:
-                description: the type of application workload for which the profile is targeted. Will be a subdirectory in the profile path on disk.
-                type: string
             required:
             - defaultAction
-            - targetWorkload
             type: object
           status:
             description: SeccompProfileStatus contains status of the deployed SeccompProfile.

--- a/examples/baseprofile-crun.yaml
+++ b/examples/baseprofile-crun.yaml
@@ -5,7 +5,6 @@ metadata:
   name: crun-v0.17
 spec:
   defaultAction: SCMP_ACT_ERRNO
-  targetWorkload: base
   architectures:
   - SCMP_ARCH_X86_64
   syscalls:

--- a/examples/baseprofile-runc.yaml
+++ b/examples/baseprofile-runc.yaml
@@ -5,7 +5,6 @@ metadata:
   name: runc-v1.0.0-rc92
 spec:
   defaultAction: SCMP_ACT_ERRNO
-  targetWorkload: base
   architectures:
   - SCMP_ARCH_X86_64
   syscalls:

--- a/examples/pod.yaml
+++ b/examples/pod.yaml
@@ -4,11 +4,11 @@ metadata:
   name: test-pod
   annotations:
     # Use the default nginx profile
-    seccomp.security.alpha.kubernetes.io/pod: 'localhost/operator/security-profiles-operator/default-profiles/nginx-1.19.1.json'
+    seccomp.security.alpha.kubernetes.io/pod: 'localhost/operator/security-profiles-operator/nginx-1.19.1.json'
     # Or one example within this directory
     # Please note the syntax:
-    # `localhost/operator/{namespace}/{configmap-name}/{profile-name}`
-    # seccomp.security.alpha.kubernetes.io/pod: 'localhost/operator/default/generic/profile-allow-unsafe.json'
+    # `localhost/operator/{namespace}/{profile-name}`
+    # seccomp.security.alpha.kubernetes.io/pod: 'localhost/operator/default/profile-allow-unsafe.json'
 spec:
   containers:
   - name: test-container
@@ -16,5 +16,5 @@ spec:
     # securityContext:
       # seccompProfile:
         # type: Localhost
-        # localhostProfile: operator/security-profiles-operator/default-profiles/nginx-1.19.1.json
+        # localhostProfile: operator/security-profiles-operator/nginx-1.19.1.json
     image: nginx:1.19.1

--- a/examples/seccompprofile.yaml
+++ b/examples/seccompprofile.yaml
@@ -7,7 +7,6 @@ metadata:
     description: "Blocks all syscalls."
 spec:
   defaultAction: "SCMP_ACT_ERRNO"
-  targetWorkload: "generic"
 ---
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
 kind: SeccompProfile
@@ -17,7 +16,6 @@ metadata:
     description: "UNSAFE: Allows all syscalls whilst logging their use. Similar to running as unconfined in terms of enforcement."
 spec:
   defaultAction: "SCMP_ACT_LOG"
-  targetWorkload: "generic"
 ---
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
 kind: SeccompProfile
@@ -27,7 +25,6 @@ metadata:
     description: "UNSAFE: Allows all syscalls. Similar to running as unconfined as it provides no enforcement."
 spec:
   defaultAction: "SCMP_ACT_ALLOW"
-  targetWorkload: "generic"
 ---
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
 kind: SeccompProfile
@@ -37,7 +34,6 @@ metadata:
     description: "Enables complain mode whilst blocking high-risk syscalls. Some essential syscalls are allowed to decrease log noise."
 spec:
   defaultAction: SCMP_ACT_LOG
-  targetWorkload: "generic"
   architectures:
   - SCMP_ARCH_X86_64
   syscalls:

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -39,7 +39,6 @@ metadata:
   name: profile1
 spec:
   defaultAction: SCMP_ACT_LOG
-  targetWorkload: custom-profiles
 ```
 
 This seccomp profile will be saved at the path:
@@ -135,7 +134,6 @@ metadata:
   name: profile1
 spec:
   defaultAction: SCMP_ACT_ERRNO
-  targetWorkload: custom-profiles
   baseProfileName: runc-v1.0.0-rc92
   syscalls:
     - action: SCMP_ACT_ALLOW
@@ -272,10 +270,9 @@ Spec:
       …[other syscalls]…
       mkdir
       …[other syscalls]…
-  Target Workload: my-pod
 Status:
-  Localhost Profile:  operator/security-profiles-operator/my-pod/test-recording-my-pod.json
-  Path:               /var/lib/kubelet/seccomp/operator/security-profiles-operator/my-pod/test-recording-my-pod.json
+  Localhost Profile:  operator/security-profiles-operator/test-recording-my-pod.json
+  Path:               /var/lib/kubelet/seccomp/operator/security-profiles-operator/test-recording-my-pod.json
   Status:             Active
 Events:
   Type    Reason                 Age                From             Message
@@ -333,8 +330,8 @@ two seccomp profiles for each container:
 ```
 > kubectl get sp -o wide
 NAME              STATUS   AGE   LOCALHOSTPROFILE
-recording-nginx   Active   32s   operator/default/my-pod/recording-nginx.json
-recording-redis   Active   32s   operator/default/my-pod/recording-redis.json
+recording-nginx   Active   32s   operator/default/recording-nginx.json
+recording-redis   Active   32s   operator/default/recording-redis.json
 ```
 
 Please note that we encourage you to only use this recording approach for
@@ -366,7 +363,7 @@ I1019 19:34:14.942464       1 main.go:90] setup "msg"="starting security-profile
 I1019 19:34:15.348389       1 listener.go:44] controller-runtime/metrics "msg"="metrics server is starting to listen"  "addr"=":8080"
 I1019 19:34:15.349076       1 main.go:126] setup "msg"="starting manager"
 I1019 19:34:15.349449       1 internal.go:391] controller-runtime/manager "msg"="starting metrics server"  "path"="/metrics"
-I1019 19:34:15.350201       1 controller.go:142] controller "msg"="Starting EventSource" "controller"="profile" "reconcilerGroup"="security-profiles-operator.x-k8s.io" "reconcilerKind"="SeccompProfile" "source"={"Type":{"metadata":{"creationTimestamp":null},"spec":{"targetWorkload":"","defaultAction":""}}}
+I1019 19:34:15.350201       1 controller.go:142] controller "msg"="Starting EventSource" "controller"="profile" "reconcilerGroup"="security-profiles-operator.x-k8s.io" "reconcilerKind"="SeccompProfile" "source"={"Type":{"metadata":{"creationTimestamp":null},"spec":{"defaultAction":""}}}
 I1019 19:34:15.450674       1 controller.go:149] controller "msg"="Starting Controller" "controller"="profile" "reconcilerGroup"="security-profiles-operator.x-k8s.io" "reconcilerKind"="SeccompProfile"
 I1019 19:34:15.450757       1 controller.go:176] controller "msg"="Starting workers" "controller"="profile" "reconcilerGroup"="security-profiles-operator.x-k8s.io" "reconcilerKind"="SeccompProfile" "worker count"=1
 I1019 19:34:15.453102       1 profile.go:148] profile "msg"="Reconciled profile from SeccompProfile" "namespace"="security-profiles-operator" "profile"="nginx-1.19.1" "name"="nginx-1.19.1" "resource version"="728"

--- a/internal/pkg/daemon/profilerecorder/profilerecorder.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder.go
@@ -224,9 +224,6 @@ func (r *RecorderReconciler) collectProfile(ctx context.Context, name types.Name
 				Name:      profileName,
 				Namespace: name.Namespace,
 			},
-			Spec: v1alpha1.SeccompProfileSpec{
-				TargetWorkload: name.Name,
-			},
 		}
 		res, err := controllerutil.CreateOrUpdate(ctx, r.client, profile,
 			func() error {

--- a/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
@@ -145,7 +145,7 @@ func TestSaveProfileOnDisk(t *testing.T) {
 	}{
 		{
 			name:        "CreateDirsAndWriteFile",
-			fileName:    path.Join(dir, "/seccomp/operator/namespace/sp/filename.json"),
+			fileName:    path.Join(dir, "/seccomp/operator/namespace/filename.json"),
 			contents:    "some content",
 			fileCreated: true,
 		},
@@ -209,66 +209,51 @@ func TestGetProfilePath(t *testing.T) {
 	}{
 		{
 			name: "AppendNamespaceAndProfile",
-			want: path.Join(config.ProfilesRootPath, "config-namespace", "config-target", "file.json"),
+			want: path.Join(config.ProfilesRootPath, "config-namespace", "file.json"),
 			sp: &v1alpha1.SeccompProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "file.json",
 					Namespace: "config-namespace",
-				},
-				Spec: v1alpha1.SeccompProfileSpec{
-					TargetWorkload: "config-target",
 				},
 			},
 		},
 		{
 			name: "BlockTraversalAtProfileName",
-			want: path.Join(config.ProfilesRootPath, "ns", "config-target", "file.json"),
+			want: path.Join(config.ProfilesRootPath, "ns", "file.json"),
 			sp: &v1alpha1.SeccompProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "../../../../../file.json",
 					Namespace: "ns",
 				},
-				Spec: v1alpha1.SeccompProfileSpec{
-					TargetWorkload: "config-target",
-				},
 			},
 		},
 		{
 			name: "BlockTraversalAtTargetName",
-			want: path.Join(config.ProfilesRootPath, "ns", "config-target", "file.json"),
+			want: path.Join(config.ProfilesRootPath, "ns", "file.json"),
 			sp: &v1alpha1.SeccompProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "file.json",
 					Namespace: "ns",
 				},
-				Spec: v1alpha1.SeccompProfileSpec{
-					TargetWorkload: "../../../../../config-target",
-				},
 			},
 		},
 		{
 			name: "BlockTraversalAtSPNamespace",
-			want: path.Join(config.ProfilesRootPath, "ns", "config-target", "file.json"),
+			want: path.Join(config.ProfilesRootPath, "ns", "file.json"),
 			sp: &v1alpha1.SeccompProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "file.json",
 					Namespace: "../../../../../ns",
 				},
-				Spec: v1alpha1.SeccompProfileSpec{
-					TargetWorkload: "config-target",
-				},
 			},
 		},
 		{
 			name: "AppendExtension",
-			want: path.Join(config.ProfilesRootPath, "config-namespace", "config-target", "file.json"),
+			want: path.Join(config.ProfilesRootPath, "config-namespace", "file.json"),
 			sp: &v1alpha1.SeccompProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "file",
 					Namespace: "config-namespace",
-				},
-				Spec: v1alpha1.SeccompProfileSpec{
-					TargetWorkload: "config-target",
 				},
 			},
 		},
@@ -279,7 +264,7 @@ func TestGetProfilePath(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, gotErr := GetProfilePath(tc.sp.ObjectMeta.Name, tc.sp.ObjectMeta.Namespace, tc.sp.Spec.TargetWorkload)
+			got, gotErr := GetProfilePath(tc.sp.ObjectMeta.Name, tc.sp.ObjectMeta.Namespace)
 			if tc.wantErr == "" {
 				require.NoError(t, gotErr)
 			} else {
@@ -472,8 +457,8 @@ func TestUnionSyscalls(t *testing.T) {
 func TestGetSeccompProfilesFromPod(t *testing.T) {
 	t.Parallel()
 
-	profilePath := "operator/default/example-profiles/test.json"
-	profilePath2 := "operator/default/example-profiles/test2.json"
+	profilePath := "operator/default/test.json"
+	profilePath2 := "operator/default/test2.json"
 	cases := []struct {
 		name string
 		pod  corev1.Pod
@@ -616,11 +601,11 @@ func TestGetSeccompProfilesFromPod(t *testing.T) {
 	}{
 		{
 			name:    "NoSuffix",
-			profile: "operator/default/example-profiles/test",
+			profile: "operator/default/test",
 		},
 		{
 			name:    "BadSuffix",
-			profile: "operator/default/example-profiles/test.js",
+			profile: "operator/default/test.js",
 		},
 		{
 			name:    "WrongPath",

--- a/internal/pkg/manager/spod/bindata/default_profiles.go
+++ b/internal/pkg/manager/spod/bindata/default_profiles.go
@@ -42,9 +42,8 @@ func DefaultProfiles() []*v1alpha1.SeccompProfile {
 				},
 			},
 			Spec: v1alpha1.SeccompProfileSpec{
-				TargetWorkload: "default-profiles",
-				DefaultAction:  seccomp.ActErrno,
-				Architectures:  []*v1alpha1.Arch{&archX8664, &archX86, &archX32},
+				DefaultAction: seccomp.ActErrno,
+				Architectures: []*v1alpha1.Arch{&archX8664, &archX86, &archX32},
 				Syscalls: []*v1alpha1.Syscall{
 					{
 						Action: seccomp.ActAllow,

--- a/test/tc_base_profiles_test.go
+++ b/test/tc_base_profiles_test.go
@@ -39,7 +39,6 @@ metadata:
   name: hello
 spec:
   defaultAction: SCMP_ACT_ERRNO
-  targetWorkload: hello
   baseProfileName: %s
   syscalls:
   - action: SCMP_ACT_ALLOW
@@ -62,7 +61,7 @@ spec:
   securityContext:
     seccompProfile:
       type: Localhost
-      localhostProfile: operator/%s/hello/hello.json
+      localhostProfile: operator/%s/hello.json
   restartPolicy: Never
 `
 	e.kubectl("create", "-f", baseProfilePath)

--- a/test/tc_default_profiles_test.go
+++ b/test/tc_default_profiles_test.go
@@ -87,7 +87,7 @@ func (e *e2e) verifyBaseProfileContent(node string, cm *v1.ConfigMap) {
 func (e *e2e) verifyCRDProfileContent(node string, sp *v1alpha1.SeccompProfile) {
 	e.logf("Verifying %s profile on node %s", sp.Name, node)
 	name := sp.Name
-	profilePath, err := seccompprofile.GetProfilePath(name, sp.ObjectMeta.Namespace, sp.Spec.TargetWorkload)
+	profilePath, err := seccompprofile.GetProfilePath(name, sp.ObjectMeta.Namespace)
 	e.Nil(err)
 	catOutput := e.execNode(node, "cat", profilePath)
 	output := seccompprofile.OutputProfile{}

--- a/test/tc_delete_profiles_test.go
+++ b/test/tc_delete_profiles_test.go
@@ -33,7 +33,6 @@ metadata:
   name: delete-me
 spec:
   defaultAction: "SCMP_ACT_ALLOW"
-  targetWorkload: "example-profiles"
 `
 		deleteProfileName = "delete-me"
 		deletePod         = `
@@ -48,7 +47,7 @@ spec:
   securityContext:
     seccompProfile:
       type: Localhost
-      localhostProfile: operator/%s/example-profiles/delete-me.json
+      localhostProfile: operator/%s/delete-me.json
 `
 		deletePodSecurityContextInContainer = `
 apiVersion: v1
@@ -62,7 +61,7 @@ spec:
     securityContext:
       seccompProfile:
         type: Localhost
-        localhostProfile: operator/%s/example-profiles/delete-me.json
+        localhostProfile: operator/%s/delete-me.json
 `
 		deletePodSecurityContextInInitContainer = `
 apiVersion: v1
@@ -76,7 +75,7 @@ spec:
     securityContext:
       seccompProfile:
         type: Localhost
-        localhostProfile: operator/%s/example-profiles/delete-me.json
+        localhostProfile: operator/%s/delete-me.json
   containers:
   - name: test-container
     image: quay.io/security-profiles-operator/test-nginx:1.19.1
@@ -87,7 +86,7 @@ kind: Pod
 metadata:
   name: test-pod
   annotations:
-    seccomp.security.alpha.kubernetes.io/pod: 'localhost/operator/%s/example-profiles/delete-me.json'
+    seccomp.security.alpha.kubernetes.io/pod: 'localhost/operator/%s/delete-me.json'
 spec:
   containers:
   - name: test-container
@@ -101,7 +100,7 @@ spec:
 
 	namespace := e.getCurrentContextNamespace(defaultNamespace)
 	sp := e.getSeccompProfile(deleteProfileName, namespace)
-	path, err := seccompprofile.GetProfilePath(deleteProfileName, sp.ObjectMeta.Namespace, sp.Spec.TargetWorkload)
+	path, err := seccompprofile.GetProfilePath(deleteProfileName, sp.ObjectMeta.Namespace)
 	e.Nil(err)
 
 	e.logf("Verifying profile exists")

--- a/test/tc_profilebindings_test.go
+++ b/test/tc_profilebindings_test.go
@@ -99,7 +99,7 @@ spec:
 		"get", "pod", "hello",
 		"--output", "jsonpath={.spec.containers[0].securityContext.seccompProfile.localhostProfile}",
 	)
-	e.Equal(fmt.Sprintf("operator/%s/generic/profile-allow-unsafe.json", namespace), output)
+	e.Equal(fmt.Sprintf("operator/%s/profile-allow-unsafe.json", namespace), output)
 
 	e.logf("Testing that profile binding has pod reference")
 	output = e.kubectl("get", "profilebinding", "hello-binding", "--output", "jsonpath={.status.activeWorkloads[0]}")


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
Most of us felt confused by the field and I think since we do not
support configmaps any more we can remove it.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes #347 
#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed `targetWorkload` field from seccomp profile CRD
```
