### PR TITLE
Add metrics-token secret to deployment

### DIFF
--- a/deploy/base/metrics_client.yaml
+++ b/deploy/base/metrics_client.yaml
@@ -22,3 +22,12 @@ subjects:
 - kind: ServiceAccount
   name: default
   namespace: security-profiles-operator
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: metrics-token
+  namespace: security-profiles-operator
+  annotations:
+    kubernetes.io/service-account.name: default
+type: kubernetes.io/service-account-token

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1613,6 +1613,17 @@ subjects:
   namespace: security-profiles-operator
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: default
+  labels:
+    app: security-profiles-operator
+  name: metrics-token
+  namespace: security-profiles-operator
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
 data:
   security-profiles-operator.json: |
     {

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1611,6 +1611,17 @@ subjects:
   namespace: security-profiles-operator
 ---
 apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    kubernetes.io/service-account.name: default
+  labels:
+    app: security-profiles-operator
+  name: metrics-token
+  namespace: security-profiles-operator
+type: kubernetes.io/service-account-token
+---
+apiVersion: v1
 data:
   security-profiles-operator.json: |
     {


### PR DESCRIPTION
#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
This allows referencing the metrics token from a stable secret name.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #276 
#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `metrics-token` secret to the operator namespace for metrics client retrieval.
```
