### PR TITLE
fedora: Call dnf upgrade to force modules metadata refresh

### DIFF
--- a/hack/ci/Vagrantfile-fedora
+++ b/hack/ci/Vagrantfile-fedora
@@ -29,6 +29,8 @@ Vagrant.configure("2") do |config|
       echo 'export GOPATH="$HOME/go"' >> /etc/profile
       echo 'export GOBIN="$GOPATH/bin"' >> /etc/profile
 
+      dnf upgrade -y \
+
       dnf install -y \
         conntrack \
         container-selinux \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Without applying upgrades, I was often seeing:
  default: No available modular metadata for modular package 'perl-AutoLoader-5.74-471.module_f33+12592+71aff0e2.noarch', it cannot be installed on the system
  default: No available modular metadata for modular package 'perl-B-1.80-471.module_f33+12592+71aff0e2.x86_64', it cannot be installed on the system
  default: No available modular metadata for modular package 'perl-Carp-1.50-457.module_f33+11297+42184919.noarch', it cannot be installed on the system
  default: No available modular metadata for modular package 'perl-Class-Struct-0.66-471.module_f33+12592+71aff0e2.noarch', it cannot be installed on the system
  default: No available modular metadata for modular package 'perl-Data-Dumper-2.174-459.module_f33+11297+42184919.x86_64', it cannot be installed on the system

Which then aborted the vagrant up procedure. I wasn't able to find the
single package that fixes the upgrade so let's just upgrade everything.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE

```