### PR TITLE
spod: Make /etc/selinux.d an emptyDir instead of hostPath

### DIFF
--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -582,10 +582,7 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 					{
 						Name: "selinux-drop-dir",
 						VolumeSource: corev1.VolumeSource{
-							HostPath: &corev1.HostPathVolumeSource{
-								Path: SelinuxDropDirectory,
-								Type: &hostPathDirectoryOrCreate,
-							},
+							EmptyDir: &corev1.EmptyDirVolumeSource{},
 						},
 					},
 					{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Since the directory only contains policy definitions, not the actual
policy result it is not needed to be a hostPath. The actual policy is
persisted in /etc/selinux (without the .d).

The original idea behind having a hostPath was to run selinuxd on the
nodes directly to lock down even e.g. the kubelet. But that will not
happen, at least not in the short term, so let's reduce the number of
our hostPath mounts a little.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A tested by existing tests

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The directory /etc/selinux.d used to be mounted on the hosts in previous SPO versions.
This is no longer the case, the directory was converted to an emptyDir instead,
reducing the number of required host mounts.

```