### PR TITLE
selinux: Don't emit errors or events if we're only waiting for selinuxd to remove policy

### DIFF
--- a/internal/pkg/daemon/selinuxprofile/selinuxpolicy_controller.go
+++ b/internal/pkg/daemon/selinuxprofile/selinuxpolicy_controller.go
@@ -180,9 +180,13 @@ func (r *ReconcileSP) Reconcile(_ context.Context, request reconcile.Request) (r
 	}
 
 	res, err := r.reconcileDeletePolicy(instance, nodeStatus, reqLogger)
-	if res.Requeue || err != nil {
+	if err != nil {
+		reqLogger.Error(err, "cannot delete policy or requeue")
 		r.metrics.IncSelinuxProfileError(reasonCannotRemovePolicy)
 		r.record.Event(instance, event.Warning(reasonCannotRemovePolicy, err))
+		return res, err
+	} else if res.Requeue {
+		reqLogger.Info("Re-queueing delete request to make sure the policy is gone")
 		return res, err
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In case selinuxd is taking its time to delete a policy, the
reconcileDeletePolicy method in the selinuxprofile controller might just
tell the controller to requeue and try again later. But because the code
was conflating handling of this case with a genuine error, it would have
tried to also emit an error metric for SELinux as well as an event.

It appears as emiting the event, which accepts the error as an argument
might cause a crash:
```
I1104 19:34:02.701789   57516 selinuxpolicy_controller.go:356] selinuxprofile "msg"="Removing policy file" "Request.Name"="errorlogger" "Request.Namespace"="default" "policyPath"="/etc/selinux.d/errorlogger_default.cil"
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x172683e]

goroutine 383 [running]:
github.com/crossplane/crossplane-runtime/pkg/event.Warning(0x1cbb0ef, 0x19, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        github.com/crossplane/crossplane-runtime@v0.14.1-0.20210713194031-85b19c28ea88/pkg/event/event.go:63 +0x5e
sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/selinuxprofile.(*ReconcileSP).Reconcile(0xc000163540, 0x1f1e038, 0xc00002d860, 0xc0007a3639, 0x7, 0xc0007a3624, 0xb, 0xc00002d860, 0xc00002d830, 0xc00054fdb0, ...)
        sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/selinuxprofile/selinuxpolicy_controller.go:185 +0x6be
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Reconcile(0xc000181540, 0x1f1e038, 0xc00002d830, 0xc0007a3639, 0x7, 0xc0007a3624, 0xb, 0xc00002d800, 0x0, 0x0, ...)
        sigs.k8s.io/controller-runtime@v0.10.2/pkg/internal/controller/controller.go:114 +0x247
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler(0xc000181540, 0x1f1df90, 0xc000162f00, 0x1adff00, 0xc000048220)
        sigs.k8s.io/controller-runtime@v0.10.2/pkg/internal/controller/controller.go:311 +0x305
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem(0xc000181540, 0x1f1df90, 0xc000162f00, 0x0)
        sigs.k8s.io/controller-runtime@v0.10.2/pkg/internal/controller/controller.go:266 +0x205
sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2.2(0xc0004b1950, 0xc000181540, 0x1f1df90, 0xc000162f00)
        sigs.k8s.io/controller-runtime@v0.10.2/pkg/internal/controller/controller.go:227 +0x6b
created by sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
        sigs.k8s.io/controller-runtime@v0.10.2/pkg/internal/controller/controller.go:223 +0x425
{"level":"info","ts":1636054442.7021089,"logger":"file-watcher","caller":"daemon/daemon.go:89","msg":"Removing policy","file":"/etc/selinux.d/errorlogger_default.cil"}
{"level":"info","ts":1636054442.8720913,"caller":"semanage/semanage.go:89","msg":"Removing last errorlogger_default module (no other errorlogger_default module exists at another priority)."}
{"level":"info","ts":1636054450.455779,"logger":"policy-installer","caller":"daemon/daemon.go:130","msg":"The operation was successful","operation":"remove - /etc/selinux.d/errorlogger_default.cil"}
```

This patch changes the logic so that the events and metrics are only emited
in case of an error and not a requeue.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```