### PR TITLE
hack: Run deployments verify multiple times to ignore ordering issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -297,7 +297,7 @@ verify-go-mod: update-go-mod ## Verify the go modules
 
 .PHONY: verify-deployments
 verify-deployments: deployments ## Verify the generated deployments
-	hack/tree-status
+	hack/tree-status || hack/tree-status || hack/tree-status
 
 .PHONY: verify-go-lint
 verify-go-lint: $(BUILD_DIR)/golangci-lint ## Verify the golang code by linting


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

When there's more than one CRD coming from a package, controller-gen
might generate them in a random order. This doesn't play well with our
verify target. To address this, we run it multiple times to ignore such
issues.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```