### PR TITLE
Add syslog support to log enricher

### DIFF
--- a/installation-usage.md
+++ b/installation-usage.md
@@ -211,8 +211,9 @@ $ kubectl get pod test-pod -o jsonpath='{.spec.containers[*].securityContext.sec
 ### Record profiles from workloads with `ProfileRecordings`
 
 The operator is capable of recording seccomp profiles by the usage of the
-[oci-seccomp-bpf-hook][bpf-hook] or by evaluating the [audit][auditd] logs. Both
-methods have its pros and cons as well as separate technical requirements.
+[oci-seccomp-bpf-hook][bpf-hook] or by evaluating the [audit][auditd] or
+[syslog][syslog] files. Both methods have its pros and cons as well as separate
+technical requirements.
 
 #### Hook based recording
 
@@ -407,8 +408,8 @@ workload via a BPF module.
 When using the log enricher for recording seccomp profiles, please ensure that
 the feature [is enabled within the spod](#using-the-log-enricher) configuration
 resource. The log based recording works in the same way with
-[containerd][containerd] and [CRI-O][cri-o], while using the node local
-[audit][auditd] logs as input source of truth.
+[containerd][containerd] and [CRI-O][cri-o], while using the node local logs as
+input source of truth.
 
 To record by using the enricher, create a `ProfileRecording` which is using
 `recorder: logs`:
@@ -644,13 +645,16 @@ privileged mode to be able to read the audit logs from the local node. It is als
 required that the enricher is able to read the host processes and therefore runs
 within host PID namespace (`hostPID`).
 
-Further requirements to the Kubernetes node have to be fulfilled to use the log
-enrichment feature:
+One of the following requirements to the Kubernetes node have to be fulfilled to
+use the log enrichment feature:
 
 - [auditd][auditd] needs to run and has to be configured to log into
   `/var/log/audit/audit.log`
+- [syslog][syslog] can be used as fallback to auditd and needs to log into
+  `/var/log/syslog`
 
 [auditd]: https://man7.org/linux/man-pages/man8/auditd.8.html
+[syslog]: https://man7.org/linux/man-pages/man3/syslog.3.html
 
 If all requirements are met, then the feature can be enabled by patching the
 `spod` configuration:

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -73,6 +73,9 @@ const (
 	// AuditLogPath is the path to the auditd log file.
 	AuditLogPath = "/var/log/audit/audit.log"
 
+	// SyslogLogPath is the path to the syslog log file.
+	SyslogLogPath = "/var/log/syslog"
+
 	// LogEnricherProfile is the seccomp profile name for tracing syscalls from
 	// the log enricher.
 	LogEnricherProfile = "log-enricher-trace"

--- a/internal/pkg/daemon/enricher/audit_test.go
+++ b/internal/pkg/daemon/enricher/audit_test.go
@@ -36,6 +36,12 @@ func Test_isAuditLine(t *testing.T) {
 			true,
 		},
 		{
+			"Should identify type=1326 lines with timestamp",
+			//nolint:lll
+			`Jul  8 10:31:23 ubuntu2004 kernel: [  270.853767] audit: type=1326 audit(1625740283.502:574): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=4709 comm="sh" exe="/bin/busybox" sig=0 arch=c000003e syscall=13 compat=0 ip=0x7f3c012e467b code=0x7ffc0000`,
+			true,
+		},
+		{
 			"Should identify type=SECCOMP log lines",
 			//nolint:lll
 			`type=SECCOMP msg=audit(1613596317.899:6461): auid=4294967295 uid=0 gid=0 ses=4294967295 subj=system_u:system_r:spc_t:s0:c284,c594 pid=2039886 comm="ls" exe="/bin/ls" sig=0 arch=c000003e syscall=3 compat=0 ip=0x7f62dce3d4c7 code=0x7ffc0000AUID="unset" UID="root" GID="root" ARCH=x86_64 SYSCALL=close`,

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -358,8 +358,13 @@ semodule -i /opt/spo-profiles/selinuxd.cil
 						ImagePullPolicy: v1.PullAlways,
 						VolumeMounts: []v1.VolumeMount{
 							{
-								Name:      "host-varlogaudit-volume",
+								Name:      "host-auditlog-volume",
 								MountPath: filepath.Dir(config.AuditLogPath),
+								ReadOnly:  true,
+							},
+							{
+								Name:      "host-syslog-volume",
+								MountPath: filepath.Dir(config.SyslogLogPath),
 								ReadOnly:  true,
 							},
 						},
@@ -518,10 +523,19 @@ semodule -i /opt/spo-profiles/selinuxd.cil
 						},
 					},
 					{
-						Name: "host-varlogaudit-volume",
+						Name: "host-auditlog-volume",
 						VolumeSource: v1.VolumeSource{
 							HostPath: &v1.HostPathVolumeSource{
 								Path: filepath.Dir(config.AuditLogPath),
+								Type: &hostPathDirectoryOrCreate,
+							},
+						},
+					},
+					{
+						Name: "host-syslog-volume",
+						VolumeSource: v1.VolumeSource{
+							HostPath: &v1.HostPathVolumeSource{
+								Path: filepath.Dir(config.SyslogLogPath),
 								Type: &hostPathDirectoryOrCreate,
 							},
 						},


### PR DESCRIPTION


#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
This adds support for `/var/log/syslog` log files if auditd is not available on a node.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added syslog support for log enricher.
```
