### PR TITLE
Support custom host /proc path in config

### DIFF
--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -58,6 +58,11 @@ type SPODSpec struct {
 	// Defines options specific to the SELinux
 	// functionality of the SecurityProfilesOperator
 	SelinuxOpts SelinuxOptions `json:"selinuxOptions,omitempty"`
+	// HostProcVolumePath is the path for specifying a custom host /proc
+	// volume, which is required for the log-enricher as well as bpf-recorder
+	// to retrieve the container ID for a process ID. This can be helpful for
+	// nested environments, for example when using "kind".
+	HostProcVolumePath string `json:"hostProcVolumePath,omitempty"`
 }
 
 // SPODState defines the state that the spod is in.

--- a/deploy/base/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base/crds/securityprofilesoperatordaemon.yaml
@@ -61,6 +61,12 @@ spec:
                 description: tells the operator whether or not to enable SELinux support
                   for this SPOD instance.
                 type: boolean
+              hostProcVolumePath:
+                description: HostProcVolumePath is the path for specifying a custom
+                  host /proc volume, which is required for the log-enricher as well
+                  as bpf-recorder to retrieve the container ID for a process ID. This
+                  can be helpful for nested environments, for example when using "kind".
+                type: string
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -584,6 +584,12 @@ spec:
                 description: tells the operator whether or not to enable SELinux support
                   for this SPOD instance.
                 type: boolean
+              hostProcVolumePath:
+                description: HostProcVolumePath is the path for specifying a custom
+                  host /proc volume, which is required for the log-enricher as well
+                  as bpf-recorder to retrieve the container ID for a process ID. This
+                  can be helpful for nested environments, for example when using "kind".
+                type: string
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -584,6 +584,12 @@ spec:
                 description: tells the operator whether or not to enable SELinux support
                   for this SPOD instance.
                 type: boolean
+              hostProcVolumePath:
+                description: HostProcVolumePath is the path for specifying a custom
+                  host /proc volume, which is required for the log-enricher as well
+                  as bpf-recorder to retrieve the container ID for a process ID. This
+                  can be helpful for nested environments, for example when using "kind".
+                type: string
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator

--- a/deploy/openshift.yaml
+++ b/deploy/openshift.yaml
@@ -584,6 +584,12 @@ spec:
                 description: tells the operator whether or not to enable SELinux support
                   for this SPOD instance.
                 type: boolean
+              hostProcVolumePath:
+                description: HostProcVolumePath is the path for specifying a custom
+                  host /proc volume, which is required for the log-enricher as well
+                  as bpf-recorder to retrieve the container ID for a process ID. This
+                  can be helpful for nested environments, for example when using "kind".
+                type: string
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -584,6 +584,12 @@ spec:
                 description: tells the operator whether or not to enable SELinux support
                   for this SPOD instance.
                 type: boolean
+              hostProcVolumePath:
+                description: HostProcVolumePath is the path for specifying a custom
+                  host /proc volume, which is required for the log-enricher as well
+                  as bpf-recorder to retrieve the container ID for a process ID. This
+                  can be helpful for nested environments, for example when using "kind".
+                type: string
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -1,7 +1,6 @@
 # Installation and Usage
 
 <!-- toc -->
-
 - [Features](#features)
 - [Tutorials and Demos](#tutorials-and-demos)
 - [Install operator](#install-operator)
@@ -21,6 +20,7 @@
 - [Using the log enricher](#using-the-log-enricher)
 - [Troubleshooting](#troubleshooting)
   - [Enable CPU and memory profiling](#enable-cpu-and-memory-profiling)
+  - [Use a custom <code>/proc</code> location for nested environments like <code>kind</code>](#use-a-custom-proc-location-for-nested-environments-like-kind)
 - [Uninstalling](#uninstalling)
 <!-- /toc -->
 
@@ -972,6 +972,7 @@ Note that selinuxd, if enabled, doesn't set up a HTTP listener, but only
 listens on a UNIX socket shared between selinuxd and the `spod` DS pod.
 Nonetheless, this socket can be used to reach the profiling enpoint as
 well:
+
 ```
 kubectl exec spod-4pt84 -c selinuxd -- curl --unix-socket /var/run/selinuxd/selinuxd.sock http://localhost/debug/pprof/heap --output - > /tmp/heap.selinuxd
 go tool pprof /tmp/heap.selinuxd
@@ -979,6 +980,16 @@ go tool pprof /tmp/heap.selinuxd
 
 For a study of the facility in action, please visit:
 https://blog.golang.org/2011/06/profiling-go-programs.html
+
+### Use a custom `/proc` location for nested environments like `kind`
+
+The operator configuration supports specifying a custom `/proc` location, which
+is required for the container ID retrieval of the log-enricher as well as the
+bpf-recorder. To use a custom path for `/proc`, just patch the spod accordingly:
+
+```
+kubectl patch spod spod --type=merge -p '{"spec":{"hostProcVolumePath":"/my-proc"}}'
+```
 
 ## Uninstalling
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We now support setting the host proc path for nested setups like kind.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `hostProcVolumePath` option to spod to define a custom `/proc` volume on the host.
```
