### PR TITLE
<!--  Thanks for sending a pull request!  Here are some tips for you:

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -70,7 +70,7 @@ dependencies:
       match: fedora
 
   - name: e2e-ubuntu
-    version: 2004
+    version: focal64
     refPaths:
     - path: hack/ci/Vagrantfile-ubuntu
       match: ubuntu

--- a/hack/ci/Vagrantfile-fedora
+++ b/hack/ci/Vagrantfile-fedora
@@ -29,6 +29,8 @@ Vagrant.configure("2") do |config|
       echo 'export GOPATH="$HOME/go"' >> /etc/profile
       echo 'export GOBIN="$GOPATH/bin"' >> /etc/profile
 
+      dnf upgrade -y \
+
       dnf install -y \
         conntrack \
         container-selinux \

--- a/hack/ci/Vagrantfile-ubuntu
+++ b/hack/ci/Vagrantfile-ubuntu
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "generic/ubuntu2004"
+  config.vm.box = "ubuntu/focal64"
   memory = 6144
   cpus = 4
 


### PR DESCRIPTION
- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind failing-test

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Tries to fix the fedora CI by applying updates to force refresh of the module data.
Without applying upgrades, I was often seeing:
default: No available modular metadata for modular package 'perl-AutoLoader-5.74-471.module_f33+12592+71aff0e2.noarch', it cannot be installed on the system
default: No available modular metadata for modular package 'perl-B-1.80-471.module_f33+12592+71aff0e2.x86_64', it cannot be installed on the system
default: No available modular metadata for modular package 'perl-Carp-1.50-457.module_f33+11297+42184919.noarch', it cannot be installed on the system
default: No available modular metadata for modular package 'perl-Class-Struct-0.66-471.module_f33+12592+71aff0e2.noarch', it cannot be installed on the system
default: No available modular metadata for modular package 'perl-Data-Dumper-2.174-459.module_f33+11297+42184919.x86_64', it cannot be installed on the system

Which then aborted the vagrant up procedure. I wasn't able to find the
single package that fixes the upgrade so let's just upgrade everything.

With the ubuntu tests, our CI seems to be hitting

https://bugs.launchpad.net/cloud-images/+bug/1939580

which causes the shared folder to not be mounted and eventually
manifests as the hack/ci/e2e-ubuntu.sh not found, because it's not
copied over to the shared folder.

which is resolved by upgrading to a recent kernel (5.4.0.84). The
generic/ubuntu64 image we have been using appears to be using 5.4.0.81.

Unfortunately, the official ubuntu boxes only ship for virtualbox, which
means that we can't use them in general. But at least let's use them for
our CI, anyone running locally would probably not run into the issue
with the VB shared folders anyway.

#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE

```