### PR TITLE
Use systemd cgroup manager for e2e tests

### DIFF
--- a/hack/ci/install-cri-o.sh
+++ b/hack/ci/install-cri-o.sh
@@ -40,12 +40,6 @@ cat <<EOT >>/etc/crio/crio.conf.d/30-selinux.conf
 selinux = true
 EOT
 
-cat <<EOT >>/etc/crio/crio.conf.d/30-cgroup-manager.conf
-[crio.runtime]
-conmon_cgroup = "pod"
-cgroup_manager = "cgroupfs"
-EOT
-
 chcon -R -u system_u -r object_r -t container_config_t \
     /etc/crio \
     /etc/crio/crio.conf \

--- a/hack/ci/install-kubernetes.sh
+++ b/hack/ci/install-kubernetes.sh
@@ -36,7 +36,7 @@ download-kubernetes() {
 local-up() {
     export PATH="$GOPATH/src/k8s.io/kubernetes/third_party/etcd:$PATH"
     export CONTAINER_RUNTIME=remote
-    export CGROUP_DRIVER=cgroupfs
+    export CGROUP_DRIVER=systemd
     export CONTAINER_RUNTIME_ENDPOINT=/var/run/crio/crio.sock
     export ALLOW_PRIVILEGED=1
 


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Systemd is the recommended cgroup manager. This should fix the fedora 34 issues with the OCI seccomp BPF hook.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes-sigs/security-profiles-operator/pull/431
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
