### PR TITLE
Add liveness/startup probe to SPOD

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -348,7 +348,8 @@ func runDaemon(ctx *cli.Context) error {
 	sigHandler := ctrl.SetupSignalHandler()
 
 	ctrlOpts := ctrl.Options{
-		SyncPeriod: &sync,
+		SyncPeriod:             &sync,
+		HealthProbeBindAddress: fmt.Sprintf(":%d", config.HealthProbePort),
 	}
 
 	setControllerOptionsForNamespaces(&ctrlOpts)
@@ -449,6 +450,10 @@ func setupEnabledControllers(
 
 		if err := enableCtrl.Setup(ctx, mgr, ctrl.Log.WithName(enableCtrl.Name()), met); err != nil {
 			return errors.Wrapf(err, "setup %s controller", enableCtrl.Name())
+		}
+
+		if err := mgr.AddHealthzCheck(enableCtrl.Name(), enableCtrl.Healthz); err != nil {
+			return errors.Wrap(err, "add readiness check to controller")
 		}
 	}
 

--- a/internal/pkg/atomic/bool.go
+++ b/internal/pkg/atomic/bool.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package atomic
+
+import "sync/atomic"
+
+// Bool is an atomic boolean type.
+type Bool int32
+
+// Set can be used to set the atomic bool to a certain value.
+func (b *Bool) Set(yes bool) {
+	var value int32 = 0
+	if yes {
+		value = 1
+	}
+	atomic.StoreInt32((*int32)(b), value)
+}
+
+// Get can be used to retrieve the set value.
+func (b *Bool) Get() bool {
+	return atomic.LoadInt32((*int32)(b))&1 == 1
+}

--- a/internal/pkg/atomic/bool_test.go
+++ b/internal/pkg/atomic/bool_test.go
@@ -1,0 +1,39 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package atomic
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test(t *testing.T) {
+	t.Parallel()
+
+	var sut Bool
+	require.False(t, sut.Get())
+
+	sut.Set(false)
+	require.False(t, sut.Get())
+
+	sut.Set(true)
+	require.True(t, sut.Get())
+
+	sut.Set(false)
+	require.False(t, sut.Get())
+}

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -61,6 +61,9 @@ const (
 	// triggers the oci-seccomp-bpf-hook to trace the syscalls of a Pod and
 	// created a seccomp profile.
 	SeccompProfileRecordAnnotationKey = "io.containers.trace-syscall"
+
+	// HealthProbePort is the port where the liveness probe will be served.
+	HealthProbePort = 8085
 )
 
 // ProfileRecordingOutputPath is the path where the recorded profiles will be

--- a/internal/pkg/controller/controller.go
+++ b/internal/pkg/controller/controller.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/go-logr/logr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -36,4 +37,7 @@ type Controller interface {
 
 	// Setup is the initialization of the controller.
 	Setup(context.Context, ctrl.Manager, logr.Logger, *metrics.Metrics) error
+
+	// Healthz is the liveness probe endpoint of the controller.
+	Healthz(*http.Request) error
 }

--- a/internal/pkg/daemon/profilerecorder/profilerecorder.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -138,6 +139,11 @@ func (r *RecorderReconciler) Setup(
 		)).
 		For(&corev1.Pod{}).
 		Complete(r)
+}
+
+// Healthz is the liveness probe endpoint of the controller.
+func (r *RecorderReconciler) Healthz(*http.Request) error {
+	return nil
 }
 
 func (r *RecorderReconciler) isPodOnLocalNode(obj runtime.Object) bool {

--- a/internal/pkg/daemon/selinuxprofile/selinuxpolicy_controller.go
+++ b/internal/pkg/daemon/selinuxprofile/selinuxpolicy_controller.go
@@ -113,6 +113,11 @@ func (r *ReconcileSP) SchemeBuilder() *scheme.Builder {
 	return selinuxprofilev1alpha1.SchemeBuilder
 }
 
+// Healthz is the liveness probe endpoint of the controller.
+func (r *ReconcileSP) Healthz(*http.Request) error {
+	return nil
+}
+
 // Security Profiles Operator RBAC permissions to manage SelinuxProfile
 // nolint:lll
 // +kubebuilder:rbac:groups=security-profiles-operator.x-k8s.io,resources=selinuxprofiles,verbs=get;list;watch;create;update;patch


### PR DESCRIPTION
#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
We now add a liveness probe for giving the SPOD more time on startup to
become ready. Every controller should at least run one `Reconile` to be
marked as ready.

We now also add a new interface `Controller`
(`internal/pkg/controller/controller.go`), which has to be fulfilled by
every SPOD controller. This allows to simplify the implementation in
`main`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added liveness and startup probe to operator daemon set to streamline the operator stratup.
```
