### PR TITLE
selinux: Enable the selinuxd profiling endpoint with enableProfiling=true

### DIFF
--- a/installation-usage.md
+++ b/installation-usage.md
@@ -968,6 +968,15 @@ Or to look at a 30-second CPU profile:
 go tool pprof http://$PODIP:6060/debug/pprof/profile?seconds=30
 ```
 
+Note that selinuxd, if enabled, doesn't set up a HTTP listener, but only
+listens on a UNIX socket shared between selinuxd and the `spod` DS pod.
+Nonetheless, this socket can be used to reach the profiling enpoint as
+well:
+```
+kubectl exec spod-4pt84 -c selinuxd -- curl --unix-socket /var/run/selinuxd/selinuxd.sock http://localhost/debug/pprof/heap --output - > /tmp/heap.selinuxd
+go tool pprof /tmp/heap.selinuxd
+```
+
 For a study of the facility in action, please visit:
 https://blog.golang.org/2011/06/profiling-go-programs.html
 

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -489,10 +489,7 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 
 		// Enable profiling if requested
 		if cfg.Spec.EnableProfiling {
-			templateSpec.Containers[i].Env = append(
-				templateSpec.Containers[i].Env,
-				profilingEnvs(i)...,
-			)
+			enableContainerProfiling(templateSpec, i)
 		}
 	}
 
@@ -508,7 +505,26 @@ func verbosityEnv(value uint) corev1.EnvVar {
 	}
 }
 
-func profilingEnvs(add int) []corev1.EnvVar {
+func enableContainerProfiling(templateSpec *corev1.PodSpec, cID int) {
+	switch cID {
+	case bindata.ContainerIDSelinuxd:
+		templateSpec.Containers[cID].Args = append(
+			templateSpec.Containers[cID].Args,
+			profilingArgsSelinuxd()...,
+		)
+	default:
+		templateSpec.Containers[cID].Env = append(
+			templateSpec.Containers[cID].Env,
+			profilingEnvsSpo(cID)...,
+		)
+	}
+}
+
+func profilingArgsSelinuxd() []string {
+	return []string{"--enable-profiling=true"}
+}
+
+func profilingEnvsSpo(add int) []corev1.EnvVar {
 	return []corev1.EnvVar{
 		{
 			Name:  config.ProfilingEnvKey,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
selinuxd also uses a profiling endpoint, but it's enabled using the
--enable-profiling=true command line switch, not using an environment
variable.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
needs a recent selinuxd image (from yesterday)

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
