### PR TITLE
Allow fetching running spod name from within it

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -34,6 +34,10 @@ const (
 	// Service Account for the security-profiles-operator daemon.
 	SPOdServiceAccount = SPOdName
 
+	// SPOdNameEnvKey allows one to query the name of the SPOd instance
+	// from within the daemon.
+	SPOdNameEnvKey = "SPOD_NAME"
+
 	// OperatorRoot is the root directory of the operator.
 	OperatorRoot = "/var/lib/security-profiles-operator"
 

--- a/internal/pkg/daemon/common/common.go
+++ b/internal/pkg/daemon/common/common.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"os"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	spodv1alpha1 "sigs.k8s.io/security-profiles-operator/api/spod/v1alpha1"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
+)
+
+// GetSPODName returns the name of the SPOD instance we're currently running
+// on.
+func GetSPODName() string {
+	name := os.Getenv(config.SPOdNameEnvKey)
+	if name == "" {
+		// Return the default spod name
+		return config.SPOdName
+	}
+	return name
+}
+
+// GetSPOD returns the SPOD instance we're currently running on.
+func GetSPOD(ctx context.Context, cli client.Client) (*spodv1alpha1.SecurityProfilesOperatorDaemon, error) {
+	spod := &spodv1alpha1.SecurityProfilesOperatorDaemon{}
+	if err := cli.Get(ctx, types.NamespacedName{
+		Name:      GetSPODName(),
+		Namespace: config.GetOperatorNamespace(),
+	}, spod); err != nil {
+		return nil, err
+	}
+
+	return spod, nil
+}

--- a/internal/pkg/daemon/profilerecorder/profilerecorder.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder.go
@@ -57,6 +57,7 @@ import (
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/controller"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/bpfrecorder"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/common"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/enricher"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/metrics"
 )
@@ -169,15 +170,7 @@ func (r *RecorderReconciler) getSPOD() (*spodv1alpha1.SecurityProfilesOperatorDa
 	ctx, cancel := context.WithTimeout(context.Background(), reconcileTimeout)
 	defer cancel()
 
-	spod := &spodv1alpha1.SecurityProfilesOperatorDaemon{}
-	if err := r.client.Get(ctx, types.NamespacedName{
-		Name:      config.SPOdName,
-		Namespace: config.GetOperatorNamespace(),
-	}, spod); err != nil {
-		return nil, err
-	}
-
-	return spod, nil
+	return common.GetSPOD(ctx, r.client)
 }
 
 // Healthz is the liveness probe endpoint of the controller.

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -275,6 +275,11 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 									},
 								},
 							},
+							{
+								// Note that this will be set per SPOD instance
+								Name:  config.SPOdNameEnvKey,
+								Value: config.SPOdName,
+							},
 						},
 						Ports: []v1.ContainerPort{
 							{

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -393,6 +393,15 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 	// Non root enabler
 	templateSpec.InitContainers[bindata.InitContainerIDNonRootenabler].Image = image
 
+	// SPOD Name
+	for envid := range templateSpec.Containers[bindata.ContainerIDDaemon].Env {
+		env := &templateSpec.Containers[bindata.ContainerIDDaemon].Env[envid]
+		if env.Name == config.SPOdNameEnvKey {
+			env.Value = cfg.GetName()
+			break
+		}
+	}
+
 	// SELinux parameters
 	if cfg.Spec.EnableSelinux {
 		templateSpec.InitContainers = append(


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Currently, the SPOD is a singleton that denotes the DaemonSet instance
running on the nodes to do the SPO work. This is mostly just enforced by
the fact that the profilerecorder will fetch the default SPOD to check
its configuration.

This changes that by adding an environment variable on the running pod
that allows one to fetch the SPOD name from the env variable. There is
now a utility function to help with that.

The result is that we would (in theory) now be able to run multiple SPOd
instances that cover different node sets. However, this also just makes the
codebase less hardcoded and more adaptable.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```