### PR TITLE
Improve fedora-e2e flakeness

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,9 @@ jobs:
       - name: Boot Virtual Machine
         run: make vagrant-up-fedora
       - name: Show environment information
-        run: $RUN kubectl get nodes -o wide
+        run: |
+          $RUN kubectl wait --for=condition=ready --timeout=60s node 127.0.0.1
+          $RUN kubectl get nodes -o wide
       - name: Run E2E tests
         run: $RUN hack/ci/e2e-fedora.sh
 
@@ -93,6 +95,8 @@ jobs:
       - name: Boot Virtual Machine
         run: make vagrant-up-ubuntu
       - name: Show environment information
-        run: $RUN kubectl get nodes -o wide
+        run: |
+          $RUN kubectl wait --for=condition=ready --timeout=60s node ubuntu-focal
+          $RUN kubectl get nodes -o wide
       - name: Run E2E tests
         run: $RUN hack/ci/e2e-ubuntu.sh

--- a/hack/ci/Vagrantfile-fedora
+++ b/hack/ci/Vagrantfile-fedora
@@ -4,7 +4,7 @@
 # Vagrant box for testing
 Vagrant.configure("2") do |config|
   config.vm.box = "fedora/35-cloud-base"
-  memory = 6144
+  memory = 8192
   cpus = 4
 
   config.vm.provider :virtualbox do |v|

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -423,7 +423,10 @@ func (e *e2e) setWorkDir() string {
 func (e *e2e) run(cmd string, args ...string) string {
 	output, err := command.New(cmd, args...).RunSuccessOutput()
 	e.Nil(err)
-	return output.OutputTrimNL()
+	if output != nil {
+		return output.OutputTrimNL()
+	}
+	return ""
 }
 
 func (e *e2e) runFailure(cmd string, args ...string) string {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

Attempt to fix flakeness of fedora-e2e and error messages.
Changes:
- When a pod was not ready after a given timeout, a nil pointer was being used which made error messages rather confusing.
- Wait for vagrant node to be `ready` before executing tests.
- Increase memory for fedora as it may be the reason why `kubectl rollout` is hanging. [xref](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/#some-nodes-run-out-of-resources)

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

![image](https://user-images.githubusercontent.com/5452977/143289668-5eef4de5-f454-4982-8b7c-49620771df86.png)


#### Does this PR introduce a user-facing change?

```release-note
NONE
```
