### PR TITLE
secprofnodestatus: Link the node profile status with profile using a custom label

### DIFF
--- a/api/secprofnodestatus/v1alpha1/secprofnodestatus_types.go
+++ b/api/secprofnodestatus/v1alpha1/secprofnodestatus_types.go
@@ -41,8 +41,9 @@ const (
 
 // Common labels of the node status objects.
 const (
-	// Identifies the profile by name so that the admin can list all node statuses for a certain profile.
-	StatusToProfLabel = "spo.x-k8s.io/profile-name"
+	// StatusToProfLabel identifies the profile by name, or if the name is too long, by a hash so that
+	// the admin can list all node statuses for a certain profile.
+	StatusToProfLabel = "spo.x-k8s.io/profile-id"
 	// Identifies the node on which the profile is installed so that the admin can list profiles per node.
 	StatusToNodeLabel = "spo.x-k8s.io/node-name"
 	// Allows the admin to filter out node statuses with a certain state (e.g. show me all that failed).

--- a/internal/pkg/util/names_test.go
+++ b/internal/pkg/util/names_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	seccompprofile "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"
+)
+
+func TestNameHashing(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		prof      seccompprofile.SeccompProfile
+		labelName string
+	}{
+		{
+			name: "short name",
+			prof: seccompprofile.SeccompProfile{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "SeccompProfile",
+					APIVersion: "security-profiles-operator.x-k8s.io/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "shortname-profile",
+					Namespace: "security-profiles-operator",
+				},
+				Spec:   seccompprofile.SeccompProfileSpec{},
+				Status: seccompprofile.SeccompProfileStatus{},
+			},
+			labelName: "SeccompProfile-shortname-profile",
+		},
+		{
+			name: "long name",
+			prof: seccompprofile.SeccompProfile{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "SeccompProfile",
+					APIVersion: "security-profiles-operator.x-k8s.io/v1beta1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "this-is-a-very-long-name-surely-over-64-characters-omg-its-overflowing",
+					Namespace: "security-profiles-operator",
+				},
+				Spec:   seccompprofile.SeccompProfileSpec{},
+				Status: seccompprofile.SeccompProfileStatus{},
+			},
+			labelName: "SeccompProfile-9d42ecd8a72de861cc202ee69381e536088eec6dc43f8f8e",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			name := KindBasedDNSLengthName(&tc.prof)
+			require.Equal(t, tc.labelName, name)
+		})
+	}
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -114,6 +114,10 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			"SPOD: Change verbosity",
 			e.testCaseVerbosityChange,
 		},
+		{
+			"Seccomp: make sure statuses for profiles with long names can be listed",
+			e.testCaseLongSeccompProfileName,
+		},
 	}
 	for _, testCase := range testCases {
 		tc := testCase
@@ -328,9 +332,9 @@ func (e *e2e) getSeccompProfile(name, namespace string) *seccompprofileapi.Secco
 }
 
 func (e *e2e) getSeccompProfileNodeStatus(
-	name, namespace, node string,
+	id, namespace, node string,
 ) *secprofnodestatusv1alpha1.SecurityProfileNodeStatus {
-	selector := fmt.Sprintf("spo.x-k8s.io/node-name=%s,spo.x-k8s.io/profile-name=%s", node, name)
+	selector := fmt.Sprintf("spo.x-k8s.io/node-name=%s,spo.x-k8s.io/profile-id=SeccompProfile-%s", node, id)
 	seccompProfileNodeStatusJSON := e.kubectl(
 		"-n", namespace, "get", "securityprofilenodestatus", "-l", selector, "-o", "json",
 	)
@@ -341,9 +345,9 @@ func (e *e2e) getSeccompProfileNodeStatus(
 }
 
 func (e *e2e) getAllSeccompProfileNodeStatuses(
-	name, namespace string,
+	id, namespace string,
 ) *secprofnodestatusv1alpha1.SecurityProfileNodeStatusList {
-	selector := fmt.Sprintf("spo.x-k8s.io/profile-name=%s", name)
+	selector := fmt.Sprintf("spo.x-k8s.io/profile-id=SeccompProfile-%s", id)
 	seccompProfileNodeStatusJSON := e.kubectl(
 		"-n", namespace, "get", "securityprofilenodestatus", "-l", selector, "-o", "json",
 	)
@@ -411,4 +415,9 @@ func (e *e2e) retryGet(args ...string) string {
 
 	e.Fail("Timed out to wait for resource")
 	return ""
+}
+
+func (e *e2e) getSeccompPolicyID(profile string) string {
+	ns := e.getCurrentContextNamespace(defaultNamespace)
+	return e.kubectl("get", "sp", "-n", ns, profile, "-o", "jsonpath={.metadata.labels.spo\\.x-k8s\\.io/profile-id}")
 }

--- a/test/tc_long_profile_name_test.go
+++ b/test/tc_long_profile_name_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"encoding/json"
+	"fmt"
+
+	secprofnodestatusv1alpha1 "sigs.k8s.io/security-profiles-operator/api/secprofnodestatus/v1alpha1"
+)
+
+const (
+	policyName     = "this-is-a-very-long-name-surely-over-64-characters-omg-its-overflowing"
+	longNamePolicy = `
+    apiVersion: security-profiles-operator.x-k8s.io/v1beta1
+    kind: SeccompProfile
+    metadata:
+      name: this-is-a-very-long-name-surely-over-64-characters-omg-its-overflowing
+    spec:
+      defaultAction: "SCMP_ACT_ALLOW"
+`
+)
+
+func (e *e2e) testCaseLongSeccompProfileName(nodes []string) {
+	e.logf("List node statuses for a policy with a very long name")
+
+	e.logf("creating policy")
+	deleteFn := e.writeAndCreate(longNamePolicy, "longname-policy.yml")
+	defer deleteFn()
+
+	e.logf("Waiting for profile to be reconciled")
+	e.waitFor("condition=ready", "sp", policyName)
+
+	e.logf("List all node statuses for policy by ID")
+	id := e.getSeccompPolicyID(policyName)
+	namespace := e.getCurrentContextNamespace(defaultNamespace)
+	selector := fmt.Sprintf("spo.x-k8s.io/profile-id=%s", id)
+	seccompProfileNodeStatusJSON := e.kubectl(
+		"-n", namespace, "get", "securityprofilenodestatus", "-l", selector, "-o", "json",
+	)
+	secpolNodeStatusList := &secprofnodestatusv1alpha1.SecurityProfileNodeStatusList{}
+	e.Nil(json.Unmarshal([]byte(seccompProfileNodeStatusJSON), secpolNodeStatusList))
+	if len(nodes) > len(secpolNodeStatusList.Items) {
+		e.Fail("Couldn't list statuses for nodes")
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We were using the profile name as the value of the spo.x-k8s.io/profile-name
label to be able to list node profile statuses for a profile. This is
user-friendly but would fail in case the profile name was longer than 64
characters as that's the label size limit.

Instead, let's rename the label to spo.x-k8s.io/profile-id. In case the
profile name is shorter than the limit, let's still use the name because
it's user-friendly, but in case the name is longer, let's instead use a
sha1 hash of the name with the profile Kind as a prefix.

Using sha1 is OK in this case, because we're not using it for any crypto
purposes, just to shorten a name.


#### Which issue(s) this PR fixes:
Fixes #408

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.


or

None
-->

#### Does this PR have test?
Yes

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The securityprofilenodestatus CR now links with the security profile its status
it represents using label spo.x-k8s.io/profile-id. If the profile name is less
than 64 characters long, then the label value is the profile name, otherwise it's
kind-sha1hashofthename.

This change supports profile names whose names are over 64 characters.

```