### PR TITLE
Reuse util.ContainerIDForPID in enricher

### DIFF
--- a/internal/pkg/daemon/enricher/enricher.go
+++ b/internal/pkg/daemon/enricher/enricher.go
@@ -173,7 +173,7 @@ func (e *Enricher) Run() error {
 			continue
 		}
 
-		cID, err := e.getContainerID(auditLine.processID)
+		cID, err := e.impl.ContainerIDForPID(e.containerIDCache, auditLine.processID)
 		if errors.Is(err, os.ErrNotExist) {
 			// We're probably in container creation or removal
 			if backlogErr := e.addToBacklog(auditLine); backlogErr != nil {

--- a/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
+++ b/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
@@ -20,7 +20,6 @@ package enricherfakes
 import (
 	"context"
 	"net"
-	"os"
 	"sync"
 	"time"
 
@@ -70,6 +69,20 @@ type FakeImpl struct {
 	}
 	closeReturnsOnCall map[int]struct {
 		result1 error
+	}
+	ContainerIDForPIDStub        func(ttlcache.SimpleCache, int) (string, error)
+	containerIDForPIDMutex       sync.RWMutex
+	containerIDForPIDArgsForCall []struct {
+		arg1 ttlcache.SimpleCache
+		arg2 int
+	}
+	containerIDForPIDReturns struct {
+		result1 string
+		result2 error
+	}
+	containerIDForPIDReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
 	}
 	DialStub        func() (*grpc.ClientConn, context.CancelFunc, error)
 	dialMutex       sync.RWMutex
@@ -184,19 +197,6 @@ type FakeImpl struct {
 	}
 	newForConfigReturnsOnCall map[int]struct {
 		result1 *kubernetes.Clientset
-		result2 error
-	}
-	OpenStub        func(string) (*os.File, error)
-	openMutex       sync.RWMutex
-	openArgsForCall []struct {
-		arg1 string
-	}
-	openReturns struct {
-		result1 *os.File
-		result2 error
-	}
-	openReturnsOnCall map[int]struct {
-		result1 *os.File
 		result2 error
 	}
 	ReasonStub        func(*tail.Tail) error
@@ -450,6 +450,71 @@ func (fake *FakeImpl) CloseReturnsOnCall(i int, result1 error) {
 	fake.closeReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeImpl) ContainerIDForPID(arg1 ttlcache.SimpleCache, arg2 int) (string, error) {
+	fake.containerIDForPIDMutex.Lock()
+	ret, specificReturn := fake.containerIDForPIDReturnsOnCall[len(fake.containerIDForPIDArgsForCall)]
+	fake.containerIDForPIDArgsForCall = append(fake.containerIDForPIDArgsForCall, struct {
+		arg1 ttlcache.SimpleCache
+		arg2 int
+	}{arg1, arg2})
+	stub := fake.ContainerIDForPIDStub
+	fakeReturns := fake.containerIDForPIDReturns
+	fake.recordInvocation("ContainerIDForPID", []interface{}{arg1, arg2})
+	fake.containerIDForPIDMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) ContainerIDForPIDCallCount() int {
+	fake.containerIDForPIDMutex.RLock()
+	defer fake.containerIDForPIDMutex.RUnlock()
+	return len(fake.containerIDForPIDArgsForCall)
+}
+
+func (fake *FakeImpl) ContainerIDForPIDCalls(stub func(ttlcache.SimpleCache, int) (string, error)) {
+	fake.containerIDForPIDMutex.Lock()
+	defer fake.containerIDForPIDMutex.Unlock()
+	fake.ContainerIDForPIDStub = stub
+}
+
+func (fake *FakeImpl) ContainerIDForPIDArgsForCall(i int) (ttlcache.SimpleCache, int) {
+	fake.containerIDForPIDMutex.RLock()
+	defer fake.containerIDForPIDMutex.RUnlock()
+	argsForCall := fake.containerIDForPIDArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeImpl) ContainerIDForPIDReturns(result1 string, result2 error) {
+	fake.containerIDForPIDMutex.Lock()
+	defer fake.containerIDForPIDMutex.Unlock()
+	fake.ContainerIDForPIDStub = nil
+	fake.containerIDForPIDReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) ContainerIDForPIDReturnsOnCall(i int, result1 string, result2 error) {
+	fake.containerIDForPIDMutex.Lock()
+	defer fake.containerIDForPIDMutex.Unlock()
+	fake.ContainerIDForPIDStub = nil
+	if fake.containerIDForPIDReturnsOnCall == nil {
+		fake.containerIDForPIDReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.containerIDForPIDReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeImpl) Dial() (*grpc.ClientConn, context.CancelFunc, error) {
@@ -1010,70 +1075,6 @@ func (fake *FakeImpl) NewForConfigReturnsOnCall(i int, result1 *kubernetes.Clien
 	}{result1, result2}
 }
 
-func (fake *FakeImpl) Open(arg1 string) (*os.File, error) {
-	fake.openMutex.Lock()
-	ret, specificReturn := fake.openReturnsOnCall[len(fake.openArgsForCall)]
-	fake.openArgsForCall = append(fake.openArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	stub := fake.OpenStub
-	fakeReturns := fake.openReturns
-	fake.recordInvocation("Open", []interface{}{arg1})
-	fake.openMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeImpl) OpenCallCount() int {
-	fake.openMutex.RLock()
-	defer fake.openMutex.RUnlock()
-	return len(fake.openArgsForCall)
-}
-
-func (fake *FakeImpl) OpenCalls(stub func(string) (*os.File, error)) {
-	fake.openMutex.Lock()
-	defer fake.openMutex.Unlock()
-	fake.OpenStub = stub
-}
-
-func (fake *FakeImpl) OpenArgsForCall(i int) string {
-	fake.openMutex.RLock()
-	defer fake.openMutex.RUnlock()
-	argsForCall := fake.openArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeImpl) OpenReturns(result1 *os.File, result2 error) {
-	fake.openMutex.Lock()
-	defer fake.openMutex.Unlock()
-	fake.OpenStub = nil
-	fake.openReturns = struct {
-		result1 *os.File
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeImpl) OpenReturnsOnCall(i int, result1 *os.File, result2 error) {
-	fake.openMutex.Lock()
-	defer fake.openMutex.Unlock()
-	fake.OpenStub = nil
-	if fake.openReturnsOnCall == nil {
-		fake.openReturnsOnCall = make(map[int]struct {
-			result1 *os.File
-			result2 error
-		})
-	}
-	fake.openReturnsOnCall[i] = struct {
-		result1 *os.File
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeImpl) Reason(arg1 *tail.Tail) error {
 	fake.reasonMutex.Lock()
 	ret, specificReturn := fake.reasonReturnsOnCall[len(fake.reasonArgsForCall)]
@@ -1395,6 +1396,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.auditIncMutex.RUnlock()
 	fake.closeMutex.RLock()
 	defer fake.closeMutex.RUnlock()
+	fake.containerIDForPIDMutex.RLock()
+	defer fake.containerIDForPIDMutex.RUnlock()
 	fake.dialMutex.RLock()
 	defer fake.dialMutex.RUnlock()
 	fake.flushBacklogMutex.RLock()
@@ -1413,8 +1416,6 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.listenMutex.RUnlock()
 	fake.newForConfigMutex.RLock()
 	defer fake.newForConfigMutex.RUnlock()
-	fake.openMutex.RLock()
-	defer fake.openMutex.RUnlock()
 	fake.reasonMutex.RLock()
 	defer fake.reasonMutex.RUnlock()
 	fake.sendMetricMutex.RLock()

--- a/internal/pkg/daemon/enricher/impl.go
+++ b/internal/pkg/daemon/enricher/impl.go
@@ -32,6 +32,7 @@ import (
 
 	api "sigs.k8s.io/security-profiles-operator/api/grpc/metrics"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/metrics"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/util"
 )
 
 type defaultImpl struct{}
@@ -46,7 +47,7 @@ type impl interface {
 	TailFile(filename string, config tail.Config) (*tail.Tail, error)
 	Lines(tailFile *tail.Tail) chan *tail.Line
 	Reason(tailFile *tail.Tail) error
-	Open(name string) (*os.File, error)
+	ContainerIDForPID(cache ttlcache.SimpleCache, pid int) (string, error)
 	InClusterConfig() (*rest.Config, error)
 	NewForConfig(c *rest.Config) (*kubernetes.Clientset, error)
 	ListPods(c *kubernetes.Clientset, nodeName string) (*v1.PodList, error)
@@ -89,8 +90,8 @@ func (d *defaultImpl) Reason(tailFile *tail.Tail) error {
 	return tailFile.Err()
 }
 
-func (d *defaultImpl) Open(name string) (*os.File, error) {
-	return os.Open(name)
+func (d *defaultImpl) ContainerIDForPID(cache ttlcache.SimpleCache, pid int) (string, error) {
+	return util.ContainerIDForPID(cache, pid)
 }
 
 func (d *defaultImpl) InClusterConfig() (*rest.Config, error) {

--- a/internal/pkg/util/containers_test.go
+++ b/internal/pkg/util/containers_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package enricher
+package util
 
 import (
 	"testing"
@@ -56,7 +56,7 @@ func TestExtractContainerID(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := regexID.FindString(tt.cgroupLine)
+			got := ContainerIDRegex.FindString(tt.cgroupLine)
 			require.Equal(t, tt.want, got)
 		})
 	}


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We now reuse the utility function to cleanup parts of the enricher
implementation.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
