### PR TITLE
Switch to GRPC sockets rather than using tcp ports

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -96,6 +96,15 @@ const (
 	// SelinuxPermissiveProfile is the selinux profile name for tracing AVC from
 	// the log enricher.
 	SelinuxPermissiveProfile = "selinuxrecording.process"
+
+	// GRPCServerSocketMetrics is the socket path for the GRPC metrics server.
+	GRPCServerSocketMetrics = "/var/run/grpc/metrics.sock"
+
+	// GRPCServerSocketEnricher is the socket path for the GRPC enricher server.
+	GRPCServerSocketEnricher = "/var/run/grpc/enricher.sock"
+
+	// GRPCServerSocketBpfRecorder is the socket path for the GRPC bpf recorder server.
+	GRPCServerSocketBpfRecorder = "/var/run/grpc/bpf-recorder.sock"
 )
 
 // ProfileRecordingOutputPath is the path where the recorded profiles will be

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorderfakes/fake_impl.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorderfakes/fake_impl.go
@@ -64,6 +64,19 @@ type FakeImpl struct {
 	bPFLoadObjectReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ChownStub        func(string, int, int) error
+	chownMutex       sync.RWMutex
+	chownArgsForCall []struct {
+		arg1 string
+		arg2 int
+		arg3 int
+	}
+	chownReturns struct {
+		result1 error
+	}
+	chownReturnsOnCall map[int]struct {
+		result1 error
+	}
 	ContainerIDForPIDStub        func(ttlcache.SimpleCache, int) (string, error)
 	containerIDForPIDMutex       sync.RWMutex
 	containerIDForPIDArgsForCall []struct {
@@ -249,6 +262,17 @@ type FakeImpl struct {
 	readOSReleaseReturnsOnCall map[int]struct {
 		result1 map[string]string
 		result2 error
+	}
+	RemoveAllStub        func(string) error
+	removeAllMutex       sync.RWMutex
+	removeAllArgsForCall []struct {
+		arg1 string
+	}
+	removeAllReturns struct {
+		result1 error
+	}
+	removeAllReturnsOnCall map[int]struct {
+		result1 error
 	}
 	ServeStub        func(*grpc.Server, net.Listener) error
 	serveMutex       sync.RWMutex
@@ -465,6 +489,69 @@ func (fake *FakeImpl) BPFLoadObjectReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.bPFLoadObjectReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) Chown(arg1 string, arg2 int, arg3 int) error {
+	fake.chownMutex.Lock()
+	ret, specificReturn := fake.chownReturnsOnCall[len(fake.chownArgsForCall)]
+	fake.chownArgsForCall = append(fake.chownArgsForCall, struct {
+		arg1 string
+		arg2 int
+		arg3 int
+	}{arg1, arg2, arg3})
+	stub := fake.ChownStub
+	fakeReturns := fake.chownReturns
+	fake.recordInvocation("Chown", []interface{}{arg1, arg2, arg3})
+	fake.chownMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) ChownCallCount() int {
+	fake.chownMutex.RLock()
+	defer fake.chownMutex.RUnlock()
+	return len(fake.chownArgsForCall)
+}
+
+func (fake *FakeImpl) ChownCalls(stub func(string, int, int) error) {
+	fake.chownMutex.Lock()
+	defer fake.chownMutex.Unlock()
+	fake.ChownStub = stub
+}
+
+func (fake *FakeImpl) ChownArgsForCall(i int) (string, int, int) {
+	fake.chownMutex.RLock()
+	defer fake.chownMutex.RUnlock()
+	argsForCall := fake.chownArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeImpl) ChownReturns(result1 error) {
+	fake.chownMutex.Lock()
+	defer fake.chownMutex.Unlock()
+	fake.ChownStub = nil
+	fake.chownReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) ChownReturnsOnCall(i int, result1 error) {
+	fake.chownMutex.Lock()
+	defer fake.chownMutex.Unlock()
+	fake.ChownStub = nil
+	if fake.chownReturnsOnCall == nil {
+		fake.chownReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.chownReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -1353,6 +1440,67 @@ func (fake *FakeImpl) ReadOSReleaseReturnsOnCall(i int, result1 map[string]strin
 	}{result1, result2}
 }
 
+func (fake *FakeImpl) RemoveAll(arg1 string) error {
+	fake.removeAllMutex.Lock()
+	ret, specificReturn := fake.removeAllReturnsOnCall[len(fake.removeAllArgsForCall)]
+	fake.removeAllArgsForCall = append(fake.removeAllArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.RemoveAllStub
+	fakeReturns := fake.removeAllReturns
+	fake.recordInvocation("RemoveAll", []interface{}{arg1})
+	fake.removeAllMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) RemoveAllCallCount() int {
+	fake.removeAllMutex.RLock()
+	defer fake.removeAllMutex.RUnlock()
+	return len(fake.removeAllArgsForCall)
+}
+
+func (fake *FakeImpl) RemoveAllCalls(stub func(string) error) {
+	fake.removeAllMutex.Lock()
+	defer fake.removeAllMutex.Unlock()
+	fake.RemoveAllStub = stub
+}
+
+func (fake *FakeImpl) RemoveAllArgsForCall(i int) string {
+	fake.removeAllMutex.RLock()
+	defer fake.removeAllMutex.RUnlock()
+	argsForCall := fake.removeAllArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImpl) RemoveAllReturns(result1 error) {
+	fake.removeAllMutex.Lock()
+	defer fake.removeAllMutex.Unlock()
+	fake.RemoveAllStub = nil
+	fake.removeAllReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) RemoveAllReturnsOnCall(i int, result1 error) {
+	fake.removeAllMutex.Lock()
+	defer fake.removeAllMutex.Unlock()
+	fake.RemoveAllStub = nil
+	if fake.removeAllReturnsOnCall == nil {
+		fake.removeAllReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.removeAllReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeImpl) Serve(arg1 *grpc.Server, arg2 net.Listener) error {
 	fake.serveMutex.Lock()
 	ret, specificReturn := fake.serveReturnsOnCall[len(fake.serveArgsForCall)]
@@ -1811,6 +1959,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.attachTracepointMutex.RUnlock()
 	fake.bPFLoadObjectMutex.RLock()
 	defer fake.bPFLoadObjectMutex.RUnlock()
+	fake.chownMutex.RLock()
+	defer fake.chownMutex.RUnlock()
 	fake.containerIDForPIDMutex.RLock()
 	defer fake.containerIDForPIDMutex.RUnlock()
 	fake.deleteKeyMutex.RLock()
@@ -1839,6 +1989,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.newModuleFromBufferArgsMutex.RUnlock()
 	fake.readOSReleaseMutex.RLock()
 	defer fake.readOSReleaseMutex.RUnlock()
+	fake.removeAllMutex.RLock()
+	defer fake.removeAllMutex.RUnlock()
 	fake.serveMutex.RLock()
 	defer fake.serveMutex.RUnlock()
 	fake.setTTLMutex.RLock()

--- a/internal/pkg/daemon/bpfrecorder/impl.go
+++ b/internal/pkg/daemon/bpfrecorder/impl.go
@@ -69,6 +69,8 @@ type impl interface {
 	DeleteKey(*bpf.BPFMap, uint32) error
 	ListPods(context.Context, *kubernetes.Clientset, string) (*v1.PodList, error)
 	GetName(seccomp.ScmpSyscall) (string, error)
+	RemoveAll(string) error
+	Chown(string, int, int) error
 }
 
 func (d *defaultImpl) SetTTL(cache ttlcache.SimpleCache, ttl time.Duration) error {
@@ -167,4 +169,12 @@ func (d *defaultImpl) ListPods(
 
 func (d *defaultImpl) GetName(s seccomp.ScmpSyscall) (string, error) {
 	return s.GetName()
+}
+
+func (d *defaultImpl) RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}
+
+func (d *defaultImpl) Chown(name string, uid, gid int) error {
+	return os.Chown(name, uid, gid)
 }

--- a/internal/pkg/daemon/enricher/enricher_test.go
+++ b/internal/pkg/daemon/enricher/enricher_test.go
@@ -156,6 +156,28 @@ func TestRun(t *testing.T) {
 				require.NotNil(t, err)
 			},
 		},
+		{ // failure on Listen
+			runAsync: false,
+			prepare: func(mock *enricherfakes.FakeImpl, lineChan chan *tail.Line) {
+				mock.GetenvReturns(node)
+				mock.DialReturns(nil, func() {}, errTest)
+				mock.ListenReturns(nil, errTest)
+			},
+			assert: func(mock *enricherfakes.FakeImpl, lineChan chan *tail.Line, err error) {
+				require.NotNil(t, err)
+			},
+		},
+		{ // failure on Chown
+			runAsync: false,
+			prepare: func(mock *enricherfakes.FakeImpl, lineChan chan *tail.Line) {
+				mock.GetenvReturns(node)
+				mock.DialReturns(nil, func() {}, errTest)
+				mock.ChownReturns(errTest)
+			},
+			assert: func(mock *enricherfakes.FakeImpl, lineChan chan *tail.Line, err error) {
+				require.NotNil(t, err)
+			},
+		},
 		{ // failure on Lines
 			runAsync: false,
 			prepare: func(mock *enricherfakes.FakeImpl, lineChan chan *tail.Line) {

--- a/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
+++ b/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
@@ -19,6 +19,7 @@ package enricherfakes
 
 import (
 	"context"
+	"io/fs"
 	"net"
 	"sync"
 	"time"
@@ -58,6 +59,19 @@ type FakeImpl struct {
 	auditIncReturnsOnCall map[int]struct {
 		result1 api_metrics.Metrics_AuditIncClient
 		result2 error
+	}
+	ChownStub        func(string, int, int) error
+	chownMutex       sync.RWMutex
+	chownArgsForCall []struct {
+		arg1 string
+		arg2 int
+		arg3 int
+	}
+	chownReturns struct {
+		result1 error
+	}
+	chownReturnsOnCall map[int]struct {
+		result1 error
 	}
 	CloseStub        func(*grpc.ClientConn) error
 	closeMutex       sync.RWMutex
@@ -210,6 +224,17 @@ type FakeImpl struct {
 	reasonReturnsOnCall map[int]struct {
 		result1 error
 	}
+	RemoveAllStub        func(string) error
+	removeAllMutex       sync.RWMutex
+	removeAllArgsForCall []struct {
+		arg1 string
+	}
+	removeAllReturns struct {
+		result1 error
+	}
+	removeAllReturnsOnCall map[int]struct {
+		result1 error
+	}
 	SendMetricStub        func(api_metrics.Metrics_AuditIncClient, *api_metrics.AuditRequest) error
 	sendMetricMutex       sync.RWMutex
 	sendMetricArgsForCall []struct {
@@ -245,6 +270,19 @@ type FakeImpl struct {
 	}
 	setTTLReturnsOnCall map[int]struct {
 		result1 error
+	}
+	StatStub        func(string) (fs.FileInfo, error)
+	statMutex       sync.RWMutex
+	statArgsForCall []struct {
+		arg1 string
+	}
+	statReturns struct {
+		result1 fs.FileInfo
+		result2 error
+	}
+	statReturnsOnCall map[int]struct {
+		result1 fs.FileInfo
+		result2 error
 	}
 	TailFileStub        func(string, tail.Config) (*tail.Tail, error)
 	tailFileMutex       sync.RWMutex
@@ -389,6 +427,69 @@ func (fake *FakeImpl) AuditIncReturnsOnCall(i int, result1 api_metrics.Metrics_A
 		result1 api_metrics.Metrics_AuditIncClient
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeImpl) Chown(arg1 string, arg2 int, arg3 int) error {
+	fake.chownMutex.Lock()
+	ret, specificReturn := fake.chownReturnsOnCall[len(fake.chownArgsForCall)]
+	fake.chownArgsForCall = append(fake.chownArgsForCall, struct {
+		arg1 string
+		arg2 int
+		arg3 int
+	}{arg1, arg2, arg3})
+	stub := fake.ChownStub
+	fakeReturns := fake.chownReturns
+	fake.recordInvocation("Chown", []interface{}{arg1, arg2, arg3})
+	fake.chownMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) ChownCallCount() int {
+	fake.chownMutex.RLock()
+	defer fake.chownMutex.RUnlock()
+	return len(fake.chownArgsForCall)
+}
+
+func (fake *FakeImpl) ChownCalls(stub func(string, int, int) error) {
+	fake.chownMutex.Lock()
+	defer fake.chownMutex.Unlock()
+	fake.ChownStub = stub
+}
+
+func (fake *FakeImpl) ChownArgsForCall(i int) (string, int, int) {
+	fake.chownMutex.RLock()
+	defer fake.chownMutex.RUnlock()
+	argsForCall := fake.chownArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeImpl) ChownReturns(result1 error) {
+	fake.chownMutex.Lock()
+	defer fake.chownMutex.Unlock()
+	fake.ChownStub = nil
+	fake.chownReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) ChownReturnsOnCall(i int, result1 error) {
+	fake.chownMutex.Lock()
+	defer fake.chownMutex.Unlock()
+	fake.ChownStub = nil
+	if fake.chownReturnsOnCall == nil {
+		fake.chownReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.chownReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeImpl) Close(arg1 *grpc.ClientConn) error {
@@ -1136,6 +1237,67 @@ func (fake *FakeImpl) ReasonReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeImpl) RemoveAll(arg1 string) error {
+	fake.removeAllMutex.Lock()
+	ret, specificReturn := fake.removeAllReturnsOnCall[len(fake.removeAllArgsForCall)]
+	fake.removeAllArgsForCall = append(fake.removeAllArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.RemoveAllStub
+	fakeReturns := fake.removeAllReturns
+	fake.recordInvocation("RemoveAll", []interface{}{arg1})
+	fake.removeAllMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) RemoveAllCallCount() int {
+	fake.removeAllMutex.RLock()
+	defer fake.removeAllMutex.RUnlock()
+	return len(fake.removeAllArgsForCall)
+}
+
+func (fake *FakeImpl) RemoveAllCalls(stub func(string) error) {
+	fake.removeAllMutex.Lock()
+	defer fake.removeAllMutex.Unlock()
+	fake.RemoveAllStub = stub
+}
+
+func (fake *FakeImpl) RemoveAllArgsForCall(i int) string {
+	fake.removeAllMutex.RLock()
+	defer fake.removeAllMutex.RUnlock()
+	argsForCall := fake.removeAllArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImpl) RemoveAllReturns(result1 error) {
+	fake.removeAllMutex.Lock()
+	defer fake.removeAllMutex.Unlock()
+	fake.RemoveAllStub = nil
+	fake.removeAllReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) RemoveAllReturnsOnCall(i int, result1 error) {
+	fake.removeAllMutex.Lock()
+	defer fake.removeAllMutex.Unlock()
+	fake.RemoveAllStub = nil
+	if fake.removeAllReturnsOnCall == nil {
+		fake.removeAllReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.removeAllReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeImpl) SendMetric(arg1 api_metrics.Metrics_AuditIncClient, arg2 *api_metrics.AuditRequest) error {
 	fake.sendMetricMutex.Lock()
 	ret, specificReturn := fake.sendMetricReturnsOnCall[len(fake.sendMetricArgsForCall)]
@@ -1322,6 +1484,70 @@ func (fake *FakeImpl) SetTTLReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeImpl) Stat(arg1 string) (fs.FileInfo, error) {
+	fake.statMutex.Lock()
+	ret, specificReturn := fake.statReturnsOnCall[len(fake.statArgsForCall)]
+	fake.statArgsForCall = append(fake.statArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	stub := fake.StatStub
+	fakeReturns := fake.statReturns
+	fake.recordInvocation("Stat", []interface{}{arg1})
+	fake.statMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) StatCallCount() int {
+	fake.statMutex.RLock()
+	defer fake.statMutex.RUnlock()
+	return len(fake.statArgsForCall)
+}
+
+func (fake *FakeImpl) StatCalls(stub func(string) (fs.FileInfo, error)) {
+	fake.statMutex.Lock()
+	defer fake.statMutex.Unlock()
+	fake.StatStub = stub
+}
+
+func (fake *FakeImpl) StatArgsForCall(i int) string {
+	fake.statMutex.RLock()
+	defer fake.statMutex.RUnlock()
+	argsForCall := fake.statArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImpl) StatReturns(result1 fs.FileInfo, result2 error) {
+	fake.statMutex.Lock()
+	defer fake.statMutex.Unlock()
+	fake.StatStub = nil
+	fake.statReturns = struct {
+		result1 fs.FileInfo
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) StatReturnsOnCall(i int, result1 fs.FileInfo, result2 error) {
+	fake.statMutex.Lock()
+	defer fake.statMutex.Unlock()
+	fake.StatStub = nil
+	if fake.statReturnsOnCall == nil {
+		fake.statReturnsOnCall = make(map[int]struct {
+			result1 fs.FileInfo
+			result2 error
+		})
+	}
+	fake.statReturnsOnCall[i] = struct {
+		result1 fs.FileInfo
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeImpl) TailFile(arg1 string, arg2 tail.Config) (*tail.Tail, error) {
 	fake.tailFileMutex.Lock()
 	ret, specificReturn := fake.tailFileReturnsOnCall[len(fake.tailFileArgsForCall)]
@@ -1394,6 +1620,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.addToBacklogMutex.RUnlock()
 	fake.auditIncMutex.RLock()
 	defer fake.auditIncMutex.RUnlock()
+	fake.chownMutex.RLock()
+	defer fake.chownMutex.RUnlock()
 	fake.closeMutex.RLock()
 	defer fake.closeMutex.RUnlock()
 	fake.containerIDForPIDMutex.RLock()
@@ -1418,12 +1646,16 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.newForConfigMutex.RUnlock()
 	fake.reasonMutex.RLock()
 	defer fake.reasonMutex.RUnlock()
+	fake.removeAllMutex.RLock()
+	defer fake.removeAllMutex.RUnlock()
 	fake.sendMetricMutex.RLock()
 	defer fake.sendMetricMutex.RUnlock()
 	fake.serveMutex.RLock()
 	defer fake.serveMutex.RUnlock()
 	fake.setTTLMutex.RLock()
 	defer fake.setTTLMutex.RUnlock()
+	fake.statMutex.RLock()
+	defer fake.statMutex.RUnlock()
 	fake.tailFileMutex.RLock()
 	defer fake.tailFileMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/internal/pkg/daemon/enricher/impl.go
+++ b/internal/pkg/daemon/enricher/impl.go
@@ -58,6 +58,9 @@ type impl interface {
 	AddToBacklog(cache *ttlcache.Cache, key string, data interface{}) error
 	GetFromBacklog(cache *ttlcache.Cache, key string) (interface{}, error)
 	FlushBacklog(cache *ttlcache.Cache, key string) error
+	Chown(string, int, int) error
+	Stat(string) (os.FileInfo, error)
+	RemoveAll(string) error
 }
 
 func (d *defaultImpl) SetTTL(cache ttlcache.SimpleCache, ttl time.Duration) error {
@@ -149,4 +152,16 @@ func (d *defaultImpl) Serve(grpcServer *grpc.Server, listener net.Listener) erro
 
 func (d *defaultImpl) Listen(network, address string) (net.Listener, error) {
 	return net.Listen(network, address)
+}
+
+func (d *defaultImpl) Chown(name string, uid, gid int) error {
+	return os.Chown(name, uid, gid)
+}
+
+func (d *defaultImpl) Stat(name string) (os.FileInfo, error) {
+	return os.Stat(name)
+}
+
+func (d *defaultImpl) RemoveAll(path string) error {
+	return os.RemoveAll(path)
 }

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -229,6 +229,10 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 								Name:      "profile-recording-output-volume",
 								MountPath: config.ProfileRecordingOutputPath,
 							},
+							{
+								Name:      "grpc-server-volume",
+								MountPath: filepath.Dir(config.GRPCServerSocketMetrics),
+							},
 						},
 						SecurityContext: &v1.SecurityContext{
 							AllowPrivilegeEscalation: &falsely,
@@ -374,6 +378,10 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 								MountPath: filepath.Dir(config.SyslogLogPath),
 								ReadOnly:  true,
 							},
+							{
+								Name:      "grpc-server-volume",
+								MountPath: filepath.Dir(config.GRPCServerSocketEnricher),
+							},
 						},
 						SecurityContext: &v1.SecurityContext{
 							ReadOnlyRootFilesystem: &truly,
@@ -424,6 +432,10 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 							{
 								Name:      "tmp-volume",
 								MountPath: "/tmp",
+							},
+							{
+								Name:      "grpc-server-volume",
+								MountPath: filepath.Dir(config.GRPCServerSocketBpfRecorder),
 							},
 						},
 						SecurityContext: &v1.SecurityContext{
@@ -626,6 +638,12 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 					},
 					{
 						Name: "tmp-volume",
+						VolumeSource: v1.VolumeSource{
+							EmptyDir: &v1.EmptyDirVolumeSource{},
+						},
+					},
+					{
+						Name: "grpc-server-volume",
 						VolumeSource: v1.VolumeSource{
 							EmptyDir: &v1.EmptyDirVolumeSource{},
 						},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
The enricher as well as the bpf recorder require host network for cgroup
determination. This means if we already serve something on the GRPC tcp
ports, then the operator will fail to deploy.

To work around this error-case, we now rely on unix domain sockets
rather than TCP ports.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
Refers to https://github.com/kubernetes-sigs/security-profiles-operator/pull/618#discussion_r739696303
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Switched to unix domain sockets for the GRPC servers.
```
