### PR TITLE
Make short running containers work with bpf recorder

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_test.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_test.go
@@ -769,7 +769,7 @@ func TestProcessEvents(t *testing.T) {
 					if success {
 						break
 					}
-					time.Sleep(100 * time.Millisecond)
+					time.Sleep(200 * time.Millisecond)
 				}
 				require.True(t, success)
 			},

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -148,6 +148,7 @@ func (e *e2e) TestSecurityProfilesOperator() {
 	})
 
 	e.Run("cluster-wide: Seccomp: Verify profile recording bpf", func() {
+		e.testCaseBpfRecorderKubectlRun()
 		e.testCaseBpfRecorderStaticPod()
 		e.testCaseBpfRecorderMultiContainer()
 		e.testCaseBpfRecorderDeployment()

--- a/test/tc_bpf_recorder_test.go
+++ b/test/tc_bpf_recorder_test.go
@@ -46,6 +46,23 @@ func (e *e2e) waitForBpfRecorderLogs(since time.Time) {
 	}
 }
 
+func (e *e2e) testCaseBpfRecorderKubectlRun() {
+	e.bpfRecorderOnlyTestCase()
+
+	e.logf("Creating bpf recording for kubectl run test")
+	e.kubectl("create", "-f", exampleRecordingBpfPath)
+
+	e.logf("Creating test pod")
+	e.kubectlRun("--labels=app=alpine", "fedora", "--", "mkdir", "/test")
+
+	resourceName := recordingName + "-fedora"
+	profile := e.retryGetSeccompProfile(resourceName)
+	e.Contains(profile, "mkdir")
+
+	e.kubectl("delete", "-f", exampleRecordingBpfPath)
+	e.kubectl("delete", "sp", resourceName)
+}
+
 func (e *e2e) testCaseBpfRecorderStaticPod() {
 	e.bpfRecorderOnlyTestCase()
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
A couple of enhancements have been done to make the bpf recorder work
containers having a short lifetime:

- Add a PID lock, which makes callers of `SyscallsForProfile` wait for
  events to be processed.
- Do not process events on the startup module load test.
- Reduce the amount of time for retrying the container ID retrieval.
- Increase logging verbosity to be able to trace the retries, especially
  if the container ID is not yet set.
- Added a `kubectl run` e2e test to proof the feature
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
Yes
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
