### PR TITLE
Do not throw "Profile saved on disk" event if profile not modified

### DIFF
--- a/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
@@ -99,7 +99,7 @@ func TestReconcile(t *testing.T) {
 				},
 				log:    log.Log,
 				record: event.NewNopRecorder(),
-				save:   func(_ string, _ []byte) error { return nil },
+				save:   func(_ string, _ []byte) (bool, error) { return false, nil },
 			},
 			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
 			wantResult: reconcile.Result{},
@@ -184,7 +184,7 @@ func TestSaveProfileOnDisk(t *testing.T) {
 				tc.setup()
 			}
 
-			gotErr := saveProfileOnDisk(tc.fileName, []byte(tc.contents))
+			_, gotErr := saveProfileOnDisk(tc.fileName, []byte(tc.contents))
 			file, _ := os.Stat(tc.fileName) // nolint: errcheck
 			gotFileCreated := file != nil
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
If a seccomp profile has not been modified locally then we do not throw
the event any more. This avoids spamming the event on large clusters.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Throw "profile saved to disk" event only if a profile modification happened on the node.
```
