### PR TITLE
Early give-up on short-lived processes

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_test.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_test.go
@@ -602,7 +602,7 @@ func TestSyscallsForProfile(t *testing.T) {
 				mock.GetValueReturns(nil, errTest)
 			},
 			assert: func(sut *BpfRecorder, resp *api.SyscallsResponse, err error) {
-				require.NotNil(t, err)
+				require.Nil(t, err)
 			},
 		},
 	} {

--- a/internal/pkg/daemon/bpfrecorder/impl.go
+++ b/internal/pkg/daemon/bpfrecorder/impl.go
@@ -34,6 +34,7 @@ import (
 	"github.com/ReneKroon/ttlcache/v2"
 	bpf "github.com/aquasecurity/libbpfgo"
 	"github.com/cobaugh/osrelease"
+	"github.com/pkg/errors"
 	seccomp "github.com/seccomp/libseccomp-golang"
 	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
@@ -160,10 +161,16 @@ func (d *defaultImpl) ContainerIDForPID(cache ttlcache.SimpleCache, pid int) (st
 }
 
 func (d *defaultImpl) GetValue(m *bpf.BPFMap, key uint32) ([]byte, error) {
+	if m == nil {
+		return nil, errors.New("provided bpf map is nil")
+	}
 	return m.GetValue(unsafe.Pointer(&key))
 }
 
 func (d *defaultImpl) DeleteKey(m *bpf.BPFMap, key uint32) error {
+	if m == nil {
+		return errors.New("provided bpf map is nil")
+	}
 	return m.DeleteKey(unsafe.Pointer(&key))
 }
 

--- a/internal/pkg/daemon/bpfrecorder/vars.go
+++ b/internal/pkg/daemon/bpfrecorder/vars.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bpfrecorder
+
+import "errors"
+
+// ErrNotFound is the GRPC error if no recording PID could be found.
+var ErrNotFound = errors.New("no PID found for profile")


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
If we're not able to retrieve the container because the process is too
short lived, then we give up retrieving the syscalls from the profile
recorder. We also have to protect the BPF maps for concurrent access to
avoid crashes.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
