### PR TITLE
Make bpf kubectl run test more robust

### DIFF
--- a/test/tc_bpf_recorder_test.go
+++ b/test/tc_bpf_recorder_test.go
@@ -53,7 +53,7 @@ func (e *e2e) testCaseBpfRecorderKubectlRun() {
 	e.kubectl("create", "-f", exampleRecordingBpfPath)
 
 	e.logf("Creating test pod")
-	e.kubectlRun("--labels=app=alpine", "fedora", "--", "mkdir", "/test")
+	e.kubectlRun("--labels=app=alpine", "fedora", "--", "sh", "-c", "sleep 3; mkdir /test")
 
 	resourceName := recordingName + "-fedora"
 	profile := e.retryGetSeccompProfile(resourceName)


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
Waiting a bit inside of the container should make the overall test more robust. 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
