### PR TITLE
Reopen audit logs on rotation

### DIFF
--- a/internal/pkg/daemon/enricher/enricher.go
+++ b/internal/pkg/daemon/enricher/enricher.go
@@ -55,6 +55,7 @@ func Run(logger logr.Logger) error {
 	tailFile, err := tail.TailFile(
 		config.AuditLogPath,
 		tail.Config{
+			ReOpen: true,
 			Follow: true,
 			Location: &tail.SeekInfo{
 				Offset: 0,


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
If the audit logs gets rotated, then the enricher should continue
reading from the original location rather than stop working.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
