### PR TITLE
SelinuxProfile: Remove apply flag from CRD

### DIFF
--- a/api/selinuxprofile/v1alpha1/selinuxpolicy_types.go
+++ b/api/selinuxprofile/v1alpha1/selinuxpolicy_types.go
@@ -27,7 +27,6 @@ var _ profilebasev1alpha1.StatusBaseUser = &SelinuxProfile{}
 
 // SelinuxProfileSpec defines the desired state of SelinuxProfile.
 type SelinuxProfileSpec struct {
-	Apply  bool   `json:"apply,omitempty"`
 	Policy string `json:"policy,omitempty"`
 }
 
@@ -45,7 +44,6 @@ type SelinuxProfileStatus struct {
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=selinuxprofiles,scope=Namespaced
 // +kubebuilder:printcolumn:name="Usage",type="string",JSONPath=`.status.usage`
-// +kubebuilder:printcolumn:name="Apply",type="boolean",JSONPath=`.spec.apply`
 // +kubebuilder:printcolumn:name="State",type="string",JSONPath=`.status.status`
 type SelinuxProfile struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/deploy/base/crd.yaml
+++ b/deploy/base/crd.yaml
@@ -476,9 +476,6 @@ spec:
     - jsonPath: .status.usage
       name: Usage
       type: string
-    - jsonPath: .spec.apply
-      name: Apply
-      type: boolean
     - jsonPath: .status.status
       name: State
       type: string
@@ -502,8 +499,6 @@ spec:
           spec:
             description: SelinuxProfileSpec defines the desired state of SelinuxProfile.
             properties:
-              apply:
-                type: boolean
               policy:
                 type: string
             type: object

--- a/deploy/base/crds/selinuxpolicy.yaml
+++ b/deploy/base/crds/selinuxpolicy.yaml
@@ -20,9 +20,6 @@ spec:
     - jsonPath: .status.usage
       name: Usage
       type: string
-    - jsonPath: .spec.apply
-      name: Apply
-      type: boolean
     - jsonPath: .status.status
       name: State
       type: string
@@ -46,8 +43,6 @@ spec:
           spec:
             description: SelinuxProfileSpec defines the desired state of SelinuxProfile.
             properties:
-              apply:
-                type: boolean
               policy:
                 type: string
             type: object

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -679,9 +679,6 @@ spec:
     - jsonPath: .status.usage
       name: Usage
       type: string
-    - jsonPath: .spec.apply
-      name: Apply
-      type: boolean
     - jsonPath: .status.status
       name: State
       type: string
@@ -705,8 +702,6 @@ spec:
           spec:
             description: SelinuxProfileSpec defines the desired state of SelinuxProfile.
             properties:
-              apply:
-                type: boolean
               policy:
                 type: string
             type: object

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -679,9 +679,6 @@ spec:
     - jsonPath: .status.usage
       name: Usage
       type: string
-    - jsonPath: .spec.apply
-      name: Apply
-      type: boolean
     - jsonPath: .status.status
       name: State
       type: string
@@ -705,8 +702,6 @@ spec:
           spec:
             description: SelinuxProfileSpec defines the desired state of SelinuxProfile.
             properties:
-              apply:
-                type: boolean
               policy:
                 type: string
             type: object

--- a/examples/selinuxprofile.yaml
+++ b/examples/selinuxprofile.yaml
@@ -3,7 +3,6 @@ kind: SelinuxProfile
 metadata:
   name: errorlogger
 spec:
-  apply: true
   policy: |
     (blockinherit container)
     (allow process var_log_t ( dir ( open read getattr lock search ioctl add_name remove_name write ))) 

--- a/test/tc_selinux_base_usage_test.go
+++ b/test/tc_selinux_base_usage_test.go
@@ -60,7 +60,6 @@ kind: SelinuxProfile
 metadata:
   name: errorlogger
 spec:
-  apply: true
   policy: |
     (blockinherit container)
     (allow process var_log_t ( dir ( open read getattr lock search ioctl add_name remove_name write ))) 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Removes the `apply` flag from SelinuxProfile objects since it was not being
used and its usecase is not that useful after all.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A.

#### Does this PR introduce a user-facing change?

```release-note
The SelinuxProfile CRD no longer has the `apply` flag in the `spec`.
```