### PR TITLE
Wait for spod profiles to be reconciled before starting tests

### DIFF
--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -363,9 +363,8 @@ func (r *Reconciler) reconcileSeccompProfile(
 	}
 
 	l.Info(
-		"Reconciled profile from SeccompProfile",
+		"Reconciled SeccompProfile",
 		"resource version", sp.GetResourceVersion(),
-		"name", sp.GetName(),
 	)
 	if updated {
 		evstr := fmt.Sprintf("Successfully saved profile to disk on %s", os.Getenv(config.NodeNameEnvKey))

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -189,6 +189,12 @@ func (e *e2e) deployOperator(manifest string) {
 	// Wait for all pods in DaemonSet
 	time.Sleep(defaultWaitTime)
 	e.waitInOperatorNSFor("condition=ready", "pod", "-l", "app=spod")
+
+	e.retry(func(i int) bool {
+		e.logf("Waiting for initial profiles to be reconciled (%d)", i)
+		output := e.kubectlOperatorNS("logs", "-l", "app=spod")
+		return strings.Contains(output, "Reconciled SeccompProfile")
+	})
 }
 
 func (e *e2e) cleanupOperator(manifest string) {


### PR DESCRIPTION
#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
This should deflake the e2e tests by waiting for the spod to reconcile
the first profiles before starting a test.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
Yes
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
