### PR TITLE
Limit bpf recorder ttl cache size

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpfrecorderfakes/fake_impl.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorderfakes/fake_impl.go
@@ -379,10 +379,10 @@ type FakeImpl struct {
 	serveReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SetTTLStub        func(ttlcache.SimpleCache, time.Duration) error
+	SetTTLStub        func(*ttlcache.Cache, time.Duration) error
 	setTTLMutex       sync.RWMutex
 	setTTLArgsForCall []struct {
-		arg1 ttlcache.SimpleCache
+		arg1 *ttlcache.Cache
 		arg2 time.Duration
 	}
 	setTTLReturns struct {
@@ -2120,11 +2120,11 @@ func (fake *FakeImpl) ServeReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeImpl) SetTTL(arg1 ttlcache.SimpleCache, arg2 time.Duration) error {
+func (fake *FakeImpl) SetTTL(arg1 *ttlcache.Cache, arg2 time.Duration) error {
 	fake.setTTLMutex.Lock()
 	ret, specificReturn := fake.setTTLReturnsOnCall[len(fake.setTTLArgsForCall)]
 	fake.setTTLArgsForCall = append(fake.setTTLArgsForCall, struct {
-		arg1 ttlcache.SimpleCache
+		arg1 *ttlcache.Cache
 		arg2 time.Duration
 	}{arg1, arg2})
 	stub := fake.SetTTLStub
@@ -2146,13 +2146,13 @@ func (fake *FakeImpl) SetTTLCallCount() int {
 	return len(fake.setTTLArgsForCall)
 }
 
-func (fake *FakeImpl) SetTTLCalls(stub func(ttlcache.SimpleCache, time.Duration) error) {
+func (fake *FakeImpl) SetTTLCalls(stub func(*ttlcache.Cache, time.Duration) error) {
 	fake.setTTLMutex.Lock()
 	defer fake.setTTLMutex.Unlock()
 	fake.SetTTLStub = stub
 }
 
-func (fake *FakeImpl) SetTTLArgsForCall(i int) (ttlcache.SimpleCache, time.Duration) {
+func (fake *FakeImpl) SetTTLArgsForCall(i int) (*ttlcache.Cache, time.Duration) {
 	fake.setTTLMutex.RLock()
 	defer fake.setTTLMutex.RUnlock()
 	argsForCall := fake.setTTLArgsForCall[i]

--- a/internal/pkg/daemon/bpfrecorder/impl.go
+++ b/internal/pkg/daemon/bpfrecorder/impl.go
@@ -52,7 +52,7 @@ type defaultImpl struct{}
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . impl
 type impl interface {
-	SetTTL(ttlcache.SimpleCache, time.Duration) error
+	SetTTL(*ttlcache.Cache, time.Duration) error
 	Getenv(string) string
 	InClusterConfig() (*rest.Config, error)
 	NewForConfig(*rest.Config) (*kubernetes.Clientset, error)
@@ -88,7 +88,7 @@ type impl interface {
 	SendMetric(apimetrics.Metrics_BpfIncClient, *apimetrics.BpfRequest) error
 }
 
-func (d *defaultImpl) SetTTL(cache ttlcache.SimpleCache, ttl time.Duration) error {
+func (d *defaultImpl) SetTTL(cache *ttlcache.Cache, ttl time.Duration) error {
 	return cache.SetTTL(ttl)
 }
 


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
In theory we could exceed memory in an unlimited way when using the TTL
caches. We now limit them by size, having enough room and space.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
