### PR TITLE
Add localhost deployment patch

### DIFF
--- a/hack/deploy-localhost.patch
+++ b/hack/deploy-localhost.patch
@@ -1,0 +1,44 @@
+diff --git a/deploy/operator.yaml b/deploy/operator.yaml
+index fd8bd11..07c664e 100644
+--- a/deploy/operator.yaml
++++ b/deploy/operator.yaml
+@@ -1351,7 +1351,7 @@ metadata:
+   name: security-profiles-operator
+   namespace: security-profiles-operator
+ spec:
+-  replicas: 3
++  replicas: 1
+   selector:
+     matchLabels:
+       app: security-profiles-operator
+@@ -1374,8 +1374,8 @@ spec:
+           valueFrom:
+             fieldRef:
+               fieldPath: metadata.namespace
+-        image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
+-        imagePullPolicy: Always
++        image: localhost/security-profiles-operator:latest
++        imagePullPolicy: IfNotPresent
+         name: security-profiles-operator
+         securityContext:
+           allowPrivilegeEscalation: false
+@@ -1400,7 +1400,7 @@ metadata:
+   name: security-profiles-operator-webhook
+   namespace: security-profiles-operator
+ spec:
+-  replicas: 3
++  replicas: 1
+   selector:
+     matchLabels:
+       app: security-profiles-operator
+@@ -1417,8 +1417,8 @@ spec:
+       containers:
+       - args:
+         - webhook
+-        image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
+-        imagePullPolicy: Always
++        image: localhost/security-profiles-operator:latest
++        imagePullPolicy: IfNotPresent
+         name: security-profiles-operator
+         ports:
+         - containerPort: 9443


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
This little helper can be used if the operator image has been built
locally on the via podman by running `sudo make image`. After that, the
patch can be applied to be able to run `kubectl apply -f
deploy/operator.yaml`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
