### PR TITLE
WIP: Move log enricher into daemon

### DIFF
--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -27,9 +27,6 @@ type SPODSpec struct {
 	// tells the operator whether or not to enable SELinux support for this
 	// SPOD instance.
 	EnableSelinux bool `json:"enableSelinux,omitempty"`
-	// tells the operator whether or not to enable log enrichment support for this
-	// SPOD instance.
-	EnableLogEnricher bool `json:"enableLogEnricher,omitempty"`
 	// If specified, the SPOD's tolerations.
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`

--- a/deploy/base/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base/crds/securityprofilesoperatordaemon.yaml
@@ -43,10 +43,6 @@ spec:
           spec:
             description: SPODStatus defines the desired state of SPOD.
             properties:
-              enableLogEnricher:
-                description: tells the operator whether or not to enable log enrichment
-                  support for this SPOD instance.
-                type: boolean
               enableSelinux:
                 description: tells the operator whether or not to enable SELinux support
                   for this SPOD instance.

--- a/deploy/base/profiles/security-profiles-operator.json
+++ b/deploy/base/profiles/security-profiles-operator.json
@@ -41,6 +41,7 @@
         "inotify_add_watch",
         "inotify_init1",
         "listen",
+        "lseek",
         "madvise",
         "membarrier",
         "mkdirat",

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -555,10 +555,6 @@ spec:
           spec:
             description: SPODStatus defines the desired state of SPOD.
             properties:
-              enableLogEnricher:
-                description: tells the operator whether or not to enable log enrichment
-                  support for this SPOD instance.
-                type: boolean
               enableSelinux:
                 description: tells the operator whether or not to enable SELinux support
                   for this SPOD instance.
@@ -1681,6 +1677,7 @@ data:
             "inotify_add_watch",
             "inotify_init1",
             "listen",
+            "lseek",
             "madvise",
             "membarrier",
             "mkdirat",

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -555,10 +555,6 @@ spec:
           spec:
             description: SPODStatus defines the desired state of SPOD.
             properties:
-              enableLogEnricher:
-                description: tells the operator whether or not to enable log enrichment
-                  support for this SPOD instance.
-                type: boolean
               enableSelinux:
                 description: tells the operator whether or not to enable SELinux support
                   for this SPOD instance.
@@ -1679,6 +1675,7 @@ data:
             "inotify_add_watch",
             "inotify_init1",
             "listen",
+            "lseek",
             "madvise",
             "membarrier",
             "mkdirat",

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -64,6 +64,12 @@ const (
 
 	// HealthProbePort is the port where the liveness probe will be served.
 	HealthProbePort = 8085
+
+	// DevKmsgPath is the path to the kernel log messages.
+	DevKmsgPath = "/dev/kmsg"
+
+	// EnricherLogFile is the path to the kernel messages log file used for the enricher.
+	EnricherLogFile = "/var/log/spo/spo.log"
 )
 
 // ProfileRecordingOutputPath is the path where the recorded profiles will be

--- a/internal/pkg/daemon/enricher/container.go
+++ b/internal/pkg/daemon/enricher/container.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -86,7 +87,7 @@ func containerIDRaw(containerID string) (string, error) {
 	return "", errors.Wrap(errUnsupportedContainerRuntime, containerID)
 }
 
-func getContainerID(processID int) string {
+func getContainerID(logger logr.Logger, processID int) string {
 	cgroupFile := fmt.Sprintf("/proc/%d/cgroup", processID)
 	file, err := os.Open(filepath.Clean(cgroupFile))
 	if err != nil {

--- a/internal/pkg/manager/spod/setup.go
+++ b/internal/pkg/manager/spod/setup.go
@@ -43,9 +43,8 @@ const (
 // daemonTunables defines the parameters to tune/modify for the
 // Security-Profiles-Operator-Daemon.
 type daemonTunables struct {
-	selinuxdImage    string
-	logEnricherImage string
-	watchNamespace   string
+	selinuxdImage  string
+	watchNamespace string
 }
 
 // Setup adds a controller that reconciles the SPOd DaemonSet.
@@ -87,8 +86,7 @@ func (r *ReconcileSPOd) createConfigIfNotExist(ctx context.Context) error {
 			Labels:    map[string]string{"app": config.OperatorName},
 		},
 		Spec: spodv1alpha1.SPODSpec{
-			EnableSelinux:     false,
-			EnableLogEnricher: false,
+			EnableSelinux: false,
 			Tolerations: []corev1.Toleration{
 				{
 					Key:      "node-role.kubernetes.io/master",
@@ -143,9 +141,6 @@ func getEffectiveSPOd(dt *daemonTunables) *appsv1.DaemonSet {
 
 	selinuxd := &refSPOd.Spec.Template.Spec.Containers[1]
 	selinuxd.Image = dt.selinuxdImage
-
-	logEnricher := &refSPOd.Spec.Template.Spec.Containers[2]
-	logEnricher.Image = dt.logEnricherImage
 
 	sepolImage := &refSPOd.Spec.Template.Spec.InitContainers[1]
 	sepolImage.Image = dt.selinuxdImage // selinuxd ships the policies as well

--- a/internal/pkg/manager/spod/setup_test.go
+++ b/internal/pkg/manager/spod/setup_test.go
@@ -35,13 +35,13 @@ func Test_getEffectiveSPOd(t *testing.T) {
 	}{
 		{
 			"Should correctly set the image",
-			daemonTunables{"foo:bar", "bar:baz", "brot:wurst"},
+			daemonTunables{"foo:bar", "bar:baz"},
 			false,
 			false,
 		},
 		{
 			"Should correctly set the namespace",
-			daemonTunables{"foo:bar", "bar:baz", "brot:wurst"},
+			daemonTunables{"foo:bar", "bar:baz"},
 			true,
 			false,
 		},
@@ -53,7 +53,6 @@ func Test_getEffectiveSPOd(t *testing.T) {
 			os.Setenv("OPERATOR_NAMESPACE", "default")
 			got := getEffectiveSPOd(&tt.dt)
 			require.Equal(t, tt.dt.selinuxdImage, got.Spec.Template.Spec.Containers[1].Image)
-			require.Equal(t, tt.dt.logEnricherImage, got.Spec.Template.Spec.Containers[2].Image)
 			var found bool
 			for _, env := range got.Spec.Template.Spec.Containers[0].Env {
 				if env.Name == config.RestrictNamespaceEnvKey {

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -403,22 +403,10 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 			"--with-selinux=true")
 	}
 
-	// Log enricher parameters
-	if cfg.Spec.EnableLogEnricher {
-		templateSpec.Containers = append(
-			templateSpec.Containers,
-			r.baseSPOd.Spec.Template.Spec.Containers[2])
-		templateSpec.Containers[2].Image = image
-
-		// HostPID is only required for the log-enricher
-		// and is used to access cgroup files to map Process IDs to Pod IDs
-		templateSpec.HostPID = true
-	}
-
 	// Metrics parameters
 	templateSpec.Containers = append(
 		templateSpec.Containers,
-		r.baseSPOd.Spec.Template.Spec.Containers[3],
+		r.baseSPOd.Spec.Template.Spec.Containers[2],
 	)
 
 	// Set image pull policy

--- a/internal/pkg/nonrootenabler/nonrootenabler_test.go
+++ b/internal/pkg/nonrootenabler/nonrootenabler_test.go
@@ -57,16 +57,41 @@ func TestRun(t *testing.T) {
 			},
 			shouldError: true,
 		},
-		{ // failure on Symlink
+		{ // failure on Chmod 0
 			prepare: func(mock *nonrootenablerfakes.FakeImpl) {
-				mock.StatReturns(nil, os.ErrNotExist)
+				mock.ChmodReturnsOnCall(0, errTest)
+			},
+			shouldError: true,
+		},
+		{ // failure on Chmod 1
+			prepare: func(mock *nonrootenablerfakes.FakeImpl) {
+				mock.ChmodReturnsOnCall(1, errTest)
+			},
+			shouldError: true,
+		},
+		{ // failure on Symlink 0
+			prepare: func(mock *nonrootenablerfakes.FakeImpl) {
+				mock.StatReturnsOnCall(0, nil, os.ErrNotExist)
 				mock.SymlinkReturns(errTest)
 			},
 			shouldError: true,
 		},
-		{ // failure on Chown
+		{ // failure on Symlink 1
 			prepare: func(mock *nonrootenablerfakes.FakeImpl) {
-				mock.ChownReturns(errTest)
+				mock.StatReturnsOnCall(1, nil, os.ErrNotExist)
+				mock.SymlinkReturns(errTest)
+			},
+			shouldError: true,
+		},
+		{ // failure on Chown 0
+			prepare: func(mock *nonrootenablerfakes.FakeImpl) {
+				mock.ChownReturnsOnCall(0, errTest)
+			},
+			shouldError: true,
+		},
+		{ // failure on Chown 1
+			prepare: func(mock *nonrootenablerfakes.FakeImpl) {
+				mock.ChownReturnsOnCall(1, errTest)
 			},
 			shouldError: true,
 		},
@@ -79,6 +104,18 @@ func TestRun(t *testing.T) {
 		{ // failure on MkdirAll with OperatorRoot
 			prepare: func(mock *nonrootenablerfakes.FakeImpl) {
 				mock.MkdirAllReturnsOnCall(1, errTest)
+			},
+			shouldError: true,
+		},
+		{ // failure on MkdirAll with enricherLogPath
+			prepare: func(mock *nonrootenablerfakes.FakeImpl) {
+				mock.MkdirAllReturnsOnCall(2, errTest)
+			},
+			shouldError: true,
+		},
+		{ // failure on Lchown
+			prepare: func(mock *nonrootenablerfakes.FakeImpl) {
+				mock.LchownReturns(errTest)
 			},
 			shouldError: true,
 		},

--- a/internal/pkg/nonrootenabler/nonrootenablerfakes/fake_impl.go
+++ b/internal/pkg/nonrootenabler/nonrootenablerfakes/fake_impl.go
@@ -60,6 +60,19 @@ type FakeImpl struct {
 	copyDirContentsLocalReturnsOnCall map[int]struct {
 		result1 error
 	}
+	LchownStub        func(string, int, int) error
+	lchownMutex       sync.RWMutex
+	lchownArgsForCall []struct {
+		arg1 string
+		arg2 int
+		arg3 int
+	}
+	lchownReturns struct {
+		result1 error
+	}
+	lchownReturnsOnCall map[int]struct {
+		result1 error
+	}
 	MkdirAllStub        func(string, fs.FileMode) error
 	mkdirAllMutex       sync.RWMutex
 	mkdirAllArgsForCall []struct {
@@ -288,6 +301,69 @@ func (fake *FakeImpl) CopyDirContentsLocalReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeImpl) Lchown(arg1 string, arg2 int, arg3 int) error {
+	fake.lchownMutex.Lock()
+	ret, specificReturn := fake.lchownReturnsOnCall[len(fake.lchownArgsForCall)]
+	fake.lchownArgsForCall = append(fake.lchownArgsForCall, struct {
+		arg1 string
+		arg2 int
+		arg3 int
+	}{arg1, arg2, arg3})
+	stub := fake.LchownStub
+	fakeReturns := fake.lchownReturns
+	fake.recordInvocation("Lchown", []interface{}{arg1, arg2, arg3})
+	fake.lchownMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) LchownCallCount() int {
+	fake.lchownMutex.RLock()
+	defer fake.lchownMutex.RUnlock()
+	return len(fake.lchownArgsForCall)
+}
+
+func (fake *FakeImpl) LchownCalls(stub func(string, int, int) error) {
+	fake.lchownMutex.Lock()
+	defer fake.lchownMutex.Unlock()
+	fake.LchownStub = stub
+}
+
+func (fake *FakeImpl) LchownArgsForCall(i int) (string, int, int) {
+	fake.lchownMutex.RLock()
+	defer fake.lchownMutex.RUnlock()
+	argsForCall := fake.lchownArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeImpl) LchownReturns(result1 error) {
+	fake.lchownMutex.Lock()
+	defer fake.lchownMutex.Unlock()
+	fake.LchownStub = nil
+	fake.lchownReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) LchownReturnsOnCall(i int, result1 error) {
+	fake.lchownMutex.Lock()
+	defer fake.lchownMutex.Unlock()
+	fake.LchownStub = nil
+	if fake.lchownReturnsOnCall == nil {
+		fake.lchownReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.lchownReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeImpl) MkdirAll(arg1 string, arg2 fs.FileMode) error {
 	fake.mkdirAllMutex.Lock()
 	ret, specificReturn := fake.mkdirAllReturnsOnCall[len(fake.mkdirAllArgsForCall)]
@@ -485,6 +561,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.chownMutex.RUnlock()
 	fake.copyDirContentsLocalMutex.RLock()
 	defer fake.copyDirContentsLocalMutex.RUnlock()
+	fake.lchownMutex.RLock()
+	defer fake.lchownMutex.RUnlock()
 	fake.mkdirAllMutex.RLock()
 	defer fake.mkdirAllMutex.RUnlock()
 	fake.statMutex.RLock()


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This moves the log enricher into the daemon as well as bootstraps a symlink to `/dev/kmsg` during the non-root-enabler. Drawback is that the daemonset now needs HostPid permissions which may be a blocker.
#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/security-profiles-operator/issues/467

#### Does this PR have test?

None

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
TBD
```
