### PR TITLE
Make seccomp profile architectures non pointers

### DIFF
--- a/api/seccompprofile/v1alpha1/seccompprofile_types.go
+++ b/api/seccompprofile/v1alpha1/seccompprofile_types.go
@@ -47,7 +47,7 @@ type SeccompProfileSpec struct {
 	// +kubebuilder:validation:Enum=SCMP_ACT_KILL;SCMP_ACT_KILL_PROCESS;SCMP_ACT_KILL_THREAD;SCMP_ACT_TRAP;SCMP_ACT_ERRNO;SCMP_ACT_TRACE;SCMP_ACT_ALLOW;SCMP_ACT_LOG
 	DefaultAction seccomp.Action `json:"defaultAction"`
 	// the architecture used for system calls
-	Architectures []*Arch `json:"architectures,omitempty"`
+	Architectures []Arch `json:"architectures,omitempty"`
 	// match a syscall in seccomp. While this property is OPTIONAL, some values
 	// of defaultAction are not useful without syscalls entries. For example,
 	// if defaultAction is SCMP_ACT_KILL and syscalls is empty or unset, the

--- a/api/seccompprofile/v1alpha1/zz_generated.deepcopy.go
+++ b/api/seccompprofile/v1alpha1/zz_generated.deepcopy.go
@@ -104,14 +104,8 @@ func (in *SeccompProfileSpec) DeepCopyInto(out *SeccompProfileSpec) {
 	*out = *in
 	if in.Architectures != nil {
 		in, out := &in.Architectures, &out.Architectures
-		*out = make([]*Arch, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(Arch)
-				**out = **in
-			}
-		}
+		*out = make([]Arch, len(*in))
+		copy(*out, *in)
 	}
 	if in.Syscalls != nil {
 		in, out := &in.Syscalls, &out.Syscalls

--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -184,7 +184,7 @@ func (r *Reconciler) Reconcile(_ context.Context, req reconcile.Request) (reconc
 // OutputProfile represents the on-disk form of the SeccompProfile.
 type OutputProfile struct {
 	DefaultAction seccomp.Action      `json:"defaultAction"`
-	Architectures []*v1alpha1.Arch    `json:"architectures,omitempty"`
+	Architectures []v1alpha1.Arch     `json:"architectures,omitempty"`
 	Syscalls      []*v1alpha1.Syscall `json:"syscalls,omitempty"`
 	Flags         []*v1alpha1.Flag    `json:"flags,omitempty"`
 }

--- a/internal/pkg/manager/spod/bindata/default_profiles.go
+++ b/internal/pkg/manager/spod/bindata/default_profiles.go
@@ -24,12 +24,6 @@ import (
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 )
 
-var (
-	archX8664 = v1alpha1.Arch(seccomp.ArchX86_64)
-	archX86   = v1alpha1.Arch(seccomp.ArchX86)
-	archX32   = v1alpha1.Arch(seccomp.ArchX32)
-)
-
 // DefaultProfiles returns the default profiles deployed by the operator.
 func DefaultProfiles() []*v1alpha1.SeccompProfile {
 	namespace := config.GetOperatorNamespace()
@@ -53,7 +47,11 @@ func DefaultProfiles() []*v1alpha1.SeccompProfile {
 			},
 			Spec: v1alpha1.SeccompProfileSpec{
 				DefaultAction: seccomp.ActErrno,
-				Architectures: []*v1alpha1.Arch{&archX8664, &archX86, &archX32},
+				Architectures: []v1alpha1.Arch{
+					v1alpha1.Arch(seccomp.ArchX86_64),
+					v1alpha1.Arch(seccomp.ArchX86),
+					v1alpha1.Arch(seccomp.ArchX32),
+				},
 				Syscalls: []*v1alpha1.Syscall{
 					{
 						Action: seccomp.ActAllow,


### PR DESCRIPTION
#### What type of PR is this?

/kind api-change


#### What this PR does / why we need it:
This makes it easier for us to maintain the string slice rather than having pointers to strings.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Change seccomp profile type `Architectures` to `[]Arch` from `[]*Arch`
```
