### PR TITLE
Rename spod `spod` to `default`

### DIFF
--- a/installation-usage.md
+++ b/installation-usage.md
@@ -656,7 +656,7 @@ If all requirements are met, then the feature can be enabled by patching the
 `spod` configuration:
 
 ```
-> kubectl -n security-profiles-operator patch spod spod --type=merge -p '{"spec":{"enableLogEnricher":true}}'
+> kubectl -n security-profiles-operator patch spod default --type=merge -p '{"spec":{"enableLogEnricher":true}}'
 securityprofilesoperatordaemon.security-profiles-operator.x-k8s.io/spod patched
 ```
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -31,6 +31,9 @@ const (
 	// Service Account for the security-profiles-operator daemon.
 	SPOdServiceAccount = "spod"
 
+	// DefaultConfig is the name of the default daemon configuration.
+	DefaultConfig = "default"
+
 	// OperatorRoot is the root directory of the operator.
 	OperatorRoot = "/var/lib/security-profiles-operator"
 

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -51,7 +51,7 @@ const (
 
 var Manifest = &appsv1.DaemonSet{
 	ObjectMeta: metav1.ObjectMeta{
-		Name:      config.OperatorName,
+		Name:      "spod",
 		Namespace: config.OperatorName,
 	},
 	Spec: appsv1.DaemonSetSpec{

--- a/internal/pkg/manager/spod/setup.go
+++ b/internal/pkg/manager/spod/setup.go
@@ -82,7 +82,7 @@ func (r *ReconcileSPOd) Setup(
 func (r *ReconcileSPOd) createConfigIfNotExist(ctx context.Context) error {
 	obj := &spodv1alpha1.SecurityProfilesOperatorDaemon{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "spod",
+			Name:      config.DefaultConfig,
 			Namespace: config.GetOperatorNamespace(),
 			Labels:    map[string]string{"app": config.OperatorName},
 		},

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -376,7 +376,6 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 ) *appsv1.DaemonSet {
 	newSPOd := r.baseSPOd.DeepCopy()
 
-	newSPOd.SetName(cfg.GetName())
 	newSPOd.SetNamespace(config.GetOperatorNamespace())
 	templateSpec := &newSPOd.Spec.Template.Spec
 

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -506,10 +506,10 @@ func (e *e2e) enableSelinuxInSpod() {
 	selinuxEnabledInSPODDS := e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
 	if !strings.Contains(selinuxEnabledInSPODDS, "--with-selinux=true") {
 		e.logf("Enable selinux in SPOD")
-		e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableSelinux": true}}`, "--type=merge")
+		e.kubectlOperatorNS("patch", "spod", config.DefaultConfig, "-p", `{"spec":{"enableSelinux": true}}`, "--type=merge")
 
 		time.Sleep(defaultWaitTime)
-		e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+		e.waitInOperatorNSFor("condition=ready", "spod", config.DefaultConfig)
 
 		e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultSelinuxOpTimeout)
 	}
@@ -525,10 +525,13 @@ func (e *e2e) logEnricherOnlyTestCase() {
 
 func (e *e2e) enableLogEnricherInSpod() {
 	e.logf("Enable log-enricher in SPOD")
-	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableLogEnricher": true}}`, "--type=merge")
+	e.kubectlOperatorNS(
+		"patch", "spod", config.DefaultConfig,
+		"-p", `{"spec":{"enableLogEnricher": true}}`, "--type=merge",
+	)
 
 	time.Sleep(defaultWaitTime)
-	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+	e.waitInOperatorNSFor("condition=ready", "spod", config.DefaultConfig)
 
 	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultLogEnricherOpTimeout)
 }

--- a/test/tc_spod_update_selinux_test.go
+++ b/test/tc_spod_update_selinux_test.go
@@ -16,13 +16,19 @@ limitations under the License.
 
 package e2e_test
 
-import "time"
+import (
+	"time"
+
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
+)
 
 func (e *e2e) testCaseSPODUpdateSelinux(nodes []string) {
 	e.selinuxOnlyTestCase()
 
 	e.logf("assert selinux is enabled in the spod object")
-	selinuxEnabledInSPODObj := e.kubectlOperatorNS("get", "spod", "spod", "-o", "jsonpath={.spec.enableSelinux}")
+	selinuxEnabledInSPODObj := e.kubectlOperatorNS(
+		"get", "spod", config.DefaultConfig, "-o", "jsonpath={.spec.enableSelinux}",
+	)
 	e.Equal(selinuxEnabledInSPODObj, "true")
 
 	e.logf("assert selinux is enabled in the spod DS")
@@ -30,20 +36,20 @@ func (e *e2e) testCaseSPODUpdateSelinux(nodes []string) {
 	e.Contains(selinuxEnabledInSPODDS, "--with-selinux=true")
 
 	e.logf("Disable selinux from SPOD")
-	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableSelinux": false}}`, "--type=merge")
+	e.kubectlOperatorNS("patch", "spod", config.DefaultConfig, "-p", `{"spec":{"enableSelinux": false}}`, "--type=merge")
 
 	time.Sleep(defaultWaitTime)
-	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+	e.waitInOperatorNSFor("condition=ready", "spod", config.DefaultConfig)
 
 	e.logf("assert selinux is disabled in the spod DS")
 	selinuxDisabledInSPODDS := e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
 	e.NotContains(selinuxDisabledInSPODDS, "--with-selinux=true")
 
 	e.logf("Re-enable selinux in SPOD")
-	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableSelinux": true}}`, "--type=merge")
+	e.kubectlOperatorNS("patch", "spod", config.DefaultConfig, "-p", `{"spec":{"enableSelinux": true}}`, "--type=merge")
 
 	time.Sleep(defaultWaitTime)
-	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+	e.waitInOperatorNSFor("condition=ready", "spod", config.DefaultConfig)
 
 	e.logf("assert selinux is enabled in the spod DS")
 	selinuxEnabledInSPODDS = e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
It may be confusing for users to see so many "spod"s around, so we now
rename the standard configuration to `default` to make things more
clear and explicit.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed default daemon configuration to be "default" instead of "spod".
```
