### PR TITLE
tests: Don't wait for all pods in all namespaces when testing against an OpenShift cluster

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -48,8 +48,7 @@ const (
 )
 
 func (e *e2e) TestSecurityProfilesOperator() {
-	e.logf("Waiting for all pods to become ready")
-	e.waitFor("condition=ready", "pods", "--all", "--all-namespaces")
+	e.waitForReadyPods()
 
 	// Deploy prerequisites
 	e.deployCertManager()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Commit cb9760d75d9d08ea624a624446d8bc38685756db made our tests much more
stable, but the part that waits for all pods in all namespaces doesn't
work well on OCP, because there's typically too many pods and the check
takes too much time.

In addition, at least at the moment, the tests against an OCP cluster
are manually executed against an already provisioned cluster.

The two other supported cluster types (vanilla and kind) have not changed
behaviour and still wait on all pods in all namespaces.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```