### PR TITLE
Pin container base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# to pin base image below may require further changes on build/release processes
 FROM quay.io/security-profiles-operator/build:latest AS build
 
 COPY . /work

--- a/Dockerfile.build-image
+++ b/Dockerfile.build-image
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM k8s.gcr.io/build-image/debian-base:bullseye-v1.0.0
+# hash below relates to tag: bullseye-v1.0.0
+FROM k8s.gcr.io/build-image/debian-base@sha256:aa2e259dfe202b601b2a94a8b2e1b203a0fe92a601947da3d0c510be4e54c352
 WORKDIR /work
 
 RUN apt-get update && apt-get install -y wget xz-utils libapparmor-dev

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM registry.fedoraproject.org/fedora-minimal:latest AS build
+# hash below referred to latest
+FROM registry.fedoraproject.org/fedora-minimal@sha256:13b422a79980fc4ce26c46b0b6ad573dfaf0825a9d93dda8f6403a66d6709f47 AS build
 USER root
 WORKDIR /work
 
@@ -30,7 +31,8 @@ ARG BPF_ENABLED=0
 
 RUN make
 
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+# hash below referred to latest
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:16da4d4c5cb289433305050a06834b7328769f8a5257ad5b4a5006465a0379ff
 ARG version
 USER root
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -80,7 +80,7 @@ dependencies:
       match: node
 
   - name: debian-base
-    version: 1.0.0
+    version: sha256:aa2e259dfe202b601b2a94a8b2e1b203a0fe92a601947da3d0c510be4e54c352
     refPaths:
     - path: Dockerfile.build-image
       match: k8s.gcr.io/build-image/debian-base


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does

Pins most docker base images.

#### Why we need it:

Pinned dependencies reduce several security risks:

- They ensure that checking and deployment are all done with the same software, reducing deployment risks, simplifying debugging, and enabling reproducibility.
- They can help mitigate compromised dependencies from undermining the security of the project (in the case where you've evaluated the pinned dependency, you are confident it's not compromised, and a later version is released that is compromised).
- They are one way to counter dependency confusion (aka substitution) attacks, in which an application uses multiple feeds to acquire software packages (a "hybrid configuration"), and attackers fool the user into using a malicious package via a feed that was not expected for that package.

More information refer to [ossf](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)

#### Which issue(s) this PR fixes:

Partially fixes https://github.com/kubernetes-sigs/security-profiles-operator/issues/653

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
