### PR TITLE
Bump and pin github actions' dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,21 +21,21 @@ permissions:
   statuses: none
 jobs:
   macos:
-    runs-on: macos-latest
+    runs-on: macos-11
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0 
+      - uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 # v2.1.4
         with:
           go-version: ${{ env.GO_VERSION }}
       - run: make test-unit
       - run: make verify-go-lint
 
   nix:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v12
-      - uses: cachix/cachix-action@v10
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0 
+      - uses: cachix/install-nix-action@d56f3ce9be45c562799280e8a561fbbe8f36de44 # v16
+      - uses: cachix/cachix-action@73e75d1a0cd4330597a571e8f9dedb41faa2fc4e # v10
         with:
           name: security-profiles-operator
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -43,14 +43,14 @@ jobs:
       - run: make nix nix-arm64
 
   bpf-btf:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 # v2.1.4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - uses: actions/checkout@v2
-      - uses: cachix/install-nix-action@v12
-      - uses: cachix/cachix-action@v10
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0 
+      - uses: cachix/install-nix-action@d56f3ce9be45c562799280e8a561fbbe8f36de44 # v16
+      - uses: cachix/cachix-action@73e75d1a0cd4330597a571e8f9dedb41faa2fc4e # v10
         with:
           name: security-profiles-operator
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -58,10 +58,10 @@ jobs:
       - run: make verify-bpf-btf | true
 
   image:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: redhat-actions/buildah-build@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0 
+      - uses: redhat-actions/buildah-build@b13805753a7ac93d18d14b22f6ebdf8499a3a95e # v2.9
         id: build-image
         with:
           image: build
@@ -77,10 +77,10 @@ jobs:
           password: ${{ secrets.QUAY_TOKEN }}
 
   ubi-image:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: redhat-actions/buildah-build@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0 
+      - uses: redhat-actions/buildah-build@b13805753a7ac93d18d14b22f6ebdf8499a3a95e # v2.9
         id: build-image
         with:
           image: build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,20 +26,20 @@ jobs:
       # write security-events is required by all codeql-action workflows
       security-events: write 
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: github/codeql-action/init@v1
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+      - uses: github/codeql-action/init@26567f6a492cf20b8a8a6913432a4f1b834b12be # v1.0.24
         with:
           languages: go
-      - uses: github/codeql-action/autobuild@v1
-      - uses: github/codeql-action/analyze@v1
+      - uses: github/codeql-action/autobuild@26567f6a492cf20b8a8a6913432a4f1b834b12be # v1.0.24
+      - uses: github/codeql-action/analyze@26567f6a492cf20b8a8a6913432a4f1b834b12be # v1.0.24
 
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+      - uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 # v2.1.4
         with:
           go-version: ${{ env.GO_VERSION }}
       - name: Install dependencies
@@ -48,38 +48,41 @@ jobs:
           sudo apt install -y libseccomp-dev libelf-dev libapparmor-dev
           sudo hack/install-libbpf.sh
       - run: make test-unit
-      - uses: codecov/codecov-action@v2
+      - uses: codecov/codecov-action@f32b3a3741e1053eb607407145bc9619351dc93b # v2.1.0
         with:
           files: build/coverage.out
           flags: unittests
           verbose: true
 
   image:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
       - run: make image
       - run: podman save -o image.tar security-profiles-operator
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@27121b0bdffd731efa15d66772be8dc71245d074 # v2.2.4
         with:
           name: image
           path: image.tar
 
   e2e-fedora:
     needs: image
+    
+    # runs-on not set to macos-11 as vagrant currently not available and stable on macos BigSur
+    # https://github.com/actions/virtual-environments/issues/2999
     runs-on: macos-10.15
     timeout-minutes: 90
     env:
       RUN: ./hack/ci/run-fedora.sh
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+      - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed # v2.1.7
         with:
           path: |
             ~/.vagrant.d/boxes
           key: e2e-fedora-${{ hashFiles('hack/ci/Vagrantfile-fedora') }}
           restore-keys: e2e-fedora-
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60 # v2.0.10
         with:
           name: image
           path: .
@@ -94,19 +97,22 @@ jobs:
 
   e2e-ubuntu:
     needs: image
+
+    # runs-on not set to macos-11 as vagrant currently not available and stable on macos BigSur
+    # https://github.com/actions/virtual-environments/issues/2999
     runs-on: macos-10.15
     timeout-minutes: 90
     env:
       RUN: ./hack/ci/run-ubuntu.sh
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/cache@v2
+      - uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+      - uses: actions/cache@937d24475381cd9c75ae6db12cb4e79714b926ed # v2.1.7
         with:
           path: |
             ~/.vagrant.d/boxes
           key: e2e-ubuntu-${{ hashFiles('hack/ci/Vagrantfile-ubuntu') }}
           restore-keys: e2e-ubuntu-
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@3be87be14a055c47b01d3bd88f8fe02320a9bb60 # v2.0.10
         with:
           name: image
           path: .


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does

- Bump all github actions to their latest released version, whilst also pinned them against the specific git commit id.
- Update all job's images to latest (`ubuntu-20.04` or `macos-11`) also pinning them. Some jobs were kept using `macos-10.15` due to a dependency to vagrant, which is currently not available on `macos-11` (xref https://github.com/actions/virtual-environments/issues/2999).

#### Why we need it:

Pinned dependencies reduce several security risks:

- They ensure that checking and deployment are all done with the same software, reducing deployment risks, simplifying debugging, and enabling reproducibility.
- They can help mitigate compromised dependencies from undermining the security of the project (in the case where you've evaluated the pinned dependency, you are confident it's not compromised, and a later version is released that is compromised).
- They are one way to counter dependency confusion (aka substitution) attacks, in which an application uses multiple feeds to acquire software packages (a "hybrid configuration"), and attackers fool the user into using a malicious package via a feed that was not expected for that package.

More information refer to [ossf](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)

#### Which issue(s) this PR fixes:

Partially fixes #653
Relates to #725

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

Running the latest version of `buildah` on `ubuntu-18.04` led to the error: `"fuse-overlayfs" is not found.` Hence why the motivation of doing both changes together.


#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
