### PR TITLE
Increase ephemeral storage for log-enricher

### DIFF
--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -449,7 +449,7 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 							},
 							Limits: corev1.ResourceList{
 								corev1.ResourceMemory:           resource.MustParse("128Mi"),
-								corev1.ResourceEphemeralStorage: resource.MustParse("20Mi"),
+								corev1.ResourceEphemeralStorage: resource.MustParse("128Mi"),
 							},
 						},
 						Env: []corev1.EnvVar{


### PR DESCRIPTION
#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
The log-enricher gets killed by the kubelet when running intensive (50 pods) seccomp recording tests:
```
Container log-enricher exceeded its local ephemeral storage limit \"20Mi\".
```
We now increase the memory to have more room left.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #736 
#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
