### PR TITLE
Add `Verbosity` option to spod config

### DIFF
--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -24,6 +24,8 @@ import (
 
 // SPODStatus defines the desired state of SPOD.
 type SPODSpec struct {
+	// Verbosity specifies the logging verbosity of the daemon.
+	Verbosity uint `json:"verbosity,omitempty"`
 	// tells the operator whether or not to enable SELinux support for this
 	// SPOD instance.
 	EnableSelinux bool `json:"enableSelinux,omitempty"`

--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -157,7 +157,7 @@ func main() {
 			Aliases: []string{"V"},
 			Usage:   "the logging verbosity to be used",
 			Value:   0,
-			EnvVars: []string{"SPO_VERBOSITY"},
+			EnvVars: []string{config.VerbosityEnvKey},
 		},
 	}
 	app.Before = initLogging

--- a/deploy/base/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base/crds/securityprofilesoperatordaemon.yaml
@@ -95,6 +95,9 @@ spec:
                       type: string
                   type: object
                 type: array
+              verbosity:
+                description: Verbosity specifies the logging verbosity of the daemon.
+                type: integer
             type: object
           status:
             description: SPODStatus defines the observed state of SPOD.

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -616,6 +616,9 @@ spec:
                       type: string
                   type: object
                 type: array
+              verbosity:
+                description: Verbosity specifies the logging verbosity of the daemon.
+                type: integer
             type: object
           status:
             description: SPODStatus defines the observed state of SPOD.

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -616,6 +616,9 @@ spec:
                       type: string
                   type: object
                 type: array
+              verbosity:
+                description: Verbosity specifies the logging verbosity of the daemon.
+                type: integer
             type: object
           status:
             description: SPODStatus defines the observed state of SPOD.

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -4,6 +4,7 @@
 - [Features](#features)
 - [Tutorials and Demos](#tutorials-and-demos)
 - [Install operator](#install-operator)
+- [Set logging verbosity](#set-logging-verbosity)
 - [Create Profile](#create-profile)
   - [Apply profile to pod](#apply-profile-to-pod)
   - [Base syscalls for a container runtime](#base-syscalls-for-a-container-runtime)
@@ -53,6 +54,24 @@ Then apply the operator manifest:
 
 ```sh
 $ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/master/deploy/operator.yaml
+```
+
+## Set logging verbosity
+
+The operator supports the default logging verbosity of `0` and an enhanced `1`.
+To switch to the enhanced logging verbosity, patch the spod config by adjusting
+the value:
+
+```
+> kubectl -n security-profiles-operator patch spod spod --type=merge -p '{"spec":{"verbosity":1}}'
+securityprofilesoperatordaemon.security-profiles-operator.x-k8s.io/spod patched
+```
+
+The daemon should now indicate that it's using the new logging verbosity:
+
+```
+> k logs ds/spod security-profiles-operator | head -n1
+I1111 15:13:16.942837       1 main.go:182]  "msg"="Set logging verbosity to 1"
 ```
 
 ## Create Profile

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -60,6 +60,9 @@ const (
 	// the operator to work on only a single Kubernetes namespace.
 	RestrictNamespaceEnvKey = "RESTRICT_TO_NAMESPACE"
 
+	// VerbosityEnvKey is the environment variable key for the logging verbosity.
+	VerbosityEnvKey = "SPO_VERBOSITY"
+
 	// SeccompProfileRecordHookAnnotationKey is the annotation on a Pod that
 	// triggers the oci-seccomp-bpf-hook to trace the syscalls of a Pod and
 	// created a seccomp profile.

--- a/internal/pkg/manager/spod/setup.go
+++ b/internal/pkg/manager/spod/setup.go
@@ -87,6 +87,7 @@ func (r *ReconcileSPOd) createConfigIfNotExist(ctx context.Context) error {
 			Labels:    map[string]string{"app": config.OperatorName},
 		},
 		Spec: spodv1alpha1.SPODSpec{
+			Verbosity:         0,
 			EnableSelinux:     false,
 			EnableLogEnricher: false,
 			EnableBpfRecorder: false,

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -111,6 +111,10 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			"SPOD: Update SELinux flag",
 			e.testCaseSPODUpdateSelinux,
 		},
+		{
+			"SPOD: Change verbosity",
+			e.testCaseVerbosityChange,
+		},
 	}
 	for _, testCase := range testCases {
 		tc := testCase

--- a/test/tc_verbosity_test.go
+++ b/test/tc_verbosity_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"time"
+)
+
+func (e *e2e) testCaseVerbosityChange([]string) {
+	e.logf("Change verbosity in spod")
+	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"verbosity": 1}}`, "--type=merge")
+	time.Sleep(defaultWaitTime)
+
+	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultBpfRecorderOpTimeout)
+
+	logs := e.kubectlOperatorNS(
+		"logs",
+		"ds/spod",
+		"security-profiles-operator",
+	)
+
+	e.Contains(logs, "Set logging verbosity to 1")
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
Adding a usable way to change the logging verbosity of the daemon.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `verbosity` option to spod configuration. Currently supports `0` (the default) and `1` for enhanced verbosity.
```
