### PR TITLE
Make cgroup tracking more robust

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
@@ -62,6 +62,10 @@ const (
 	verboseLvl          int           = 4
 )
 
+var excludeComms = []string{
+	"conmon", // container monitoring daemon from CRI-O
+}
+
 // BpfRecorder is the main structure of this package.
 type BpfRecorder struct {
 	api.UnimplementedBpfRecorderServer
@@ -224,6 +228,11 @@ func (b *BpfRecorder) SyscallsForProfile(
 
 	result := []string{}
 	for _, pid := range pids {
+		if util.Contains(excludeComms, pid.comm) {
+			b.logger.Info("Filtering syscalls from excluded command: " + pid.comm)
+			continue
+		}
+
 		pidKey := pid.id
 		syscalls, err := b.syscalls.GetValue(unsafe.Pointer(&pidKey))
 		if err != nil {

--- a/internal/pkg/manager/workloadannotator/workloadannotator.go
+++ b/internal/pkg/manager/workloadannotator/workloadannotator.go
@@ -174,19 +174,11 @@ func getSeccompProfilesFromPod(pod *corev1.Pod) []string {
 	// try to get profile(s) from securityContext in pods
 	containers := pod.Spec.Containers
 	containers = append(containers, pod.Spec.InitContainers...)
-	contains := func(a []string, b string) bool {
-		for _, s := range a {
-			if s == b {
-				return true
-			}
-		}
-		return false
-	}
 	for i := range containers {
 		sc := containers[i].SecurityContext
 		if sc != nil && isOperatorSeccompProfile(sc.SeccompProfile) {
 			profileString := *containers[i].SecurityContext.SeccompProfile.LocalhostProfile
-			if !contains(profiles, profileString) {
+			if !util.Contains(profiles, profileString) {
 				profiles = append(profiles, profileString)
 			}
 		}
@@ -195,7 +187,7 @@ func getSeccompProfilesFromPod(pod *corev1.Pod) []string {
 	annotation, hasAnnotation := pod.GetAnnotations()[corev1.SeccompPodAnnotationKey]
 	if hasAnnotation && strings.HasPrefix(annotation, "localhost/") {
 		profileString := strings.TrimPrefix(annotation, "localhost/")
-		if !contains(profiles, profileString) {
+		if !util.Contains(profiles, profileString) {
 			profiles = append(profiles, profileString)
 		}
 	}

--- a/internal/pkg/util/containers.go
+++ b/internal/pkg/util/containers.go
@@ -23,7 +23,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
-	"strings"
 
 	"github.com/ReneKroon/ttlcache/v2"
 	"github.com/pkg/errors"
@@ -70,11 +69,6 @@ func ContainerIDForPID(cache ttlcache.SimpleCache, pid int) (string, error) {
 	scanner := bufio.NewScanner(file)
 	for scanner.Scan() {
 		text := scanner.Text()
-
-		// exclude conmon, the container monitor of CRI-O
-		if strings.Contains(text, "/crio-conmon-") {
-			continue
-		}
 
 		if containerID := ContainerIDRegex.FindString(text); containerID != "" {
 			// Update the cache

--- a/internal/pkg/util/names.go
+++ b/internal/pkg/util/names.go
@@ -24,3 +24,13 @@ func NamespacedName(name, namespace string) types.NamespacedName {
 		Namespace: namespace,
 	}
 }
+
+// Contains returns true if the slice a contains string b.
+func Contains(a []string, b string) bool {
+	for _, s := range a {
+		if s == b {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:
Testing with different runtimes reveled that we cannot skip the
"crio-conmon-" cgroup because it may be temporarily the target cgroup to
track. To still filter out `conmon` as a process, we now use a list of
filtered comms during syscall accumulation.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
