### PR TITLE
Streamline container ID retrieval

### DIFF
--- a/internal/pkg/daemon/enricher/audit.go
+++ b/internal/pkg/daemon/enricher/audit.go
@@ -25,8 +25,9 @@ import (
 
 // type IDs are defined at https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/audit.h
 var (
-	//nolint:lll
-	seccompLineRegex = regexp.MustCompile(`(type=SECCOMP|audit:.+type=1326).+audit\((.+)\).+pid=(\b\d+\b).+exe="(.+)".+syscall=(\b\d+\b).*`)
+	seccompLineRegex = regexp.MustCompile(
+		`(type=SECCOMP|audit:.+type=1326).+audit\((.+)\).+pid=(\b\d+\b).+exe="(.+)".+syscall=(\b\d+\b).*`,
+	)
 	selinuxLineRegex = regexp.MustCompile(`type=AVC.+audit\((.+)\).+pid=(\b\d+\b).*`)
 )
 
@@ -56,7 +57,7 @@ func extractAuditLine(logLine string) (*auditLine, error) {
 		return selinux, nil
 	}
 
-	return nil, errors.Wrap(errUnsupportedLogLine, logLine)
+	return nil, errors.Errorf("unsupported log line: %s", logLine)
 }
 
 func extractSeccompLine(logLine string) *auditLine {

--- a/internal/pkg/daemon/enricher/container_test.go
+++ b/internal/pkg/daemon/enricher/container_test.go
@@ -31,8 +31,8 @@ func TestExtractContainerID(t *testing.T) {
 	}{
 		{
 			"Should extract crio ID",
-			//nolint:lll
-			`4:net_cls,net_prio:/kubepods/besteffort/pod26ba375c-2266-4ecc-bf2d-b626db8762af/crio-af208fd68bf39a07a439ed0c9b6609b9ae63ecd8a5f1a2af3e0db48b945b320a`,
+			`4:net_cls,net_prio:/kubepods/besteffort/pod26ba375c-2266-4ecc-bf2d-b626db8762af/` +
+				`crio-af208fd68bf39a07a439ed0c9b6609b9ae63ecd8a5f1a2af3e0db48b945b320a`,
 			"af208fd68bf39a07a439ed0c9b6609b9ae63ecd8a5f1a2af3e0db48b945b320a",
 		},
 		{
@@ -50,7 +50,7 @@ func TestExtractContainerID(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := extractID(tt.cgroupLine)
+			got := regexID.FindString(tt.cgroupLine)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/internal/pkg/daemon/enricher/enricher.go
+++ b/internal/pkg/daemon/enricher/enricher.go
@@ -117,12 +117,19 @@ func (e *Enricher) Run() error {
 		}
 
 		cID, err := e.getContainerID(auditLine.processID)
+		if errors.Is(err, os.ErrNotExist) {
+			// We're probably in container creation or removal
+			continue
+		}
 		if err != nil {
-			e.logger.Error(err, "unable to get container ID", "processID", auditLine.processID)
+			e.logger.Error(
+				err, "unable to get container ID",
+				"processID", auditLine.processID,
+			)
 			continue
 		}
 
-		info, err := e.getContainerInfo(e.logger, nodeName, cID)
+		info, err := e.getContainerInfo(nodeName, cID)
 		if err != nil {
 			e.logger.Error(
 				err, "container ID not found in cluster",

--- a/internal/pkg/daemon/enricher/types.go
+++ b/internal/pkg/daemon/enricher/types.go
@@ -16,13 +16,6 @@ limitations under the License.
 
 package enricher
 
-import "errors"
-
-var (
-	errUnsupportedLogLine = errors.New("unsupported log line")
-	errContainerIDEmpty   = errors.New("container ID is empty")
-)
-
 const (
 	auditTypeSeccomp = "seccomp"
 	auditTypeSelinux = "selinux"


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
   
We now do not error any more if the cgroup path does not exist to reduce the log verbosity. This also fixes some smaller issues with the logger as well as cleans some unnecessarily complex code paths.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
