### PR TITLE
Support verbosity=1 for log-enricher

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -67,6 +67,9 @@ const (
 	// VerbosityEnvKey is the environment variable key for the logging verbosity.
 	VerbosityEnvKey = "SPO_VERBOSITY"
 
+	// VerboseLevel is the increased verbosity log level.
+	VerboseLevel = 1
+
 	// ProfilingEnvKey is the environment variable key for enabling profiling
 	// support.
 	ProfilingEnvKey = "SPO_PROFILING"

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
@@ -54,7 +54,6 @@ const (
 	defaultTimeout      time.Duration = time.Minute
 	maxMsgSize          int           = 16 * 1024 * 1024
 	defaultCacheTimeout time.Duration = time.Hour
-	verboseLvl          int           = 1
 	maxCacheItems       int           = 1000
 )
 
@@ -330,7 +329,7 @@ func (b *BpfRecorder) SyscallsForProfile(
 					continue
 				}
 
-				b.logger.V(verboseLvl).Info(
+				b.logger.V(config.VerboseLevel).Info(
 					"Got syscall",
 					"comm", pid.comm, "pid", pid.id, "name", name,
 				)
@@ -539,7 +538,7 @@ func (b *BpfRecorder) processEvents(events chan []byte) {
 
 			// Filter out non-containers
 			if mntns == b.systemMountNamespace {
-				b.logger.V(verboseLvl).Info(
+				b.logger.V(config.VerboseLevel).Info(
 					"Skipping PID, because it's on the system mount namespace",
 					"pid", pid, "mntns", mntns,
 				)
@@ -563,14 +562,14 @@ func (b *BpfRecorder) processEvents(events chan []byte) {
 			// Regular container ID retrieval via the cgroup
 			containerID, err := b.ContainerIDForPID(b.containerIDCache, int(pid))
 			if err != nil {
-				b.logger.V(verboseLvl).Info(
+				b.logger.V(config.VerboseLevel).Info(
 					"No container ID found for PID",
 					"pid", pid, "err", err.Error(),
 				)
 				return
 			}
 
-			b.logger.V(verboseLvl).Info(
+			b.logger.V(config.VerboseLevel).Info(
 				"Found container for PID", "pid", pid, "containerID", containerID,
 			)
 			if err := b.findContainerID(containerID); err != nil {
@@ -691,7 +690,7 @@ func (b *BpfRecorder) findContainerID(id string) error {
 
 					key := config.SeccompProfileRecordBpfAnnotationKey + containerName
 					if profile, ok := pod.Annotations[key]; ok {
-						b.logger.V(verboseLvl).Info(
+						b.logger.V(config.VerboseLevel).Info(
 							"Found profile to record",
 							"profile", profile,
 							"containerID", containerID,

--- a/internal/pkg/daemon/enricher/enricher.go
+++ b/internal/pkg/daemon/enricher/enricher.go
@@ -165,7 +165,9 @@ func (e *Enricher) Run() error {
 		}
 
 		line := l.Text
+		e.logger.V(config.VerboseLevel).Info("Got line: " + line)
 		if !isAuditLine(line) {
+			e.logger.V(config.VerboseLevel).Info("Not an audit line")
 			continue
 		}
 
@@ -175,6 +177,7 @@ func (e *Enricher) Run() error {
 			continue
 		}
 
+		e.logger.V(config.VerboseLevel).Info(fmt.Sprintf("Get container ID for PID: %d", auditLine.processID))
 		cID, err := e.impl.ContainerIDForPID(e.containerIDCache, auditLine.processID)
 		if errors.Is(err, os.ErrNotExist) {
 			// We're probably in container creation or removal
@@ -194,6 +197,7 @@ func (e *Enricher) Run() error {
 			continue
 		}
 
+		e.logger.V(config.VerboseLevel).Info("Get container info for: " + cID)
 		info, err := e.getContainerInfo(nodeName, cID)
 		if err != nil {
 			e.logger.Error(


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
Added increased verbosity to log enricher.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support `verbosity=1` for log-enricher
```
