### PR TITLE
WIP: Split fedora-e2e flake tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,6 +94,12 @@ jobs:
           $RUN kubectl get nodes -o wide
       - name: Run E2E tests
         run: $RUN hack/ci/e2e-fedora.sh
+      - name: Run E2E flake tests
+        uses: nick-invision/retry@002ef572db3a198cb4a15e23c0121bcdcfdb016d # v2.5.1
+        with:
+          timeout_minutes: 35
+          max_attempts: 3
+          command: $RUN hack/ci/e2e-fedora-flake.sh
 
   e2e-ubuntu:
     needs: image

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,8 @@ else
 BUILDTAGS := $(BUILDTAGS) no_bpf
 endif
 
+E2E_TEST_TAGS ?= 
+
 export CGO_LDFLAGS
 export CGO_ENABLED=1
 
@@ -366,7 +368,7 @@ test-unit: $(BUILD_DIR) ## Run the unit tests
 
 .PHONY: test-e2e
 test-e2e: ## Run the end-to-end tests
-	CGO_LDFLAGS= $(GO) test -parallel 1 -timeout 80m -count=1 ./test/... -v
+	CGO_LDFLAGS= $(GO) test -parallel 1 -timeout 80m -tags='$(E2E_TEST_TAGS)' -count=1 ./test/... -v
 
 # Generate CRD manifests
 manifests:

--- a/hack/ci/e2e-fedora-flake.sh
+++ b/hack/ci/e2e-fedora-flake.sh
@@ -16,12 +16,14 @@
 set -euo pipefail
 
 export E2E_CLUSTER_TYPE=vanilla
-export E2E_TEST_SELINUX=true
-export E2E_TEST_LOG_ENRICHER=true
-export E2E_TEST_PROFILE_RECORDING=true
 
 # These are already tested in the standard e2e test.
 # No need to test them here.
 export E2E_TEST_SECCOMP=false
 
-make test-e2e
+# These are already tested in the fedora e2e test.
+export E2E_TEST_SELINUX=false
+export E2E_TEST_LOG_ENRICHER=false
+export E2E_TEST_PROFILE_RECORDING=false
+
+E2E_TEST_TAGS=flake make test-e2e

--- a/test/e2e_flake_test.go
+++ b/test/e2e_flake_test.go
@@ -1,0 +1,75 @@
+//go:build flake
+// +build flake
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+func (e *e2e) runClusterWideTests(nodes []string) {
+	// Execute the test cases. Each test case should cleanup on its own and
+	// leave a working operator behind.
+	e.logf("testing cluster-wide operator")
+	testCases := []struct {
+		description string
+		fn          func(nodes []string)
+	}{
+		{
+			"Seccomp: Metrics",
+			e.testCaseSeccompMetrics,
+		},
+	}
+	for _, testCase := range testCases {
+		tc := testCase
+		e.Run("cluster-wide: "+tc.description, func() {
+			tc.fn(nodes)
+		})
+	}
+
+	// TODO(jaosorior): Re-introduce this to the namespaced tests once we
+	// fix the issue with the certs.
+	e.Run("cluster-wide: Seccomp: Verify profile binding", func() {
+		e.testCaseProfileBinding(nodes)
+	})
+
+	e.Run("cluster-wide: Seccomp: Verify profile recording bpf", func() {
+		e.enableBpfRecorderInSpod()
+		e.testCaseBpfRecorderKubectlRun()
+		e.testCaseBpfRecorderStaticPod()
+		e.testCaseBpfRecorderMultiContainer()
+		e.testCaseBpfRecorderDeployment()
+		e.testCaseBpfRecorderParallel()
+	})
+}
+
+func (e *e2e) runNamespacedTests(nodes []string) {
+	testCases := []struct {
+		description string
+		fn          func(nodes []string)
+	}{
+		{
+			"SELinux: Metrics (update, delete)",
+			e.testCaseSelinuxMetrics,
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+		e.Run("namespaced: "+tc.description, func() {
+			tc.fn(nodes)
+		})
+	}
+}

--- a/test/e2e_noflake_test.go
+++ b/test/e2e_noflake_test.go
@@ -1,0 +1,167 @@
+//go:build !flake
+// +build !flake
+
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+func (e *e2e) runClusterWideTests(nodes []string) {
+	// Execute the test cases. Each test case should cleanup on its own and
+	// leave a working operator behind.
+	e.logf("testing cluster-wide operator")
+	testCases := []struct {
+		description string
+		fn          func(nodes []string)
+	}{
+		{
+			"Seccomp: Verify default and example profiles",
+			e.testCaseDefaultAndExampleProfiles,
+		},
+		{
+			"Seccomp: Run a test pod",
+			e.testCaseRunPod,
+		},
+		{
+			"Seccomp: Verify base profile merge",
+			e.testCaseBaseProfile,
+		},
+		{
+			"Seccomp: Delete profiles",
+			e.testCaseDeleteProfiles,
+		},
+		{
+			"Seccomp: Re-deploy the operator",
+			e.testCaseReDeployOperator,
+		},
+		{
+			"Log Enricher",
+			e.testCaseLogEnricher,
+		},
+		{
+			"SELinux: sanity check",
+			e.testCaseSelinuxSanityCheck,
+		},
+		{
+			"SELinux: base case (install policy, run pod and delete)",
+			e.testCaseSelinuxBaseUsage,
+		},
+		{
+			"SELinux: Metrics (update, delete)",
+			e.testCaseSelinuxMetrics,
+		},
+		{
+			"SPOD: Update SELinux flag",
+			e.testCaseSPODUpdateSelinux,
+		},
+		{
+			"SPOD: Change verbosity",
+			e.testCaseVerbosityChange,
+		},
+		{
+			"Seccomp: make sure statuses for profiles with long names can be listed",
+			e.testCaseLongSeccompProfileName,
+		},
+	}
+	for _, testCase := range testCases {
+		tc := testCase
+		e.Run("cluster-wide: "+tc.description, func() {
+			tc.fn(nodes)
+		})
+	}
+
+	e.Run("cluster-wide: Seccomp: Verify profile recording hook", func() {
+		e.testCaseProfileRecordingStaticPodHook()
+		e.testCaseProfileRecordingKubectlRunHook()
+		e.testCaseProfileRecordingMultiContainerHook()
+		e.testCaseProfileRecordingDeploymentHook()
+	})
+
+	e.Run("cluster-wide: Seccomp: Verify profile recording logs", func() {
+		e.testCaseProfileRecordingStaticPodLogs()
+		e.testCaseProfileRecordingMultiContainerLogs()
+		e.testCaseProfileRecordingDeploymentLogs()
+	})
+
+	e.Run("cluster-wide: Selinux: Verify SELinux profile recording logs", func() {
+		e.testCaseProfileRecordingStaticPodSELinuxLogs()
+		e.testCaseProfileRecordingMultiContainerSELinuxLogs()
+		e.testCaseProfileRecordingSelinuxDeploymentLogs()
+	})
+}
+
+func (e *e2e) runNamespacedTests(nodes []string) {
+	testCases := []struct {
+		description string
+		fn          func(nodes []string)
+	}{
+		{
+			"Seccomp: Verify default and example profiles",
+			e.testCaseDefaultAndExampleProfiles,
+		},
+		{
+			"Seccomp: Run a test pod",
+			e.testCaseRunPod,
+		},
+		{
+			"Seccomp: Verify base profile merge",
+			e.testCaseBaseProfile,
+		},
+		{
+			"Seccomp: Delete profiles",
+			e.testCaseDeleteProfiles,
+		},
+		{
+			"Seccomp: Metrics",
+			e.testCaseSeccompMetrics,
+		},
+		{
+			"Seccomp: Re-deploy the operator",
+			e.testCaseReDeployNamespaceOperator,
+		},
+		{
+			"Log Enricher",
+			e.testCaseLogEnricher,
+		},
+		{
+			"SELinux: sanity check",
+			e.testCaseSelinuxSanityCheck,
+		},
+		{
+			"SELinux: base case (install policy, run pod and delete)",
+			e.testCaseSelinuxBaseUsage,
+		},
+		{
+			"SPOD: Update SELinux flag",
+			e.testCaseSPODUpdateSelinux,
+		},
+		{
+			"SPOD: Change verbosity",
+			e.testCaseVerbosityChange,
+		},
+		{
+			"Seccomp: make sure statuses for profiles with long names can be listed",
+			e.testCaseLongSeccompProfileName,
+		},
+	}
+
+	for _, testCase := range testCases {
+		tc := testCase
+		e.Run("namespaced: "+tc.description, func() {
+			tc.fn(nodes)
+		})
+	}
+}

--- a/test/tc_bpf_recorder_test.go
+++ b/test/tc_bpf_recorder_test.go
@@ -1,3 +1,6 @@
+//go:build flake
+// +build flake
+
 /*
 Copyright 2021 The Kubernetes Authors.
 
@@ -47,8 +50,6 @@ func (e *e2e) waitForBpfRecorderLogs(since time.Time) {
 }
 
 func (e *e2e) testCaseBpfRecorderKubectlRun() {
-	e.bpfRecorderOnlyTestCase()
-
 	e.logf("Creating bpf recording for kubectl run test")
 	e.kubectl("create", "-f", exampleRecordingBpfPath)
 
@@ -64,8 +65,6 @@ func (e *e2e) testCaseBpfRecorderKubectlRun() {
 }
 
 func (e *e2e) testCaseBpfRecorderStaticPod() {
-	e.bpfRecorderOnlyTestCase()
-
 	e.logf("Creating bpf recording for static pod test")
 	e.kubectl("create", "-f", exampleRecordingBpfPath)
 
@@ -92,8 +91,6 @@ func (e *e2e) testCaseBpfRecorderStaticPod() {
 }
 
 func (e *e2e) testCaseBpfRecorderMultiContainer() {
-	e.bpfRecorderOnlyTestCase()
-
 	e.logf("Creating bpf recording for multi container test")
 	e.kubectl("create", "-f", exampleRecordingBpfPath)
 
@@ -116,8 +113,6 @@ func (e *e2e) testCaseBpfRecorderMultiContainer() {
 }
 
 func (e *e2e) testCaseBpfRecorderDeployment() {
-	e.bpfRecorderOnlyTestCase()
-
 	e.logf("Creating bpf recording for deployment test")
 	e.kubectl("create", "-f", exampleRecordingBpfPath)
 
@@ -172,8 +167,6 @@ spec:
 }
 
 func (e *e2e) testCaseBpfRecorderParallel() {
-	e.bpfRecorderOnlyTestCase()
-
 	e.logf("Creating bpf recording for parallel test")
 	e.kubectl("create", "-f", exampleRecordingBpfPath)
 
@@ -244,4 +237,14 @@ spec:
 	}
 
 	return since, podNames
+}
+
+func (e *e2e) enableBpfRecorderInSpod() {
+	e.logf("Enable bpf recorder in SPOD")
+	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableBpfRecorder": true}}`, "--type=merge")
+
+	time.Sleep(defaultWaitTime)
+	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+
+	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultBpfRecorderOpTimeout)
 }

--- a/test/tc_profilebindings_test.go
+++ b/test/tc_profilebindings_test.go
@@ -1,3 +1,6 @@
+//go:build flake
+// +build flake
+
 /*
 Copyright 2021 The Kubernetes Authors.
 


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind flake

#### What this PR does / why we need it:

Some tests are intermittendly failing (a.k.a. flaking). They are most often happening as part of the `fedora-e2e` test suite which  currently takes around 40 minutes to run.

By splitting them from the more reliable tests allows us to better decide how to approach the problem - (e.g. auto-retry). 

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
