### PR TITLE
Require `ContainerCreating` state for ID retry

### DIFF
--- a/hack/deploy-localhost.patch
+++ b/hack/deploy-localhost.patch
@@ -1,8 +1,8 @@
 diff --git a/deploy/operator.yaml b/deploy/operator.yaml
-index f0b1a57..eb44040 100644
+index 6d28eddd..154fbad0 100644
 --- a/deploy/operator.yaml
 +++ b/deploy/operator.yaml
-@@ -1358,7 +1358,7 @@ metadata:
+@@ -1359,7 +1359,7 @@ metadata:
    name: security-profiles-operator
    namespace: security-profiles-operator
  spec:
@@ -11,7 +11,7 @@ index f0b1a57..eb44040 100644
    selector:
      matchLabels:
        app: security-profiles-operator
-@@ -1381,8 +1381,8 @@ spec:
+@@ -1382,8 +1382,8 @@ spec:
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace
@@ -20,9 +20,9 @@ index f0b1a57..eb44040 100644
 +        image: localhost/security-profiles-operator:latest
 +        imagePullPolicy: IfNotPresent
          name: security-profiles-operator
-         securityContext:
-           allowPrivilegeEscalation: false
-@@ -1407,7 +1407,7 @@ metadata:
+         resources:
+           limits:
+@@ -1414,7 +1414,7 @@ metadata:
    name: security-profiles-operator-webhook
    namespace: security-profiles-operator
  spec:
@@ -31,7 +31,7 @@ index f0b1a57..eb44040 100644
    selector:
      matchLabels:
        app: security-profiles-operator
-@@ -1429,8 +1429,8 @@ spec:
+@@ -1436,8 +1436,8 @@ spec:
            valueFrom:
              fieldRef:
                fieldPath: metadata.namespace

--- a/internal/pkg/daemon/enricher/container.go
+++ b/internal/pkg/daemon/enricher/container.go
@@ -72,12 +72,20 @@ func (e *Enricher) getContainerInfo(
 					containerName := containerStatus.Name
 
 					if containerID == "" {
-						e.logger.Info(
-							"container ID is still empty, retrying",
-							"podName", pod.Name,
-							"containerName", containerName,
+						if containerStatus.State.Waiting != nil &&
+							containerStatus.State.Waiting.Reason == "ContainerCreating" {
+							e.logger.Info(
+								"container ID is still empty, retrying",
+								"podName", pod.Name,
+								"containerName", containerName,
+							)
+							return errContainerIDEmpty
+						}
+
+						return errors.Errorf(
+							"container ID not found with container state: %v",
+							containerStatus.State,
 						)
-						return errContainerIDEmpty
 					}
 
 					rawContainerID := regexID.FindString(containerID)


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We now make the retry of the container ID retrieval more strict by
requiring a container in "ContainerCreating" state. This way we can
mitigate retrying on failure cases, for example image pull issues.


#### Which issue(s) this PR fixes:

Fixes #586

#### Does this PR have test?

None

#### Special notes for your reviewer:
cc @jhrozek 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Do not retry container ID retrieval on container creation failures any more.
```
