### PR TITLE
images: fix invalid k8s-staging-test-infra/gcb-docker-gcloud tag

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -5,7 +5,7 @@ options:
   substitution_option: ALLOW_LOOSE
   machineType: N1_HIGHCPU_8
 steps:
-  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211008-60e346af
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90
     entrypoint: bash
     env:
       - TAG=$_GIT_TAG

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -99,7 +99,7 @@ dependencies:
     version: v20210722-085d930
     refPaths:
     - path: cloudbuild.yaml
-      match: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211008-60e346af
+      match: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20211118-2f2d816b90
 
   - name: libbpf
     version: 0.5.0


### PR DESCRIPTION
Related:
- Part of: https://github.com/kubernetes/k8s.io/issues/1523
- Followup to: https://github.com/kubernetes-sigs/security-profiles-operator/pull/729

I copy-pasted the wrong tag :sweat_smile:  Sorry about the churn