### PR TITLE
Add Metrics for SELinux profiles

### DIFF
--- a/installation-usage.md
+++ b/installation-usage.md
@@ -473,6 +473,8 @@ additional metrics are provided by the daemon, which are always prefixed with
 | ----------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------- |
 | `seccomp_profile_total`       | `operation={delete,update}`                                                                                                                                                                                | Counter | Amount of seccomp profile operations. |
 | `seccomp_profile_error_total` | `reason={`<br>`SeccompNotSupportedOnNode,`<br>`InvalidSeccompProfile,`<br>`CannotSaveSeccompProfile,`<br>`CannotRemoveSeccompProfile,`<br>`CannotUpdateSeccompProfile,`<br>`CannotUpdateNodeStatus`<br>`}` | Counter | Amount of seccomp profile errors.     |
+| `selinux_profile_total`       | `operation={delete,update}`                                                                                                                                                                                | Counter | Amount of selinux profile operations. |
+| `selinux_profile_error_total` | `reason={`<br>`CannotSaveSelinuxPolicy,`<br>`CannotUpdatePolicyStatus,`<br>`CannotRemoveSelinuxPolicy,`<br>`CannotContactSelinuxd,`<br>`CannotWritePolicyFile,`<br>`CannotGetPolicyStatus`<br>`}` | Counter | Amount of selinux profile errors.     |
 
 ## Automatic ServiceMonitor deployment
 

--- a/internal/pkg/daemon/metrics/metrics_test.go
+++ b/internal/pkg/daemon/metrics/metrics_test.go
@@ -82,7 +82,7 @@ func TestSeccompProfile(t *testing.T) {
 				m.IncSeccompProfileUpdate()
 			},
 			then: func(m *Metrics) {
-				ctr, err := m.metricSeccompProfile.GetMetricWithLabelValues(metricLabelValueSeccompProfileUpdate)
+				ctr, err := m.metricSeccompProfile.GetMetricWithLabelValues(metricLabelValueProfileUpdate)
 				require.Nil(t, err)
 				require.Equal(t, 1, getMetricValue(ctr))
 			},
@@ -92,7 +92,7 @@ func TestSeccompProfile(t *testing.T) {
 				m.IncSeccompProfileDelete()
 			},
 			then: func(m *Metrics) {
-				ctr, err := m.metricSeccompProfile.GetMetricWithLabelValues(metricLabelValueSeccompProfileDelete)
+				ctr, err := m.metricSeccompProfile.GetMetricWithLabelValues(metricLabelValueProfileDelete)
 				require.Nil(t, err)
 				require.Equal(t, 1, getMetricValue(ctr))
 			},
@@ -106,11 +106,49 @@ func TestSeccompProfile(t *testing.T) {
 				m.IncSeccompProfileDelete()
 			},
 			then: func(m *Metrics) {
-				ctrUpdate, err := m.metricSeccompProfile.GetMetricWithLabelValues(metricLabelValueSeccompProfileUpdate)
+				ctrUpdate, err := m.metricSeccompProfile.GetMetricWithLabelValues(metricLabelValueProfileUpdate)
 				require.Nil(t, err)
 				require.Equal(t, 3, getMetricValue(ctrUpdate))
 
-				ctrDelete, err := m.metricSeccompProfile.GetMetricWithLabelValues(metricLabelValueSeccompProfileDelete)
+				ctrDelete, err := m.metricSeccompProfile.GetMetricWithLabelValues(metricLabelValueProfileDelete)
+				require.Nil(t, err)
+				require.Equal(t, 2, getMetricValue(ctrDelete))
+			},
+		},
+		{ // Selinux single update
+			when: func(m *Metrics) {
+				m.IncSelinuxProfileUpdate()
+			},
+			then: func(m *Metrics) {
+				ctr, err := m.metricSelinuxProfile.GetMetricWithLabelValues(metricLabelValueProfileUpdate)
+				require.Nil(t, err)
+				require.Equal(t, 1, getMetricValue(ctr))
+			},
+		},
+		{ // Selinux single delete
+			when: func(m *Metrics) {
+				m.IncSelinuxProfileDelete()
+			},
+			then: func(m *Metrics) {
+				ctr, err := m.metricSelinuxProfile.GetMetricWithLabelValues(metricLabelValueProfileDelete)
+				require.Nil(t, err)
+				require.Equal(t, 1, getMetricValue(ctr))
+			},
+		},
+		{ // Selinux multiple update and delete
+			when: func(m *Metrics) {
+				m.IncSelinuxProfileUpdate()
+				m.IncSelinuxProfileUpdate()
+				m.IncSelinuxProfileDelete()
+				m.IncSelinuxProfileUpdate()
+				m.IncSelinuxProfileDelete()
+			},
+			then: func(m *Metrics) {
+				ctrUpdate, err := m.metricSelinuxProfile.GetMetricWithLabelValues(metricLabelValueProfileUpdate)
+				require.Nil(t, err)
+				require.Equal(t, 3, getMetricValue(ctrUpdate))
+
+				ctrDelete, err := m.metricSelinuxProfile.GetMetricWithLabelValues(metricLabelValueProfileDelete)
 				require.Nil(t, err)
 				require.Equal(t, 2, getMetricValue(ctrDelete))
 			},

--- a/internal/pkg/daemon/selinuxprofile/setup.go
+++ b/internal/pkg/daemon/selinuxprofile/setup.go
@@ -47,6 +47,7 @@ func (r *ReconcileSP) Setup(
 	r.scheme = mgr.GetScheme()
 	r.policyTemplate = tmpl
 	r.record = event.NewAPIRecorder(mgr.GetEventRecorderFor("selinuxprofile"))
+	r.metrics = met
 
 	// Register the regular reconciler to manage SelinuxProfiles
 	return ctrl.NewControllerManagedBy(mgr).

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -80,7 +80,7 @@ func (e *e2e) TestSecurityProfilesOperator() {
 		},
 		{
 			"Seccomp: Metrics",
-			e.testCaseMetrics,
+			e.testCaseSeccompMetrics,
 		},
 		{
 			"Seccomp: Re-deploy the operator",
@@ -93,6 +93,10 @@ func (e *e2e) TestSecurityProfilesOperator() {
 		{
 			"SELinux: base case (install policy, run pod and delete)",
 			e.testCaseSelinuxBaseUsage,
+		},
+		{
+			"SELinux: Metrics (update, delete)",
+			e.testCaseSelinuxMetrics,
 		},
 		{
 			"SPOD: Update SELinux flag",

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -452,7 +452,7 @@ func (e *e2e) logf(format string, a ...interface{}) {
 	e.logger.Info(fmt.Sprintf(format, a...))
 }
 
-func (e *e2e) selinuxtOnlyTestCase() {
+func (e *e2e) selinuxOnlyTestCase() {
 	if !e.selinuxEnabled {
 		e.T().Skip("Skipping SELinux-related test")
 	}

--- a/test/tc_selinux_sanity_check_test.go
+++ b/test/tc_selinux_sanity_check_test.go
@@ -17,7 +17,7 @@ limitations under the License.
 package e2e_test
 
 func (e *e2e) testCaseSelinuxSanityCheck([]string) {
-	e.selinuxtOnlyTestCase()
+	e.selinuxOnlyTestCase()
 
 	const podWithoutPolicy = `
 apiVersion: v1

--- a/test/tc_spod_update_selinux_test.go
+++ b/test/tc_spod_update_selinux_test.go
@@ -19,7 +19,7 @@ package e2e_test
 import "time"
 
 func (e *e2e) testCaseSPODUpdateSelinux(nodes []string) {
-	e.selinuxtOnlyTestCase()
+	e.selinuxOnlyTestCase()
 
 	e.logf("assert selinux is enabled in the spod object")
 	selinuxEnabledInSPODObj := e.kubectlOperatorNS("get", "spod", "spod", "-o", "jsonpath={.spec.enableSelinux}")


### PR DESCRIPTION
This PR adds metrics updates for the SELinux profile functionality (mentioned in https://github.com/kubernetes-sigs/security-profiles-operator/issues/276#issuecomment-839636908)

```
# HELP security_profiles_operator_selinux_profile_error_total Counter about selinux profile errors.
# TYPE security_profiles_operator_selinux_profile_error_total counter                                   
security_profiles_operator_selinux_profile_error_total{reason="CannotUpdatePolicyStatus"} 1

# HELP security_profiles_operator_selinux_profile_total Counter about selinux profile operations.
# TYPE security_profiles_operator_selinux_profile_total counter
security_profiles_operator_selinux_profile_total{operation="delete"} 1
security_profiles_operator_selinux_profile_total{operation="update"} 6
```

```release-note
Add Metrics for SELinux profiles
```


@saschagrunert @jhrozek @JAORMX 