### PR TITLE
openshift: Deploy webhook using internal CA instead of cert-manager

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -36,8 +36,6 @@ dependencies:
       match: jetstack/cert-manager
     - path: installation-usage.md
       match: jetstack/cert-manager
-    - path: Makefile
-      match: jetstack/cert-manager
 
   - name: kind
     version: 0.11.1

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -1797,7 +1797,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: security-profiles-operator/webhook-cert
+    service.beta.openshift.io/inject-cabundle: "true"
   labels:
     app: security-profiles-operator
   name: spo-mutating-webhook-configuration
@@ -1861,55 +1861,11 @@ webhooks:
     - pods
   sideEffects: None
 ---
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  labels:
-    app: security-profiles-operator
-  name: selfsigned-issuer
-  namespace: security-profiles-operator
-spec:
-  selfSigned: {}
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    app: security-profiles-operator
-  name: webhook-cert
-  namespace: security-profiles-operator
-spec:
-  dnsNames:
-  - webhook-service.security-profiles-operator.svc
-  - webhook-service.security-profiles-operator.svc.cluster.local
-  issuerRef:
-    kind: Issuer
-    name: selfsigned-issuer
-  secretName: webhook-server-cert
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    app: security-profiles-operator
-  name: metrics-cert
-  namespace: security-profiles-operator
-spec:
-  dnsNames:
-  - metrics.security-profiles-operator
-  - metrics.security-profiles-operator.svc
-  - metrics.security-profiles-operator.svc.cluster.local
-  issuerRef:
-    kind: Issuer
-    name: selfsigned-issuer
-  secretName: metrics-server-cert
-  subject:
-    organizations:
-    - security-profiles-operator
----
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
   labels:
     app: security-profiles-operator
   name: webhook-service
@@ -1925,6 +1881,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: metrics-server-cert
   labels:
     app: security-profiles-operator
     name: spod

--- a/deploy/openshift.yaml
+++ b/deploy/openshift.yaml
@@ -1797,7 +1797,7 @@ apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   annotations:
-    cert-manager.io/inject-ca-from: security-profiles-operator/webhook-cert
+    service.beta.openshift.io/inject-cabundle: "true"
   labels:
     app: security-profiles-operator
   name: spo-mutating-webhook-configuration
@@ -1861,55 +1861,11 @@ webhooks:
     - pods
   sideEffects: None
 ---
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  labels:
-    app: security-profiles-operator
-  name: selfsigned-issuer
-  namespace: security-profiles-operator
-spec:
-  selfSigned: {}
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    app: security-profiles-operator
-  name: webhook-cert
-  namespace: security-profiles-operator
-spec:
-  dnsNames:
-  - webhook-service.security-profiles-operator.svc
-  - webhook-service.security-profiles-operator.svc.cluster.local
-  issuerRef:
-    kind: Issuer
-    name: selfsigned-issuer
-  secretName: webhook-server-cert
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  labels:
-    app: security-profiles-operator
-  name: metrics-cert
-  namespace: security-profiles-operator
-spec:
-  dnsNames:
-  - metrics.security-profiles-operator
-  - metrics.security-profiles-operator.svc
-  - metrics.security-profiles-operator.svc.cluster.local
-  issuerRef:
-    kind: Issuer
-    name: selfsigned-issuer
-  secretName: metrics-server-cert
-  subject:
-    organizations:
-    - security-profiles-operator
----
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
   labels:
     app: security-profiles-operator
   name: webhook-service
@@ -1925,6 +1881,8 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: metrics-server-cert
   labels:
     app: security-profiles-operator
     name: spod

--- a/deploy/overlays/openshift/kustomization.yaml
+++ b/deploy/overlays/openshift/kustomization.yaml
@@ -8,3 +8,11 @@ bases:
 
 patchesStrategicMerge:
   - deployment.yaml
+  - no_certificate.yaml
+  - svc_gen_cert.yaml
+patchesJson6902:
+  - target:
+      version: v1
+      kind: MutatingWebhookConfiguration
+      name: spo-mutating-webhook-configuration
+    path: mutatingwebhookconfig.yaml

--- a/deploy/overlays/openshift/mutatingwebhookconfig.yaml
+++ b/deploy/overlays/openshift/mutatingwebhookconfig.yaml
@@ -1,0 +1,6 @@
+- op: add
+  path: /metadata/annotations/service.beta.openshift.io~1inject-cabundle
+  value: true
+- op: remove
+  path: /metadata/annotations/cert-manager.io~1inject-ca-from
+  value: "security-profiles-operator/webhook-cert"

--- a/deploy/overlays/openshift/no_certificate.yaml
+++ b/deploy/overlays/openshift/no_certificate.yaml
@@ -1,0 +1,43 @@
+---
+$patch: delete
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: security-profiles-operator
+spec:
+  selfSigned: {}
+---
+$patch: delete
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: webhook-cert
+  namespace: security-profiles-operator
+spec:
+  dnsNames:
+  - webhook-service.security-profiles-operator.svc
+  - webhook-service.security-profiles-operator.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: webhook-server-cert
+---
+$patch: delete
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: metrics-cert
+  namespace: security-profiles-operator
+spec:
+  subject:
+    organizations:
+    - security-profiles-operator
+  dnsNames:
+  - metrics.security-profiles-operator
+  - metrics.security-profiles-operator.svc
+  - metrics.security-profiles-operator.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert

--- a/deploy/overlays/openshift/svc_gen_cert.yaml
+++ b/deploy/overlays/openshift/svc_gen_cert.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: webhook-service
+  namespace: security-profiles-operator
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: webhook-server-cert
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: metrics
+  namespace: security-profiles-operator
+  annotations:
+    service.beta.openshift.io/serving-cert-secret-name: metrics-server-cert


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
OpenShift does not include cert-manager by default and moreover includes
its own way of generating keys and certificates for services:

- https://docs.openshift.com/container-platform/4.7/nodes/pods/nodes-pods-secrets.html#nodes-pods-secrets-certificates-creating_nodes-pods-secrets
-  https://docs.openshift.com/container-platform/4.7/security/certificate_types_descriptions/service-ca-certificates.html

and providing the CA bundles for webhook configuration:
  
- https://docs.openshift.com/container-platform/4.7/security/certificates/service-serving-certificate.html#add-service-certificate-mutating-webhook_service-serving-certificate

While we could have add a dependency on the OpenShift Operator level, it is not needed and we can instead just use the built-in CA.

#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
Not specifically, but we can run existing tests on OCP

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
Marking this as WIP because I haven't tested myself past deployment, but I'm interested in early feedback.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
When deploying on OpenShift, cert-manager is no longer required.
```
