### PR TITLE
Add missing libseccomp version to init log

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -152,16 +152,9 @@ func main() {
 }
 
 func printInfo(component string) {
-	v := version.Get()
 	setupLog.Info(
 		fmt.Sprintf("starting component: %s", component),
-		"version", v.Version,
-		"gitCommit", v.GitCommit,
-		"gitTreeState", v.GitTreeState,
-		"buildDate", v.BuildDate,
-		"goVersion", v.GoVersion,
-		"compiler", v.Compiler,
-		"platform", v.Platform,
+		version.Get().AsKeyValues()...,
 	)
 }
 

--- a/internal/pkg/version/version.go
+++ b/internal/pkg/version/version.go
@@ -84,3 +84,17 @@ func (i *Info) JSONString() (string, error) {
 	}
 	return string(b), nil
 }
+
+// AsKeyValues returns a key value slice of the info.
+func (i *Info) AsKeyValues() []interface{} {
+	return []interface{}{
+		"version", i.Version,
+		"gitCommit", i.GitCommit,
+		"gitTreeState", i.GitTreeState,
+		"buildDate", i.BuildDate,
+		"goVersion", i.GoVersion,
+		"compiler", i.Compiler,
+		"platform", i.Platform,
+		"libseccomp", i.Libseccomp,
+	}
+}

--- a/internal/pkg/version/version_test.go
+++ b/internal/pkg/version/version_test.go
@@ -43,3 +43,9 @@ func TestVersionJSON(t *testing.T) {
 	require.Nil(t, err)
 	require.NotEmpty(t, sut)
 }
+
+func TestAsKeyValues(t *testing.T) {
+	t.Parallel()
+	sut := Get().AsKeyValues()
+	require.Len(t, sut, 2*8)
+}


### PR DESCRIPTION

#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
We now print the libseccomp version also on operator startup. To achieve
that, we now add a dedicated method to retrieve the keys and values from
the version. Tests have been added as well.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Log libseccomp version on operator startup.
```
