### PR TITLE
Increase maximum log enricher memory to 256MiB

### DIFF
--- a/internal/pkg/daemon/enricher/enricher.go
+++ b/internal/pkg/daemon/enricher/enricher.go
@@ -309,7 +309,6 @@ func (e *Enricher) addToBacklog(line *auditLine) error {
 		return errors.Wrap(setErr, "adding a line to the backlog")
 	}
 
-	e.logger.Info("line appended to backlog")
 	return nil
 }
 

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -449,7 +449,7 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 								corev1.ResourceEphemeralStorage: resource.MustParse("10Mi"),
 							},
 							Limits: corev1.ResourceList{
-								corev1.ResourceMemory:           resource.MustParse("128Mi"),
+								corev1.ResourceMemory:           resource.MustParse("256Mi"),
 								corev1.ResourceEphemeralStorage: resource.MustParse("128Mi"),
 							},
 						},


### PR DESCRIPTION
#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:
The log enricher gets out of memory killed when running intense tests.
Therefore we increase it's maximum used memory. We also lower the
verbosity of the backlog lines to not spam the logs.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #736 
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
