### PR TITLE
Merge metrics endpoints for using different paths

### DIFF
--- a/deploy/base/metrics_client.yaml
+++ b/deploy/base/metrics_client.yaml
@@ -6,6 +6,7 @@ metadata:
 rules:
 - nonResourceURLs:
   - /metrics
+  - /metrics-spod
   verbs:
   - get
 ---

--- a/deploy/base/service.yaml
+++ b/deploy/base/service.yaml
@@ -14,25 +14,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: metrics-controller-runtime
+  name: metrics
   namespace: security-profiles-operator
 spec:
   ports:
   - name: https
     port: 443
-    targetPort: 8442
-  selector:
-    name: spod
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: metrics-spod
-  namespace: security-profiles-operator
-spec:
-  ports:
-  - name: https
-    port: 443
-    targetPort: 8443
+    targetPort: 9443
   selector:
     name: spod

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1546,29 +1546,13 @@ kind: Service
 metadata:
   labels:
     app: security-profiles-operator
-  name: metrics-controller-runtime
+  name: metrics
   namespace: security-profiles-operator
 spec:
   ports:
   - name: https
     port: 443
-    targetPort: 8442
-  selector:
-    app: security-profiles-operator
-    name: spod
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: security-profiles-operator
-  name: metrics-spod
-  namespace: security-profiles-operator
-spec:
-  ports:
-  - name: https
-    port: 443
-    targetPort: 8443
+    targetPort: 9443
   selector:
     app: security-profiles-operator
     name: spod
@@ -1582,6 +1566,7 @@ metadata:
 rules:
 - nonResourceURLs:
   - /metrics
+  - /metrics-spod
   verbs:
   - get
 ---

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1544,29 +1544,13 @@ kind: Service
 metadata:
   labels:
     app: security-profiles-operator
-  name: metrics-controller-runtime
+  name: metrics
   namespace: security-profiles-operator
 spec:
   ports:
   - name: https
     port: 443
-    targetPort: 8442
-  selector:
-    app: security-profiles-operator
-    name: spod
----
-apiVersion: v1
-kind: Service
-metadata:
-  labels:
-    app: security-profiles-operator
-  name: metrics-spod
-  namespace: security-profiles-operator
-spec:
-  ports:
-  - name: https
-    port: 443
-    targetPort: 8443
+    targetPort: 9443
   selector:
     app: security-profiles-operator
     name: spod
@@ -1580,6 +1564,7 @@ metadata:
 rules:
 - nonResourceURLs:
   - /metrics
+  - /metrics-spod
   verbs:
   - get
 ---

--- a/internal/pkg/daemon/metrics/metrics.go
+++ b/internal/pkg/daemon/metrics/metrics.go
@@ -37,6 +37,9 @@ const (
 	metricLabelValueSeccompProfileUpdate = "update"
 	metricLabelValueSeccompProfileDelete = "delete"
 	metricLabelOperation                 = "operation"
+
+	// HandlerPath is the default path for serving metrics.
+	HandlerPath = "/metrics-spod"
 )
 
 // Metrics is the main structure of this package.
@@ -75,18 +78,11 @@ func (m *Metrics) Register() error {
 	return nil
 }
 
-// Serve creates an HTTP endpoint "/metrics" and starts serving them.
-func (m *Metrics) Serve() error {
-	const (
-		addr = ":8081" // controller-runtime is already serving metrics on :8080
-		path = "/metrics"
-	)
-	m.log.Info(fmt.Sprintf("Serving metrics on %s%s", addr, path))
-
+// Handler creates an HTTP handler for the metrics.
+func (m *Metrics) Handler() http.Handler {
 	handler := &http.ServeMux{}
-	handler.Handle(path, promhttp.Handler())
-	err := m.impl.ListenAndServe(addr, handler)
-	return errors.Wrap(err, "serve metrics")
+	handler.Handle(HandlerPath, promhttp.Handler())
+	return handler
 }
 
 // IncSeccompProfileUpdate increments the seccomp profile update counter.

--- a/internal/pkg/daemon/metrics/metrics_test.go
+++ b/internal/pkg/daemon/metrics/metrics_test.go
@@ -61,38 +61,6 @@ func TestRegister(t *testing.T) {
 	}
 }
 
-func TestServe(t *testing.T) {
-	t.Parallel()
-	for _, tc := range []struct {
-		prepare   func(*metricsfakes.FakeImpl)
-		shouldErr bool
-	}{
-		{ // success
-			prepare: func(*metricsfakes.FakeImpl) {},
-		},
-		{ // error ListenAndServe fails
-			prepare: func(mock *metricsfakes.FakeImpl) {
-				mock.ListenAndServeReturns(errTest)
-			},
-			shouldErr: true,
-		},
-	} {
-		mock := &metricsfakes.FakeImpl{}
-		tc.prepare(mock)
-
-		sut := New()
-		sut.impl = mock
-
-		err := sut.Serve()
-
-		if tc.shouldErr {
-			require.NotNil(t, err)
-		} else {
-			require.Nil(t, err)
-		}
-	}
-}
-
 func TestSeccompProfile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -362,7 +362,6 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 	templateSpec.Containers = append(
 		templateSpec.Containers,
 		r.baseSPOd.Spec.Template.Spec.Containers[3],
-		r.baseSPOd.Spec.Template.Spec.Containers[4],
 	)
 
 	// Set image pull policy


### PR DESCRIPTION
#### What type of PR is this?


/kind feature
/kind design

#### What this PR does / why we need it:
We now use the additional handler from the controller runtime to serve
the metrics under a new path `/metrics-spod`. This way we can ensure
having only one service and one kube-rbac-proxy instance.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #276 
#### Does this PR have test?

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
