### PR TITLE
Fix log enricher read and automatically add `/dev/kmsg` device 

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -67,6 +67,9 @@ const (
 
 	// EnricherLogFile is the path to the kernel messages log file used for the enricher.
 	EnricherLogFile = "/var/log/spo.log"
+
+	// DevKmsgPath is the path to the kernel log messages.
+	DevKmsgPath = "/dev/kmsg"
 )
 
 // ProfileRecordingOutputPath is the path where the recorded profiles will be

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -34,7 +34,7 @@ var (
 	truly                           = true
 	userRoot                  int64 = 0
 	userRootless                    = int64(config.UserRootless)
-	hostPathFile                    = v1.HostPathFile
+	hostPathFileOrCreate            = v1.HostPathFileOrCreate
 	hostPathDirectory               = v1.HostPathDirectory
 	hostPathDirectoryOrCreate       = v1.HostPathDirectoryOrCreate
 	metricsPort               int32 = 9443
@@ -65,8 +65,9 @@ var Manifest = &appsv1.DaemonSet{
 		Template: v1.PodTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Annotations: map[string]string{
-					"openshift.io/scc":         "privileged",
-					v1.SeccompPodAnnotationKey: v1.SeccompProfileRuntimeDefault,
+					"openshift.io/scc":            "privileged",
+					"io.kubernetes.cri-o.Devices": config.DevKmsgPath,
+					v1.SeccompPodAnnotationKey:    v1.SeccompProfileRuntimeDefault,
 					v1.SeccompContainerAnnotationKeyPrefix + config.OperatorName: "localhost/security-profiles-operator.json",
 				},
 				Labels: map[string]string{
@@ -523,7 +524,7 @@ semodule -i /opt/spo-profiles/selinuxd.cil
 						VolumeSource: v1.VolumeSource{
 							HostPath: &v1.HostPathVolumeSource{
 								Path: config.EnricherLogFile,
-								Type: &hostPathFile,
+								Type: &hostPathFileOrCreate,
 							},
 						},
 					},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When using CRI-O, we can utilize the annotation
`io.kubernetes.cri-o.Devices` to correctly mount the device into the
container. This means we do not rely on a symlink any more and can use
the device directly.

The enricher read has been fixed because one read always returns a full
line which makes the offset calculation obsolete.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Automatically mount /dev/kmsg for log enricher usage if running with CRI-O and an allowed `io.kubernetes.cri-o.Devices` annotation.
```
