### PR TITLE
Switch to using quay.io/security-profiles-operator/selinuxd

### DIFF
--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -24,7 +24,7 @@ patchesStrategicMerge:
           - name: security-profiles-operator
             env:
               - name: RELATED_IMAGE_SELINUXD
-                value: quay.io/jaosorior/selinuxd
+                value: quay.io/security-profiles-operator/selinuxd
 
 commonLabels:
   app: security-profiles-operator

--- a/deploy/base/manager_deployment.yaml
+++ b/deploy/base/manager_deployment.yaml
@@ -34,7 +34,7 @@ spec:
               memory: 64Mi
           env:
             - name: RELATED_IMAGE_SELINUXD
-              value: quay.io/jaosorior/selinuxd
+              value: quay.io/security-profiles-operator/selinuxd
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1697,7 +1697,7 @@ spec:
         - name: RESTRICT_TO_NAMESPACE
           value: NS_REPLACE
         - name: RELATED_IMAGE_SELINUXD
-          value: quay.io/jaosorior/selinuxd
+          value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -1697,7 +1697,7 @@ spec:
         - name: DEFAULT_ENABLE_SELINUX
           value: "true"
         - name: RELATED_IMAGE_SELINUXD
-          value: quay.io/jaosorior/selinuxd
+          value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/openshift.yaml
+++ b/deploy/openshift.yaml
@@ -1697,7 +1697,7 @@ spec:
         - name: DEFAULT_ENABLE_SELINUX
           value: "true"
         - name: RELATED_IMAGE_SELINUXD
-          value: quay.io/jaosorior/selinuxd
+          value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1695,7 +1695,7 @@ spec:
         - manager
         env:
         - name: RELATED_IMAGE_SELINUXD
-          value: quay.io/jaosorior/selinuxd
+          value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -175,7 +175,7 @@ var Manifest = &appsv1.DaemonSet{
 					},
 					{
 						Name:  "selinux-shared-policies-copier",
-						Image: "quay.io/jaosorior/selinuxd",
+						Image: "quay.io/security-profiles-operator/selinuxd",
 						// Primes the volume mount under /etc/selinux.d with the
 						// shared policies shipped by selinuxd and makes sure the volume mount
 						// is writable by 65535 in order for the controller to be able to
@@ -356,7 +356,7 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 					},
 					{
 						Name:  "selinuxd",
-						Image: "quay.io/jaosorior/selinuxd",
+						Image: "quay.io/security-profiles-operator/selinuxd",
 						Args: []string{
 							"daemon",
 							"--datastore-path", SelinuxdDBPath,

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -129,7 +129,7 @@ func TestSuite(t *testing.T) {
 		bpfRecorderEnabled = false
 	}
 
-	selinuxdImage := "quay.io/jaosorior/selinuxd"
+	selinuxdImage := "quay.io/security-profiles-operator/selinuxd"
 	switch {
 	case clusterType == "" || strings.EqualFold(clusterType, clusterTypeKind):
 		if testImage == "" {
@@ -179,7 +179,7 @@ func TestSuite(t *testing.T) {
 		if testImage == "" {
 			testImage = "localhost/" + config.OperatorName + ":latest"
 		}
-		selinuxdImage = "quay.io/jaosorior/selinuxd-fedora"
+		selinuxdImage = "quay.io/security-profiles-operator/selinuxd-fedora"
 		suite.Run(t, &vanilla{
 			e2e{
 				logger:               klogr.New(),
@@ -261,7 +261,7 @@ func (e *kinde2e) SetupTest() {
 		containerRuntime, "pull", e.selinuxdImage,
 	)
 	e.run(
-		e.kindPath, "load", "docker-image", "--name="+e.clusterName, "quay.io/jaosorior/selinuxd",
+		e.kindPath, "load", "docker-image", "--name="+e.clusterName, "quay.io/security-profiles-operator/selinuxd",
 	)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug

/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
selinuxd graduated and moved out of a personal GH namespace and a personal quay.io repo. Let's use the new builds.

#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A will be tested with the existing tests

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
selinuxd now uses containers from quay.io/security-profiles-operator
```
