### PR TITLE
DO NOT MERGE: Log per-node status in e2e tests

### DIFF
--- a/test/tc_base_profiles_test.go
+++ b/test/tc_base_profiles_test.go
@@ -80,15 +80,16 @@ spec:
 	e.kubectl("create", "-f", helloProfileFile.Name())
 	defer e.kubectl("delete", "-f", helloProfileFile.Name())
 
+	namespace := e.getCurrentContextNamespace(defaultNamespace)
+
 	e.logf("Waiting for profile to be reconciled")
-	e.waitFor("condition=ready", "sp", "hello")
+	e.waitForProfileReady("sp", "hello", namespace)
 
 	e.logf("Creating hello-world pod")
 	helloPodFile, err := ioutil.TempFile(os.TempDir(), "hello-pod*.yaml")
 	e.Nil(err)
 	defer os.Remove(helloPodFile.Name())
 
-	namespace := e.getCurrentContextNamespace(defaultNamespace)
 	_, err = helloPodFile.Write([]byte(fmt.Sprintf(helloPod, namespace)))
 	e.Nil(err)
 	err = helloPodFile.Close()

--- a/test/tc_delete_profiles_test.go
+++ b/test/tc_delete_profiles_test.go
@@ -107,7 +107,7 @@ spec:
 	e.Nil(err)
 
 	e.logf("Waiting for profile to be reconciled")
-	e.waitFor("condition=ready", "seccompprofile", deleteProfileName)
+	e.waitForProfileReady("seccompprofile", deleteProfileName, namespace)
 
 	e.logf("Verifying profile exists")
 	time.Sleep(time.Second)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
So far just logs more information so that we get better insight into why
a test is failing.

#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

NONE
```