### PR TITLE
Make log enricher work with containerd

### DIFF
--- a/installation-usage.md
+++ b/installation-usage.md
@@ -558,7 +558,6 @@ within host PID namespace (`hostPID`).
 Further requirements to the Kubernetes node have to be fulfilled to use the log
 enrichment feature:
 
-- [CRI-O][cri-o] has to be the container runtime
 - [auditd][auditd] needs to run and has to be configured to log into
   `/var/log/audit/audit.log`
 

--- a/internal/pkg/daemon/enricher/types.go
+++ b/internal/pkg/daemon/enricher/types.go
@@ -19,9 +19,8 @@ package enricher
 import "errors"
 
 var (
-	errUnsupportedContainerRuntime = errors.New("unsupported container runtime")
-	errUnsupportedLogLine          = errors.New("unsupported log line")
-	errContainerIDEmpty            = errors.New("container ID is empty")
+	errUnsupportedLogLine = errors.New("unsupported log line")
+	errContainerIDEmpty   = errors.New("container ID is empty")
 )
 
 const (


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
This should make the CRI-O requirement obsolete and also work on containerd.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
