### PR TITLE
Add libseccomp version to version command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.48.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/prometheus/client_model v0.2.0
+	github.com/seccomp/libseccomp-golang v0.9.2-0.20200616122406-847368b35ebf
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.3.0
 	google.golang.org/grpc v1.39.0

--- a/internal/pkg/version/version.go
+++ b/internal/pkg/version/version.go
@@ -41,6 +41,7 @@ type Info struct {
 	GoVersion    string `json:"goVersion,omitempty"`
 	Compiler     string `json:"compiler,omitempty"`
 	Platform     string `json:"platform,omitempty"`
+	Libseccomp   string `json:"libseccomp,omitempty"`
 }
 
 func Get() *Info {
@@ -52,6 +53,7 @@ func Get() *Info {
 		GoVersion:    runtime.Version(),
 		Compiler:     runtime.Compiler,
 		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		Libseccomp:   libseccompVersion(),
 	}
 }
 
@@ -67,6 +69,7 @@ func (i *Info) String() string {
 	fmt.Fprintf(w, "GoVersion:\t%s\n", i.GoVersion)
 	fmt.Fprintf(w, "Compiler:\t%s\n", i.Compiler)
 	fmt.Fprintf(w, "Platform:\t%s\n", i.Platform)
+	fmt.Fprintf(w, "Libseccomp:\t%s\n", i.Libseccomp)
 
 	w.Flush()
 	return b.String()

--- a/internal/pkg/version/version_supported.go
+++ b/internal/pkg/version/version_supported.go
@@ -1,0 +1,31 @@
+// +build linux
+
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+import (
+	"fmt"
+
+	seccomp "github.com/seccomp/libseccomp-golang"
+)
+
+// libseccompVersion returns a human readable string of the libseccomp version.
+func libseccompVersion() string {
+	major, minor, patch := seccomp.GetLibraryVersion()
+	return fmt.Sprintf("%d.%d.%d", major, minor, patch)
+}

--- a/internal/pkg/version/version_unsupported.go
+++ b/internal/pkg/version/version_unsupported.go
@@ -1,0 +1,24 @@
+// +build !linux
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package version
+
+// libseccompVersion returns a human readable string of the libseccomp version.
+func libseccompVersion() string {
+	return "none"
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -254,6 +254,7 @@ github.com/prometheus/procfs/internal/util
 # github.com/russross/blackfriday/v2 v2.0.1
 github.com/russross/blackfriday/v2
 # github.com/seccomp/libseccomp-golang v0.9.2-0.20200616122406-847368b35ebf
+## explicit
 github.com/seccomp/libseccomp-golang
 # github.com/sergi/go-diff v1.1.0
 github.com/sergi/go-diff/diffmatchpatch


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
We now also output the version of libseccomp used to build the project.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added libseccomp version output to `version` subcommand output.
```
