### PR TITLE
OCP: Sync the cert-manager version used for OpenShift deployment with the version used by the rest of SPO and upgrade to 1.5.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -317,7 +317,7 @@ push-openshift-dev: set-openshift-image-params openshift-user image
 .PHONY: do-deploy-openshift-dev
 do-deploy-openshift-dev: $(BUILD_DIR)/kustomize
 	@echo "Deploying cert-manager"
-	oc apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
+	oc apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.4/cert-manager.yaml
 	oc wait --for=condition=Ready pod -lapp.kubernetes.io/instance=cert-manager -ncert-manager
 	@echo "Building custom operator.yaml"
 	$(BUILD_DIR)/kustomize build --reorder=none deploy/overlays/openshift-dev -o deploy/operator.yaml

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -30,7 +30,7 @@ dependencies:
       match: KUSTOMIZE_VERSION
 
   - name: cert-manager
-    version: 1.5.3
+    version: 1.5.4
     refPaths:
     - path: test/e2e_test.go
       match: jetstack/cert-manager

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -45,7 +45,7 @@ architectures `amd64` and `arm64` for now. To deploy the operator, first install
 cert-manager via `kubectl`:
 
 ```sh
-$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml
+$ kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.5.4/cert-manager.yaml
 $ kubectl --namespace cert-manager wait --for condition=ready pod -l app.kubernetes.io/instance=cert-manager
 ```
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -32,7 +32,7 @@ import (
 )
 
 const (
-	certmanager       = "https://github.com/jetstack/cert-manager/releases/download/v1.5.3/cert-manager.yaml"
+	certmanager       = "https://github.com/jetstack/cert-manager/releases/download/v1.5.4/cert-manager.yaml"
 	manifest          = "deploy/operator.yaml"
 	namespaceManifest = "deploy/namespace-operator.yaml"
 	testNamespace     = "test-ns"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We generally follow upstream releases of cert manager (see e.g. commit 
8708dfa1ca07813dc2d0ee133f648240078557b2) but the openshift Makefile 
targets drifted.

With OpenShift 4.9 rebasing to Kubernetes 1.22 this means that several APIs
the old version was using were deprecated and cert-manager no longer
worked.

See also:
   https://cert-manager.io/docs/release-notes/release-notes-1.5/ which
says:
   If you intend to upgrade to Kubernetes 1.22, you must upgrade to
   cert-manager 1.5.

#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```