### PR TITLE
Add logs to non root enabler

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -133,11 +133,9 @@ func main() {
 			},
 		},
 		&cli.Command{
-			Name:  "non-root-enabler",
-			Usage: "run the non root enabler",
-			Action: func(*cli.Context) error {
-				return nonrootenabler.New().Run()
-			},
+			Name:   "non-root-enabler",
+			Usage:  "run the non root enabler",
+			Action: runNonRootEnabler,
 		},
 		&cli.Command{
 			Name:    "log-enricher",
@@ -324,8 +322,15 @@ func runDaemon(ctx *cli.Context) error {
 }
 
 func runLogEnricher(ctx *cli.Context) error {
-	printInfo("log-enricher")
-	return enricher.Run(ctrl.Log.WithName("log-enricher"))
+	const component = "log-enricher"
+	printInfo(component)
+	return enricher.Run(ctrl.Log.WithName(component))
+}
+
+func runNonRootEnabler(ctx *cli.Context) error {
+	const component = "non-root-enabler"
+	printInfo(component)
+	return nonrootenabler.New().Run(ctrl.Log.WithName(component))
 }
 
 func runWebhook(ctx *cli.Context) error {

--- a/internal/pkg/nonrootenabler/nonrootenabler_test.go
+++ b/internal/pkg/nonrootenabler/nonrootenabler_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/nonrootenabler"
@@ -88,7 +89,7 @@ func TestRun(t *testing.T) {
 		tc.prepare(mock)
 		sut.SetImpl(mock)
 
-		err := sut.Run()
+		err := sut.Run(logr.DiscardLogger{})
 		if tc.shouldError {
 			require.NotNil(t, err)
 		} else {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This enhances the verbosity of the non-root-enabler by adding logging information.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added logging to non-root-enabler
```
