### PR TITLE
Set resource version for SPOD update

### DIFF
--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -281,6 +281,9 @@ func (r *ReconcileSPOd) handleUpdate(
 		foundProfile := &sccmpv1alpha1.SeccompProfile{}
 		var err error
 		if err = r.client.Get(ctx, pKey, foundProfile); err == nil {
+			// Set the resource version for an update, otherwise it would fail.
+			profile.SetResourceVersion(foundProfile.GetResourceVersion())
+
 			if updateErr := r.client.Update(ctx, profile); updateErr != nil {
 				return errors.Wrapf(
 					updateErr, "updating operator default profile %s", profile.Name,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
Every update would fail because the resource version won't be set. This patch fixes this corner case.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed SPOD update bug for default profiles where resource version is not set.
```
