### PR TITLE
SELinux: Add health probe

### DIFF
--- a/internal/pkg/daemon/selinuxprofile/common_controller.go
+++ b/internal/pkg/daemon/selinuxprofile/common_controller.go
@@ -123,6 +123,13 @@ func (r *ReconcileSelinux) SchemeBuilder() *scheme.Builder {
 
 // Healthz is the liveness probe endpoint of the controller.
 func (r *ReconcileSelinux) Healthz(*http.Request) error {
+	ready, err := isSelinuxdReady()
+	if err != nil {
+		return errors.Wrapf(err, "getting health status")
+	}
+	if !ready {
+		return errors.New("not ready")
+	}
 	return nil
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This checks if selinuxd is ready to serve requests in order to determine
the health of the selinux controllers.

This will result in a more accurate reflection of the controllers' health
status.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```