### PR TITLE
Pin cri-o and redhat-actions/push-to-registry

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
           dockerfiles: |
             Dockerfile.build-image
       - if: github.ref == 'refs/heads/main'
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5e1b62eb0c53b3fa78da944c85c01e810172297d # v2.5
         with:
           image: ${{ steps.build-image.outputs.image }}
           registry: quay.io/security-profiles-operator

--- a/hack/ci/install-cri-o.sh
+++ b/hack/ci/install-cri-o.sh
@@ -15,7 +15,9 @@
 
 set -euo pipefail
 
-curl https://raw.githubusercontent.com/cri-o/cri-o/main/scripts/get | bash
+COMMIT_ID="d7cc66fe80c51a197d13a642ad5bddd9dc7e9f74"
+
+curl "https://raw.githubusercontent.com/cri-o/cri-o/${COMMIT_ID}/scripts/get" | bash
 
 chcon -u system_u -r object_r -t container_runtime_exec_t \
     /usr/local/bin/crio \


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does

- Pins the script used to install CRI-O.
- Pins GitHub action redhat-actions/push-to-registry to v2.5.

#### Why we need it:

Pinned dependencies reduce several security risks:

- They ensure that checking and deployment are all done with the same software, reducing deployment risks, simplifying debugging, and enabling reproducibility.
- They can help mitigate compromised dependencies from undermining the security of the project (in the case where you've evaluated the pinned dependency, you are confident it's not compromised, and a later version is released that is compromised).
- They are one way to counter dependency confusion (aka substitution) attacks, in which an application uses multiple feeds to acquire software packages (a "hybrid configuration"), and attackers fool the user into using a malicious package via a feed that was not expected for that package.

More information refer to [ossf](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)

#### Which issue(s) this PR fixes:

Relates to https://github.com/kubernetes-sigs/security-profiles-operator/issues/653

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

Once this PR is merged, there is only one valid item dependency to be pinned (as per reported by ossf scorecard), which is the build base image:
https://github.com/kubernetes-sigs/security-profiles-operator/blob/main/Dockerfile#L16

This item will be remediated in the coming weeks.

The ossf scorecard also reported a few items within the `vendor` folder, but I am treating it as false positive (https://github.com/ossf/scorecard/issues/1095).

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
