### PR TITLE
Remove no_bpf build tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,10 +24,11 @@ jobs:
       - uses: actions/setup-go@v2
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Install libseccomp-dev
+      - name: Install dependencies
         run: |
           sudo apt update
-          sudo apt install -y libseccomp-dev
+          sudo apt install -y libseccomp-dev libelf-dev
+          sudo hack/install-libbpf.sh
       - run: make test-unit
       - uses: codecov/codecov-action@v1
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,6 +2,12 @@
 run:
   concurrency: 6
   deadline: 5m
+issues:
+  exclude-rules:
+    - path: internal/pkg/daemon/bpfrecorder/generated.go
+      linters:
+        - gofumpt
+        - lll
 linters:
   disable-all: true
   enable:

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -16,9 +16,24 @@ FROM registry.fedoraproject.org/fedora-minimal:latest AS build
 USER root
 WORKDIR /work
 
-RUN microdnf install -y make golang-bin libseccomp-static glibc-static
+RUN microdnf install -y \
+        bzip2 \
+        curl-devel \
+        g++ \
+        glibc-static \
+        golang-bin \
+        libarchive-devel \
+        libmicrohttpd-devel \
+        libseccomp-static \
+        m4 \
+        make \
+        sqlite-devel \
+        tar \
+        zlib-static
 
 ADD . /work
+RUN hack/install-libelf.sh
+RUN hack/install-libbpf.sh
 RUN mkdir -p build
 
 RUN make

--- a/Makefile
+++ b/Makefile
@@ -45,17 +45,11 @@ GIT_COMMIT := $(shell git rev-parse HEAD 2> /dev/null || echo unknown)
 GIT_TREE_STATE := $(if $(shell git status --porcelain --untracked-files=no),dirty,clean)
 VERSION := $(shell cat VERSION)
 
-ifdef WITH_BPF
-export CGO_LDFLAGS=-lelf -lz -lbpf -lseccomp
-BPF_BUILD_TAG :=
-else
-BPF_BUILD_TAG := no_bpf
-endif
-
 ifneq ($(shell uname -s), Darwin)
-BUILDTAGS := netgo osusergo seccomp $(BPF_BUILD_TAG)
+export CGO_LDFLAGS=-lelf -lz -lbpf -lseccomp
+BUILDTAGS := netgo osusergo seccomp
 else
-BUILDTAGS := netgo osusergo $(BPF_BUILD_TAG)
+BUILDTAGS := netgo osusergo
 endif
 
 ifneq ($(shell uname -s), Darwin)
@@ -333,7 +327,7 @@ test-unit: $(BUILD_DIR) ## Run the unit tests
 
 .PHONY: test-e2e
 test-e2e: ## Run the end-to-end tests
-	$(GO) test -parallel 1 -timeout 80m -count=1 ./test/... -v
+	CGO_LDFLAGS= $(GO) test -parallel 1 -timeout 80m -count=1 ./test/... -v
 
 # Generate CRD manifests
 manifests:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -100,3 +100,15 @@ dependencies:
     refPaths:
     - path: cloudbuild.yaml
       match: gcr.io/k8s-testimages/gcb-docker-gcloud
+
+  - name: libbpf
+    version: 0.5.0
+    refPaths:
+    - path: hack/install-libbpf.sh
+      match: VERSION
+
+  - name: libelf
+    version: 0.185
+    refPaths:
+    - path: hack/install-libelf.sh
+      match: VERSION

--- a/go.mod
+++ b/go.mod
@@ -31,5 +31,3 @@ require (
 	sigs.k8s.io/release-utils v0.3.0
 	sigs.k8s.io/zeitgeist v0.3.0
 )
-
-replace github.com/aquasecurity/libbpfgo => github.com/saschagrunert/libbpfgo v0.2.1-libbpf-0.4.0.0.20211026092140-9b286c168b65

--- a/go.sum
+++ b/go.sum
@@ -115,6 +115,8 @@ github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
+github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210928164917-f097a0171b12 h1:QLp21PoE/3ScbhcdZsmu3EoR01JTp8uEoPn4F1wd3Kc=
+github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210928164917-f097a0171b12/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
@@ -900,8 +902,6 @@ github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
-github.com/saschagrunert/libbpfgo v0.2.1-libbpf-0.4.0.0.20211026092140-9b286c168b65 h1:JaWygnqEPl1x9R5ISZHO2zKY0YDsLXrGchYkChrKdag=
-github.com/saschagrunert/libbpfgo v0.2.1-libbpf-0.4.0.0.20211026092140-9b286c168b65/go.mod h1:/+clceXE103FaXvVTIY2HAkQjxNtkra4DRWvZYr2SKw=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.4.0 h1:z/Q9idDcay5m5irkZ28M7PtQM4aOISzOpj4bUPkDee8=
 github.com/sclevine/spec v1.4.0/go.mod h1:LvpgJaFyvQzRvc1kaDs0bulYwzC70PbiYjC4QnFHkOM=

--- a/hack/install-libbpf.sh
+++ b/hack/install-libbpf.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+VERSION=0.5.0
+curl -sSfL --retry 5 --retry-delay 3 \
+    "https://github.com/libbpf/libbpf/archive/refs/tags/v$VERSION.tar.gz" -o- |
+    tar xfz -
+pushd "libbpf-$VERSION/src"
+make BUILD_STATIC_ONLY=y install
+popd
+rm -rf "libbpf-$VERSION"

--- a/hack/install-libelf.sh
+++ b/hack/install-libelf.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Copyright 2021 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -euo pipefail
+
+curl_retry() {
+    curl -sSfL --retry 5 --retry-delay 3 "$@"
+}
+
+VERSION=0.185
+URL="https://sourceware.org/elfutils/ftp/$VERSION/elfutils-$VERSION.tar.bz2"
+TAR_FILE=elfutils.tar.bz2
+KEY=12768A96795990107A0D2FDFFC57E3CCACD99A78
+
+curl_retry "$URL" -o $TAR_FILE
+curl_retry "$URL.sig" -o $TAR_FILE.sig
+
+gpg --keyserver hkp://keys.gnupg.net --recv-keys $KEY
+gpg --verify $TAR_FILE.sig $TAR_FILE
+
+tar xfj $TAR_FILE
+pushd "elfutils-$VERSION"
+
+./configure
+make install
+
+popd
+rm -rf "elfutils-$VERSION" $TAR_FILE $TAR_FILE.sig

--- a/hack/pull-security-profiles-operator-build
+++ b/hack/pull-security-profiles-operator-build
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # assume a Debian based golang image, like: golang:1.16
 apt-get update
-apt-get install -y libseccomp-dev
+apt-get install -y libseccomp-dev libelf-dev
+./hack/install-libbpf.sh
 
 make

--- a/hack/pull-security-profiles-operator-test-unit
+++ b/hack/pull-security-profiles-operator-test-unit
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # assume a Debian based golang image, like: golang:1.16
 apt-get update
-apt-get install -y libseccomp-dev
+apt-get install -y libseccomp-dev libelf-dev
+./hack/install-libbpf.sh
 
 make test-unit

--- a/hack/pull-security-profiles-operator-verify
+++ b/hack/pull-security-profiles-operator-verify
@@ -3,6 +3,7 @@ set -euo pipefail
 
 # assume a Debian based golang image, like: golang:1.16
 apt-get update
-apt-get install -y libseccomp-dev python3
+apt-get install -y libseccomp-dev libelf-dev python3
+./hack/install-libbpf.sh
 
 make verify

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_unsupported.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux no_bpf
+// +build !linux
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/internal/pkg/daemon/bpfrecorder/generate/main.go
+++ b/internal/pkg/daemon/bpfrecorder/generate/main.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/bpfrecorder/types"
 )
 
-const header = `// +build linux,!no_bpf
+const header = `// +build linux
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/internal/pkg/daemon/bpfrecorder/generated.go
+++ b/internal/pkg/daemon/bpfrecorder/generated.go
@@ -1,5 +1,5 @@
-//go:build linux && !no_bpf
-// +build linux,!no_bpf
+//go:build linux
+// +build linux
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/vendor/github.com/aquasecurity/libbpfgo/Readme.md
+++ b/vendor/github.com/aquasecurity/libbpfgo/Readme.md
@@ -64,15 +64,6 @@ $ make selftest-static-run => will build & run all static selftests
 > Note 01: dynamic builds need your OS to have a *recent enough* libbpf package (and its headers) installed. Sometimes, recent features might require the use of backported OS packages in order for your OS to contain latest *libbpf* features (sometimes required by libbpfgo).
 > Note 02: static builds need `git submodule init` first. Make sure to sync the *libbpf* git submodule before trying to statically compile or test the *libbpfgo* repository.
 
-### Build tags
-
-If a project wants to make the libbpfgo dependencies (libbpf, libz, libelf)
-optional, then it can disable bpf support by using the build tag `no_bpf`:
-
-```bash
-go build -tags no_bpf ./...
-```
-
 ## Concepts
 
 libbpfgo tries to make it natural for Go developers to use, by abstracting away C technicalities. For example, it will translate low level return codes into Go `error`, it will organize functionality around Go `struct`, and it will use `channel` as to let you consume events.

--- a/vendor/github.com/aquasecurity/libbpfgo/libbpf_cb.go
+++ b/vendor/github.com/aquasecurity/libbpfgo/libbpf_cb.go
@@ -1,5 +1,3 @@
-// +build !no_bpf
-
 package libbpfgo
 
 import (

--- a/vendor/github.com/aquasecurity/libbpfgo/libbpfgo.go
+++ b/vendor/github.com/aquasecurity/libbpfgo/libbpfgo.go
@@ -1,5 +1,3 @@
-// +build !no_bpf
-
 package libbpfgo
 
 /*

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -4,7 +4,7 @@ github.com/BurntSushi/toml/internal
 # github.com/ReneKroon/ttlcache/v2 v2.9.0
 ## explicit
 github.com/ReneKroon/ttlcache/v2
-# github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210928164917-f097a0171b12 => github.com/saschagrunert/libbpfgo v0.2.1-libbpf-0.4.0.0.20211026092140-9b286c168b65
+# github.com/aquasecurity/libbpfgo v0.2.1-libbpf-0.4.0.0.20210928164917-f097a0171b12
 ## explicit
 github.com/aquasecurity/libbpfgo
 github.com/aquasecurity/libbpfgo/helpers
@@ -794,4 +794,3 @@ sigs.k8s.io/zeitgeist/internal/github/internal
 sigs.k8s.io/zeitgeist/internal/release/regex
 sigs.k8s.io/zeitgeist/pkg/gitlab
 sigs.k8s.io/zeitgeist/upstreams
-# github.com/aquasecurity/libbpfgo => github.com/saschagrunert/libbpfgo v0.2.1-libbpf-0.4.0.0.20211026092140-9b286c168b65


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Target is to get rid of the overwritten go module and always build-in BPF support.
#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

None

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
