### PR TITLE
Increase manager memory constraints

### DIFF
--- a/deploy/base/manager_deployment.yaml
+++ b/deploy/base/manager_deployment.yaml
@@ -28,10 +28,10 @@ spec:
             allowPrivilegeEscalation: false
           resources:
             requests:
-              memory: 32Mi
+              memory: 50Mi
               cpu: 250m
             limits:
-              memory: 64Mi
+              memory: 128Mi
           env:
             - name: RELATED_IMAGE_SELINUXD
               value: quay.io/security-profiles-operator/selinuxd

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1711,10 +1711,10 @@ spec:
         name: security-profiles-operator
         resources:
           limits:
-            memory: 64Mi
+            memory: 128Mi
           requests:
             cpu: 250m
-            memory: 32Mi
+            memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -1711,10 +1711,10 @@ spec:
         name: security-profiles-operator
         resources:
           limits:
-            memory: 64Mi
+            memory: 128Mi
           requests:
             cpu: 250m
-            memory: 32Mi
+            memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/deploy/openshift.yaml
+++ b/deploy/openshift.yaml
@@ -1711,10 +1711,10 @@ spec:
         name: security-profiles-operator
         resources:
           limits:
-            memory: 64Mi
+            memory: 128Mi
           requests:
             cpu: 250m
-            memory: 32Mi
+            memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1709,10 +1709,10 @@ spec:
         name: security-profiles-operator
         resources:
           limits:
-            memory: 64Mi
+            memory: 128Mi
           requests:
             cpu: 250m
-            memory: 32Mi
+            memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false
           readOnlyRootFilesystem: true


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
While doing some long term testing of the operator I saw that the
manager is near its memory constraints, which causes it to be killed
from time to time. To avoid that we now bump the memory to a more stable
level.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
/hold
should merge after https://github.com/kubernetes-sigs/security-profiles-operator/pull/763
#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
None
#### Special notes for your reviewer:
![screenshot](https://user-images.githubusercontent.com/695473/146039022-9b450d41-8915-429d-aabb-c48b816614e7.png)

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Increase manager memory limit to 128MiB
```
