### PR TITLE
Preserve reason if tail fails

### DIFF
--- a/internal/pkg/daemon/enricher/enricher.go
+++ b/internal/pkg/daemon/enricher/enricher.go
@@ -199,7 +199,7 @@ func (e *Enricher) Run() error {
 		}
 	}
 
-	return errors.New("enricher failed")
+	return errors.Wrap(e.impl.Reason(tailFile), "enricher failed")
 }
 
 // logFilePath returns either the path to the audit logs or falls back to

--- a/internal/pkg/daemon/enricher/enricher_test.go
+++ b/internal/pkg/daemon/enricher/enricher_test.go
@@ -165,6 +165,7 @@ func TestRun(t *testing.T) {
 				mock.GetenvReturns(node)
 				close(lineChan)
 				mock.LinesReturns(lineChan)
+				mock.ReasonReturns(errTest)
 			},
 			assert: func(mock *enricherfakes.FakeImpl, lineChan chan *tail.Line, err error) {
 				require.NotNil(t, err)

--- a/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
+++ b/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
@@ -142,6 +142,17 @@ type FakeImpl struct {
 		result1 *os.File
 		result2 error
 	}
+	ReasonStub        func(*tail.Tail) error
+	reasonMutex       sync.RWMutex
+	reasonArgsForCall []struct {
+		arg1 *tail.Tail
+	}
+	reasonReturns struct {
+		result1 error
+	}
+	reasonReturnsOnCall map[int]struct {
+		result1 error
+	}
 	RecordSyscallStub        func(api.SecurityProfilesOperatorClient) (api.SecurityProfilesOperator_RecordSyscallClient, error)
 	recordSyscallMutex       sync.RWMutex
 	recordSyscallArgsForCall []struct {
@@ -761,6 +772,67 @@ func (fake *FakeImpl) OpenReturnsOnCall(i int, result1 *os.File, result2 error) 
 	}{result1, result2}
 }
 
+func (fake *FakeImpl) Reason(arg1 *tail.Tail) error {
+	fake.reasonMutex.Lock()
+	ret, specificReturn := fake.reasonReturnsOnCall[len(fake.reasonArgsForCall)]
+	fake.reasonArgsForCall = append(fake.reasonArgsForCall, struct {
+		arg1 *tail.Tail
+	}{arg1})
+	stub := fake.ReasonStub
+	fakeReturns := fake.reasonReturns
+	fake.recordInvocation("Reason", []interface{}{arg1})
+	fake.reasonMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) ReasonCallCount() int {
+	fake.reasonMutex.RLock()
+	defer fake.reasonMutex.RUnlock()
+	return len(fake.reasonArgsForCall)
+}
+
+func (fake *FakeImpl) ReasonCalls(stub func(*tail.Tail) error) {
+	fake.reasonMutex.Lock()
+	defer fake.reasonMutex.Unlock()
+	fake.ReasonStub = stub
+}
+
+func (fake *FakeImpl) ReasonArgsForCall(i int) *tail.Tail {
+	fake.reasonMutex.RLock()
+	defer fake.reasonMutex.RUnlock()
+	argsForCall := fake.reasonArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImpl) ReasonReturns(result1 error) {
+	fake.reasonMutex.Lock()
+	defer fake.reasonMutex.Unlock()
+	fake.ReasonStub = nil
+	fake.reasonReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) ReasonReturnsOnCall(i int, result1 error) {
+	fake.reasonMutex.Lock()
+	defer fake.reasonMutex.Unlock()
+	fake.ReasonStub = nil
+	if fake.reasonReturnsOnCall == nil {
+		fake.reasonReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.reasonReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeImpl) RecordSyscall(arg1 api.SecurityProfilesOperatorClient) (api.SecurityProfilesOperator_RecordSyscallClient, error) {
 	fake.recordSyscallMutex.Lock()
 	ret, specificReturn := fake.recordSyscallReturnsOnCall[len(fake.recordSyscallArgsForCall)]
@@ -1097,6 +1169,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.newForConfigMutex.RUnlock()
 	fake.openMutex.RLock()
 	defer fake.openMutex.RUnlock()
+	fake.reasonMutex.RLock()
+	defer fake.reasonMutex.RUnlock()
 	fake.recordSyscallMutex.RLock()
 	defer fake.recordSyscallMutex.RUnlock()
 	fake.sendMetricMutex.RLock()

--- a/internal/pkg/daemon/enricher/impl.go
+++ b/internal/pkg/daemon/enricher/impl.go
@@ -44,6 +44,7 @@ type impl interface {
 	Close(*grpc.ClientConn) error
 	TailFile(filename string, config tail.Config) (*tail.Tail, error)
 	Lines(tailFile *tail.Tail) chan *tail.Line
+	Reason(tailFile *tail.Tail) error
 	Open(name string) (*os.File, error)
 	InClusterConfig() (*rest.Config, error)
 	NewForConfig(c *rest.Config) (*kubernetes.Clientset, error)
@@ -88,6 +89,10 @@ func (d *defaultImpl) TailFile(
 
 func (d *defaultImpl) Lines(tailFile *tail.Tail) chan *tail.Line {
 	return tailFile.Lines
+}
+
+func (d *defaultImpl) Reason(tailFile *tail.Tail) error {
+	return tailFile.Err()
 }
 
 func (d *defaultImpl) Open(name string) (*os.File, error) {


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We should still track the reason if the tail of the log file files, which is now the case.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
Yes
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
Prow e2e tests are broken until https://github.com/kubernetes/test-infra/pull/22823 got merged.
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
