### PR TITLE
Limit log enricher ttl cache size

### DIFF
--- a/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
+++ b/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
@@ -84,10 +84,10 @@ type FakeImpl struct {
 	closeReturnsOnCall map[int]struct {
 		result1 error
 	}
-	ContainerIDForPIDStub        func(ttlcache.SimpleCache, int) (string, error)
+	ContainerIDForPIDStub        func(*ttlcache.Cache, int) (string, error)
 	containerIDForPIDMutex       sync.RWMutex
 	containerIDForPIDArgsForCall []struct {
-		arg1 ttlcache.SimpleCache
+		arg1 *ttlcache.Cache
 		arg2 int
 	}
 	containerIDForPIDReturns struct {
@@ -259,10 +259,10 @@ type FakeImpl struct {
 	serveReturnsOnCall map[int]struct {
 		result1 error
 	}
-	SetTTLStub        func(ttlcache.SimpleCache, time.Duration) error
+	SetTTLStub        func(*ttlcache.Cache, time.Duration) error
 	setTTLMutex       sync.RWMutex
 	setTTLArgsForCall []struct {
-		arg1 ttlcache.SimpleCache
+		arg1 *ttlcache.Cache
 		arg2 time.Duration
 	}
 	setTTLReturns struct {
@@ -553,11 +553,11 @@ func (fake *FakeImpl) CloseReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeImpl) ContainerIDForPID(arg1 ttlcache.SimpleCache, arg2 int) (string, error) {
+func (fake *FakeImpl) ContainerIDForPID(arg1 *ttlcache.Cache, arg2 int) (string, error) {
 	fake.containerIDForPIDMutex.Lock()
 	ret, specificReturn := fake.containerIDForPIDReturnsOnCall[len(fake.containerIDForPIDArgsForCall)]
 	fake.containerIDForPIDArgsForCall = append(fake.containerIDForPIDArgsForCall, struct {
-		arg1 ttlcache.SimpleCache
+		arg1 *ttlcache.Cache
 		arg2 int
 	}{arg1, arg2})
 	stub := fake.ContainerIDForPIDStub
@@ -579,13 +579,13 @@ func (fake *FakeImpl) ContainerIDForPIDCallCount() int {
 	return len(fake.containerIDForPIDArgsForCall)
 }
 
-func (fake *FakeImpl) ContainerIDForPIDCalls(stub func(ttlcache.SimpleCache, int) (string, error)) {
+func (fake *FakeImpl) ContainerIDForPIDCalls(stub func(*ttlcache.Cache, int) (string, error)) {
 	fake.containerIDForPIDMutex.Lock()
 	defer fake.containerIDForPIDMutex.Unlock()
 	fake.ContainerIDForPIDStub = stub
 }
 
-func (fake *FakeImpl) ContainerIDForPIDArgsForCall(i int) (ttlcache.SimpleCache, int) {
+func (fake *FakeImpl) ContainerIDForPIDArgsForCall(i int) (*ttlcache.Cache, int) {
 	fake.containerIDForPIDMutex.RLock()
 	defer fake.containerIDForPIDMutex.RUnlock()
 	argsForCall := fake.containerIDForPIDArgsForCall[i]
@@ -1422,11 +1422,11 @@ func (fake *FakeImpl) ServeReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeImpl) SetTTL(arg1 ttlcache.SimpleCache, arg2 time.Duration) error {
+func (fake *FakeImpl) SetTTL(arg1 *ttlcache.Cache, arg2 time.Duration) error {
 	fake.setTTLMutex.Lock()
 	ret, specificReturn := fake.setTTLReturnsOnCall[len(fake.setTTLArgsForCall)]
 	fake.setTTLArgsForCall = append(fake.setTTLArgsForCall, struct {
-		arg1 ttlcache.SimpleCache
+		arg1 *ttlcache.Cache
 		arg2 time.Duration
 	}{arg1, arg2})
 	stub := fake.SetTTLStub
@@ -1448,13 +1448,13 @@ func (fake *FakeImpl) SetTTLCallCount() int {
 	return len(fake.setTTLArgsForCall)
 }
 
-func (fake *FakeImpl) SetTTLCalls(stub func(ttlcache.SimpleCache, time.Duration) error) {
+func (fake *FakeImpl) SetTTLCalls(stub func(*ttlcache.Cache, time.Duration) error) {
 	fake.setTTLMutex.Lock()
 	defer fake.setTTLMutex.Unlock()
 	fake.SetTTLStub = stub
 }
 
-func (fake *FakeImpl) SetTTLArgsForCall(i int) (ttlcache.SimpleCache, time.Duration) {
+func (fake *FakeImpl) SetTTLArgsForCall(i int) (*ttlcache.Cache, time.Duration) {
 	fake.setTTLMutex.RLock()
 	defer fake.setTTLMutex.RUnlock()
 	argsForCall := fake.setTTLArgsForCall[i]

--- a/internal/pkg/daemon/enricher/impl.go
+++ b/internal/pkg/daemon/enricher/impl.go
@@ -40,14 +40,14 @@ type defaultImpl struct{}
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate
 //counterfeiter:generate . impl
 type impl interface {
-	SetTTL(cache ttlcache.SimpleCache, ttl time.Duration) error
+	SetTTL(cache *ttlcache.Cache, ttl time.Duration) error
 	Getenv(key string) string
 	Dial() (*grpc.ClientConn, context.CancelFunc, error)
 	Close(*grpc.ClientConn) error
 	TailFile(filename string, config tail.Config) (*tail.Tail, error)
 	Lines(tailFile *tail.Tail) chan *tail.Line
 	Reason(tailFile *tail.Tail) error
-	ContainerIDForPID(cache ttlcache.SimpleCache, pid int) (string, error)
+	ContainerIDForPID(cache *ttlcache.Cache, pid int) (string, error)
 	InClusterConfig() (*rest.Config, error)
 	NewForConfig(c *rest.Config) (*kubernetes.Clientset, error)
 	ListPods(c *kubernetes.Clientset, nodeName string) (*v1.PodList, error)
@@ -63,7 +63,7 @@ type impl interface {
 	RemoveAll(string) error
 }
 
-func (d *defaultImpl) SetTTL(cache ttlcache.SimpleCache, ttl time.Duration) error {
+func (d *defaultImpl) SetTTL(cache *ttlcache.Cache, ttl time.Duration) error {
 	return cache.SetTTL(ttl)
 }
 
@@ -93,7 +93,7 @@ func (d *defaultImpl) Reason(tailFile *tail.Tail) error {
 	return tailFile.Err()
 }
 
-func (d *defaultImpl) ContainerIDForPID(cache ttlcache.SimpleCache, pid int) (string, error) {
+func (d *defaultImpl) ContainerIDForPID(cache *ttlcache.Cache, pid int) (string, error) {
 	return util.ContainerIDForPID(cache, pid)
 }
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
Limiting the cache sizes to not overflow the memory.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
