### PR TITLE
Make BPF optional again

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -17,26 +17,16 @@ USER root
 WORKDIR /work
 
 RUN microdnf install -y \
-        bzip2 \
-        curl-devel \
-        g++ \
         glibc-static \
         golang-bin \
-        libarchive-devel \
-        libmicrohttpd-devel \
-        libseccomp-static \
-        m4 \
         make \
-        sqlite-devel \
-        tar \
-        zlib-static
+        libseccomp-static
 
 ADD . /work
-RUN hack/install-libelf.sh
-RUN hack/install-libbpf.sh
 RUN mkdir -p build
 
 ARG APPARMOR_ENABLED=0
+ARG BPF_ENABLED=0
 
 RUN make
 

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux && !no_bpf
+// +build linux,!no_bpf
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_test.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_test.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux && !no_bpf
+// +build linux,!no_bpf
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_unsupported.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_unsupported.go
@@ -1,5 +1,5 @@
-//go:build !linux
-// +build !linux
+//go:build !linux || no_bpf
+// +build !linux no_bpf
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorderfakes/fake_impl.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorderfakes/fake_impl.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux && !no_bpf
+// +build linux,!no_bpf
 
 /*
 Copyright The Kubernetes Authors.

--- a/internal/pkg/daemon/bpfrecorder/generate/main.go
+++ b/internal/pkg/daemon/bpfrecorder/generate/main.go
@@ -31,7 +31,8 @@ import (
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/bpfrecorder/types"
 )
 
-const header = `// +build linux
+const header = `+//go:build linux,!no_bpf
+// +build linux
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/internal/pkg/daemon/bpfrecorder/generated.go
+++ b/internal/pkg/daemon/bpfrecorder/generated.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux && !no_bpf
+// +build linux,!no_bpf
 
 /*
 Copyright 2021 The Kubernetes Authors.

--- a/internal/pkg/daemon/bpfrecorder/impl.go
+++ b/internal/pkg/daemon/bpfrecorder/impl.go
@@ -1,5 +1,5 @@
-//go:build linux
-// +build linux
+//go:build linux && !no_bpf
+// +build linux,!no_bpf
 
 /*
 Copyright 2021 The Kubernetes Authors.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Some distributions insist on building from distribution packages only.
This means we can't use the built-in BPF recorder at least not on
RHEL/CentOS until all the needed package versions catch up.

This patch re-adds the no_bpf build tag triggered by the BPF_ENABLED
environment variable if set to 0. A developer can then build SPO without the
built-in BPF support by running:
    BPF_ENABLED=0 make


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
implicitly tested by UBI build

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
@saschagrunert - I used your fork of libbpfgo that supports the
nobpf build tag. I'm unsure if this is a good thing long-term,
in general forks are not. Have you considered sending the patches
upstream to see if they'd accept them? Or can you think about
a better solution?

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
This patch re-adds the no_bpf build tag triggered by the BPF_ENABLED=0 tag
environment variable if set to 0. A developer can then build SPO without the
built-in BPF support by running:
    BPF_ENABLED=0 make
This is useful to build SPO in environments with older dependencies
that don't allow building the in-tree BPF-based recorder.
```