### PR TITLE
Add seccomp error metrics

### DIFF
--- a/installation-usage.md
+++ b/installation-usage.md
@@ -469,9 +469,10 @@ The controller-runtime (`/metrics`) as well as the DaemonSet endpoint
 additional metrics are provided by the daemon, which are always prefixed with
 `security_profiles_operator_`:
 
-| Metric Key              | Possible Labels             | Type    | Purpose                               |
-| ----------------------- | --------------------------- | ------- | ------------------------------------- |
-| `seccomp_profile_total` | `operation={delete,update}` | Counter | Amount of seccomp profile operations. |
+| Metric Key                    | Possible Labels                                                                                                                                                                                            | Type    | Purpose                               |
+| ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------- |
+| `seccomp_profile_total`       | `operation={delete,update}`                                                                                                                                                                                | Counter | Amount of seccomp profile operations. |
+| `seccomp_profile_error_total` | `reason={`<br>`SeccompNotSupportedOnNode,`<br>`InvalidSeccompProfile,`<br>`CannotSaveSeccompProfile,`<br>`CannotRemoveSeccompProfile,`<br>`CannotUpdateSeccompProfile,`<br>`CannotUpdateNodeStatus`<br>`}` | Counter | Amount of seccomp profile errors.     |
 
 ## Automatic ServiceMonitor deployment
 

--- a/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
@@ -38,6 +38,7 @@ import (
 
 	"sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1alpha1"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/metrics"
 )
 
 func TestReconcile(t *testing.T) {
@@ -69,7 +70,8 @@ func TestReconcile(t *testing.T) {
 				client: &test.MockClient{
 					MockGet: test.NewMockGetFn(kerrors.NewNotFound(schema.GroupResource{}, name)),
 				},
-				log: log.Log,
+				log:     log.Log,
+				metrics: metrics.New(),
 			},
 			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
 			wantResult: reconcile.Result{},
@@ -81,8 +83,9 @@ func TestReconcile(t *testing.T) {
 				client: &test.MockClient{
 					MockGet: test.NewMockGetFn(errOops),
 				},
-				record: event.NewNopRecorder(),
-				log:    log.Log,
+				record:  event.NewNopRecorder(),
+				log:     log.Log,
+				metrics: metrics.New(),
 			},
 			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
 			wantResult: reconcile.Result{},
@@ -96,9 +99,10 @@ func TestReconcile(t *testing.T) {
 					MockUpdate:       test.NewMockUpdateFn(nil),
 					MockStatusUpdate: test.NewMockStatusUpdateFn(nil),
 				},
-				log:    log.Log,
-				record: event.NewNopRecorder(),
-				save:   func(_ string, _ []byte) (bool, error) { return false, nil },
+				log:     log.Log,
+				record:  event.NewNopRecorder(),
+				save:    func(_ string, _ []byte) (bool, error) { return false, nil },
+				metrics: metrics.New(),
 			},
 			req:        reconcile.Request{NamespacedName: types.NamespacedName{Namespace: namespace, Name: name}},
 			wantResult: reconcile.Result{},

--- a/test/tc_metrics_test.go
+++ b/test/tc_metrics_test.go
@@ -28,7 +28,7 @@ func (e *e2e) testCaseMetrics(nodes []string) {
 
 	const (
 		curlCMD         = "curl -ks -H \"Authorization: Bearer `cat /var/run/secrets/kubernetes.io/serviceaccount/token`\" "
-		metricsURL      = "https://metrics/"
+		metricsURL      = "https://metrics.security-profiles-operator/"
 		curlSpodCMD     = curlCMD + metricsURL + "metrics-spod"
 		curlCtrlCMD     = curlCMD + metricsURL + "metrics"
 		profileName     = "metrics-profile"
@@ -57,7 +57,7 @@ spec:
 	e.waitFor("condition=ready", "sp", profileName)
 
 	e.logf("Deleting test profile")
-	e.kubectl("delete", "sp", profileName, "--wait=0")
+	e.kubectl("delete", "sp", profileName)
 
 	e.logf("Retrieving controller runtime metrics")
 	outputCtrl := e.kubectlRunOperatorNS("pod", "--", "bash", "-c", curlCtrlCMD)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
We now provide metrics about seccomp profile errors, while mapping the
event reasons to a label.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #276 
#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `seccomp_profile_error_total` metrics.
```
