### PR TITLE
selinux: Print diagnostic message from selinuxd in event on failure

### DIFF
--- a/internal/pkg/daemon/selinuxprofile/selinuxpolicy_controller.go
+++ b/internal/pkg/daemon/selinuxprofile/selinuxpolicy_controller.go
@@ -244,7 +244,7 @@ func (r *ReconcileSP) reconcilePolicy(
 		r.record.Event(sp, event.Normal(reasonInstalledPolicy, evstr))
 	case failedStatus:
 		polState = statusv1alpha1.ProfileStateError
-		evstr := fmt.Sprintf("Failed to save profile to disk on %s", os.Getenv(config.NodeNameEnvKey))
+		evstr := fmt.Sprintf("Failed to save profile to disk on %s: %s", os.Getenv(config.NodeNameEnvKey), polStatus.Msg)
 		r.metrics.IncSelinuxProfileError(reasonCannotInstallPolicy)
 		r.record.Event(sp, event.Warning(reasonCannotInstallPolicy, errors.New(evstr)))
 	}
@@ -337,6 +337,8 @@ func (r *ReconcileSP) reconcileDeletePolicy(
 				return reconcile.Result{}, errors.Wrap(err, "Updating SELinux policy with installation")
 			}
 
+			evstr := fmt.Sprintf("Failed to save profile to disk on %s: %s", os.Getenv(config.NodeNameEnvKey), polStatus.Msg)
+			r.record.Event(sp, event.Warning(reasonCannotInstallPolicy, errors.New(evstr)))
 			return reconcile.Result{}, nil
 		}
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
selinuxd does include a diagnostic message for some time and we even
parse it, it was just unused. Instead of changing the CRD just to
include an error message, we might as well just dump the message in an
event.


#### Which issue(s) this PR fixes:
Fixes #223 (sort of? The issue talked about enhancing the CRD which I
don't think is needed honestly..)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.


or

None
-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE

```