### PR TITLE
Suppress one linter issue

### DIFF
--- a/test/tc_profilerecordings_test.go
+++ b/test/tc_profilerecordings_test.go
@@ -262,7 +262,6 @@ spec:
 	err = testFile.Close()
 	e.Nil(err)
 
-	since := time.Now() // nolint: ifshort
 	e.kubectl("create", "-f", testFile.Name())
 
 	const deployName = "my-deployment"
@@ -270,6 +269,7 @@ spec:
 	e.waitFor("condition=available", "deploy", deployName)
 
 	if waitConditions != nil {
+		since := time.Now()
 		e.waitForEnricherLogs(since, waitConditions...)
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The first patch (ifshort) was spotted by Sascha during a code review. The
second is something I started seeing locally and have no idea why it's not
showing up in CI. The second warning seems totally wrong to me, but I keep
getting linter errors locally otherwise, so I decided to suppress it.

#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
I'm running:
```
jhrozek@kyubey:~/devel/security-profiles-operator|misc ⇒  go version
go version go1.17.1 linux/amd64
jhrozek@kyubey:~/devel/security-profiles-operator|misc ⇒  ./build/golangci-lint version
golangci-lint has version 1.42.0 built from c6142e38 on 2021-08-17T11:47:22Z
```
As said earlier I think the second warning is either a linter issue or something
is up with my local setup. If someone can spot where the problem is, that would
be preferable over adding a suppression.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE

```