### PR TITLE
Use single TLS certificate/key for serving metrics

### DIFF
--- a/deploy/base/certificate.yaml
+++ b/deploy/base/certificate.yaml
@@ -20,3 +20,21 @@ spec:
     kind: Issuer
     name: selfsigned-issuer
   secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: metrics-cert
+  namespace: security-profiles-operator
+spec:
+  subject:
+    organizations:
+    - security-profiles-operator
+  dnsNames:
+  - metrics.security-profiles-operator
+  - metrics.security-profiles-operator.svc
+  - metrics.security-profiles-operator.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1533,6 +1533,26 @@ spec:
     name: selfsigned-issuer
   secretName: webhook-server-cert
 ---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: security-profiles-operator
+  name: metrics-cert
+  namespace: security-profiles-operator
+spec:
+  dnsNames:
+  - metrics.security-profiles-operator
+  - metrics.security-profiles-operator.svc
+  - metrics.security-profiles-operator.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert
+  subject:
+    organizations:
+    - security-profiles-operator
+---
 apiVersion: v1
 kind: Service
 metadata:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1531,6 +1531,26 @@ spec:
     name: selfsigned-issuer
   secretName: webhook-server-cert
 ---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: security-profiles-operator
+  name: metrics-cert
+  namespace: security-profiles-operator
+spec:
+  dnsNames:
+  - metrics.security-profiles-operator
+  - metrics.security-profiles-operator.svc
+  - metrics.security-profiles-operator.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert
+  subject:
+    organizations:
+    - security-profiles-operator
+---
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This allows to use the CA certificate for metrics access without having
to insecure the TLS connection.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added single TLS certificate for serving metrics. See `installation-usage.md` for more details.
```
