### PR TITLE
Change SPOD update strategy to maximum parallelism

### DIFF
--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -101,6 +101,13 @@ var Manifest = &appsv1.DaemonSet{
 		Namespace: config.OperatorName,
 	},
 	Spec: appsv1.DaemonSetSpec{
+		UpdateStrategy: appsv1.DaemonSetUpdateStrategy{
+			Type: appsv1.RollingUpdateDaemonSetStrategyType,
+			RollingUpdate: &appsv1.RollingUpdateDaemonSet{
+				// Update everything in parallel
+				MaxUnavailable: &intstr.IntOrString{Type: intstr.String, StrVal: "100%"},
+			},
+		},
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{
 				"app":  config.OperatorName,


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
The DaemonSet pods are acting completely separated, which is why we can update all in parallel.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Changed DaemonSet update strategy to update all Pods in parallel.
```
