### PR TITLE
Run `make image` on ubuntu 18.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
           verbose: true
 
   image:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - run: make image


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Uses ubuntu 18.04 as the github actions image to run `make image` for running
e2e tests.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```