### PR TITLE
Remove `custom-profiles` path within docs

### DIFF
--- a/installation-usage.md
+++ b/installation-usage.md
@@ -50,7 +50,7 @@ spec:
 
 This seccomp profile will be saved at the path:
 
-`/var/lib/kubelet/seccomp/operator/my-namespace/custom-profiles/profile1.json`.
+`/var/lib/kubelet/seccomp/operator/my-namespace/profile1.json`.
 
 An init container will set up the root directory of the operator to be able to
 run it without root G/UID. This will be done by creating a symlink from the
@@ -71,7 +71,7 @@ spec:
   securityContext:
     seccompProfile:
       type: Localhost
-      localhostProfile: operator/my-namespace/custom-profiles/profile1.json
+      localhostProfile: operator/my-namespace/profile1.json
   containers:
     - name: test-container
       image: nginx
@@ -85,7 +85,7 @@ kind: Pod
 metadata:
   name: test-pod
   annotations:
-    seccomp.security.alpha.kubernetes.io/pod: "localhost/operator/my-namespace/custom-profiles/profile1.json"
+    seccomp.security.alpha.kubernetes.io/pod: "localhost/operator/my-namespace/profile1.json"
 spec:
   containers:
     - name: test-container
@@ -98,7 +98,7 @@ You can find the profile path of the seccomp profile by checking the
 ```sh
 $ kubectl --namespace my-namespace get seccompprofile profile1 --output wide
 NAME       STATUS   AGE   SECCOMPPROFILE.LOCALHOSTPROFILE
-profile1   Active   14s   operator/my-namespace/custom-profiles/profile1.json
+profile1   Active   14s   operator/my-namespace/profile1.json
 ```
 
 You can apply the profile to an existing application, such as a Deployment or
@@ -116,7 +116,7 @@ profile was applied correctly:
 $ kubectl --namespace my-namespace get deployment myapp --output=jsonpath='{.spec.template.spec.securityContext}' | jq .
 {
   "seccompProfile": {
-    "localhostProfile": "operator/my-namespace/custom-profiles/profile1.json",
+    "localhostProfile": "operator/my-namespace/profile1.json",
     "type": "Localhost"
   }
 }


### PR DESCRIPTION

#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
The docs needs to be updated to remove this additional path, since we
removed it a while ago.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Removed additional `custom-profiles` seccomp path from installation manual.
```
