### PR TITLE
Fix codeql workflow permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,11 @@ permissions:
   statuses: none
 jobs:
   analyze:
+    permissions:
+      
+      # write security-events is required by all codeql-action workflows
+      security-events: write 
+
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind regression


#### What this PR does / why we need it:

The changes on https://github.com/kubernetes-sigs/security-profiles-operator/pull/737 made the `analyze` workflow to stop working at the branch `main`:

![image](https://user-images.githubusercontent.com/5452977/144319068-da4648aa-e1ac-4211-9086-99b7880db802.png)

Further analysis showed that the issue was the codeql-action trying to `PUT` an analysis status:

![image](https://user-images.githubusercontent.com/5452977/144319261-0c3b9832-f61d-41fa-881a-ae77ad21f211.png)

This PR adds `security-events: write` for those workflows only, which is aligned with the recomendations from the component's [documentation](https://github.com/github/codeql-action#usage).


#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
