### PR TITLE
Make profilerecording gathering more resilient

### DIFF
--- a/internal/pkg/daemon/profilerecorder/profilerecorder.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder.go
@@ -161,7 +161,7 @@ func (r *RecorderReconciler) Reconcile(_ context.Context, req reconcile.Request)
 	if err := r.client.Get(ctx, req.NamespacedName, pod); err != nil {
 		if kerrors.IsNotFound(err) {
 			if err := r.collectProfile(ctx, req.NamespacedName); err != nil {
-				return reconcile.Result{}, nil
+				return reconcile.Result{}, err
 			}
 		} else {
 			// Returning an error means we will be requeued implicitly.
@@ -194,7 +194,7 @@ func (r *RecorderReconciler) Reconcile(_ context.Context, req reconcile.Request)
 
 	if pod.Status.Phase == corev1.PodSucceeded {
 		if err := r.collectProfile(ctx, req.NamespacedName); err != nil {
-			return reconcile.Result{}, nil
+			return reconcile.Result{}, err
 		}
 	}
 

--- a/internal/pkg/daemon/profilerecorder/profilerecorder.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder.go
@@ -161,7 +161,7 @@ func (r *RecorderReconciler) Reconcile(_ context.Context, req reconcile.Request)
 	if err := r.client.Get(ctx, req.NamespacedName, pod); err != nil {
 		if kerrors.IsNotFound(err) {
 			if err := r.collectProfile(ctx, req.NamespacedName); err != nil {
-				return reconcile.Result{}, err
+				return reconcile.Result{}, errors.Wrap(err, "collect profile for removed pod")
 			}
 		} else {
 			// Returning an error means we will be requeued implicitly.
@@ -194,7 +194,7 @@ func (r *RecorderReconciler) Reconcile(_ context.Context, req reconcile.Request)
 
 	if pod.Status.Phase == corev1.PodSucceeded {
 		if err := r.collectProfile(ctx, req.NamespacedName); err != nil {
-			return reconcile.Result{}, err
+			return reconcile.Result{}, errors.Wrap(err, "collect profile for succeeded pod")
 		}
 	}
 


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

This will retry if there's an error getting the profile recording.

It could be that the profile recording gets collected while the hook is
still writing it. So let's try to be more resilient with this. If the
user notices a lot of errors they'll have to delete the recording
object.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```