### PR TITLE
Use context for GRPC client connection

### DIFF
--- a/internal/pkg/daemon/enricher/enricher.go
+++ b/internal/pkg/daemon/enricher/enricher.go
@@ -76,10 +76,11 @@ func (e *Enricher) Run() error {
 	e.logger.Info("Starting log-enricher on node: " + nodeName)
 
 	e.logger.Info("Connecting to local GRPC server")
-	conn, err := e.impl.Dial()
+	conn, cancel, err := e.impl.Dial()
 	if err != nil {
 		return errors.Wrap(err, "connecting to local GRPC server")
 	}
+	defer cancel()
 	defer e.impl.Close(conn)
 	client := api.NewSecurityProfilesOperatorClient(conn)
 

--- a/internal/pkg/daemon/enricher/enricher_test.go
+++ b/internal/pkg/daemon/enricher/enricher_test.go
@@ -133,7 +133,7 @@ func TestRun(t *testing.T) {
 			runAsync: false,
 			prepare: func(mock *enricherfakes.FakeImpl, lineChan chan *tail.Line) {
 				mock.GetenvReturns(node)
-				mock.DialReturns(nil, errTest)
+				mock.DialReturns(nil, nil, errTest)
 			},
 			assert: func(mock *enricherfakes.FakeImpl, lineChan chan *tail.Line, err error) {
 				require.NotNil(t, err)
@@ -143,6 +143,7 @@ func TestRun(t *testing.T) {
 			runAsync: false,
 			prepare: func(mock *enricherfakes.FakeImpl, lineChan chan *tail.Line) {
 				mock.GetenvReturns(node)
+				mock.DialReturns(nil, func() {}, errTest)
 				mock.MetricsAuditIncReturns(nil, errTest)
 			},
 			assert: func(mock *enricherfakes.FakeImpl, lineChan chan *tail.Line, err error) {
@@ -153,6 +154,7 @@ func TestRun(t *testing.T) {
 			runAsync: false,
 			prepare: func(mock *enricherfakes.FakeImpl, lineChan chan *tail.Line) {
 				mock.GetenvReturns(node)
+				mock.DialReturns(nil, func() {}, errTest)
 				mock.TailFileReturns(nil, errTest)
 			},
 			assert: func(mock *enricherfakes.FakeImpl, lineChan chan *tail.Line, err error) {
@@ -163,6 +165,7 @@ func TestRun(t *testing.T) {
 			runAsync: false,
 			prepare: func(mock *enricherfakes.FakeImpl, lineChan chan *tail.Line) {
 				mock.GetenvReturns(node)
+				mock.DialReturns(nil, func() {}, errTest)
 				close(lineChan)
 				mock.LinesReturns(lineChan)
 				mock.ReasonReturns(errTest)

--- a/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
+++ b/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
@@ -18,6 +18,7 @@ limitations under the License.
 package enricherfakes
 
 import (
+	"context"
 	"os"
 	"sync"
 	"time"
@@ -43,17 +44,19 @@ type FakeImpl struct {
 	closeReturnsOnCall map[int]struct {
 		result1 error
 	}
-	DialStub        func() (*grpc.ClientConn, error)
+	DialStub        func() (*grpc.ClientConn, context.CancelFunc, error)
 	dialMutex       sync.RWMutex
 	dialArgsForCall []struct {
 	}
 	dialReturns struct {
 		result1 *grpc.ClientConn
-		result2 error
+		result2 context.CancelFunc
+		result3 error
 	}
 	dialReturnsOnCall map[int]struct {
 		result1 *grpc.ClientConn
-		result2 error
+		result2 context.CancelFunc
+		result3 error
 	}
 	GetenvStub        func(string) string
 	getenvMutex       sync.RWMutex
@@ -281,7 +284,7 @@ func (fake *FakeImpl) CloseReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeImpl) Dial() (*grpc.ClientConn, error) {
+func (fake *FakeImpl) Dial() (*grpc.ClientConn, context.CancelFunc, error) {
 	fake.dialMutex.Lock()
 	ret, specificReturn := fake.dialReturnsOnCall[len(fake.dialArgsForCall)]
 	fake.dialArgsForCall = append(fake.dialArgsForCall, struct {
@@ -294,9 +297,9 @@ func (fake *FakeImpl) Dial() (*grpc.ClientConn, error) {
 		return stub()
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1, ret.result2, ret.result3
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeImpl) DialCallCount() int {
@@ -305,36 +308,39 @@ func (fake *FakeImpl) DialCallCount() int {
 	return len(fake.dialArgsForCall)
 }
 
-func (fake *FakeImpl) DialCalls(stub func() (*grpc.ClientConn, error)) {
+func (fake *FakeImpl) DialCalls(stub func() (*grpc.ClientConn, context.CancelFunc, error)) {
 	fake.dialMutex.Lock()
 	defer fake.dialMutex.Unlock()
 	fake.DialStub = stub
 }
 
-func (fake *FakeImpl) DialReturns(result1 *grpc.ClientConn, result2 error) {
+func (fake *FakeImpl) DialReturns(result1 *grpc.ClientConn, result2 context.CancelFunc, result3 error) {
 	fake.dialMutex.Lock()
 	defer fake.dialMutex.Unlock()
 	fake.DialStub = nil
 	fake.dialReturns = struct {
 		result1 *grpc.ClientConn
-		result2 error
-	}{result1, result2}
+		result2 context.CancelFunc
+		result3 error
+	}{result1, result2, result3}
 }
 
-func (fake *FakeImpl) DialReturnsOnCall(i int, result1 *grpc.ClientConn, result2 error) {
+func (fake *FakeImpl) DialReturnsOnCall(i int, result1 *grpc.ClientConn, result2 context.CancelFunc, result3 error) {
 	fake.dialMutex.Lock()
 	defer fake.dialMutex.Unlock()
 	fake.DialStub = nil
 	if fake.dialReturnsOnCall == nil {
 		fake.dialReturnsOnCall = make(map[int]struct {
 			result1 *grpc.ClientConn
-			result2 error
+			result2 context.CancelFunc
+			result3 error
 		})
 	}
 	fake.dialReturnsOnCall[i] = struct {
 		result1 *grpc.ClientConn
-		result2 error
-	}{result1, result2}
+		result2 context.CancelFunc
+		result3 error
+	}{result1, result2, result3}
 }
 
 func (fake *FakeImpl) Getenv(arg1 string) string {

--- a/internal/pkg/daemon/enricher/impl.go
+++ b/internal/pkg/daemon/enricher/impl.go
@@ -40,7 +40,7 @@ type defaultImpl struct{}
 type impl interface {
 	SetTTL(cache ttlcache.SimpleCache, ttl time.Duration) error
 	Getenv(key string) string
-	Dial() (*grpc.ClientConn, error)
+	Dial() (*grpc.ClientConn, context.CancelFunc, error)
 	Close(*grpc.ClientConn) error
 	TailFile(filename string, config tail.Config) (*tail.Tail, error)
 	Lines(tailFile *tail.Tail) chan *tail.Line
@@ -73,8 +73,8 @@ func (d *defaultImpl) Getenv(key string) string {
 	return os.Getenv(key)
 }
 
-func (d *defaultImpl) Dial() (*grpc.ClientConn, error) {
-	return grpc.Dial(server.Addr(), grpc.WithInsecure())
+func (d *defaultImpl) Dial() (*grpc.ClientConn, context.CancelFunc, error) {
+	return server.Dial()
 }
 
 func (d *defaultImpl) Close(conn *grpc.ClientConn) error {

--- a/internal/pkg/daemon/profilerecorder/profilerecorder.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder.go
@@ -33,7 +33,6 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/go-logr/logr"
 	"github.com/pkg/errors"
-	"google.golang.org/grpc"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -137,10 +136,11 @@ func (r *RecorderReconciler) Setup(
 	}
 
 	r.log.Info("Connecting to local GRPC server")
-	conn, err := grpc.Dial(server.Addr(), grpc.WithInsecure())
+	conn, cancel, err := server.Dial()
 	if err != nil {
 		return errors.Wrap(err, "connecting to local GRPC server")
 	}
+	defer cancel()
 
 	r.grpcClient = api.NewSecurityProfilesOperatorClient(conn)
 	r.client = mgr.GetClient()


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
We now use a new utility function to create a context with a
corresponding timeout for connections to the GRPC server.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
