### PR TITLE
fix: health probe of seccomp controller should be ready if a node supports seccomp

### DIFF
--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -123,10 +123,11 @@ func (r *Reconciler) Healthz(*http.Request) error {
 	return r.checkSeccomp()
 }
 
-// checkSeccomp verifies if the seccomp is supported by the node
+// checkSeccomp verifies if the seccomp is supported by the node.
 func (r *Reconciler) checkSeccomp() error {
 	if !seccomp.IsSupported() {
-		err := fmt.Errorf("node %q does not support seccomp", os.Getenv(config.NodeNameEnvKey))
+		err := errors.New("seccomp not supported")
+		err = fmt.Errorf("node %q: %w", os.Getenv(config.NodeNameEnvKey), err)
 		if r.record != nil {
 			r.metrics.IncSeccompProfileError(reasonSeccompNotSupported)
 			r.record.Event(&seccompprofileapi.SeccompProfile{},


### PR DESCRIPTION
Signed-off-by: Cosmin Cojocar <gcojocar@adobe.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
bug 

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This fix avoids an endless restart of seccomp container when there isn't any seccompprofile
defined into the cluster. In this situation the reconcile loop never gets executed, and the
seccomp container keeps being restarted by Kubernetes.

This is currently happening when the operator is initially installed.

The seccompprofile controller should be ready even if there is no  profile defined but the node supports seccomp.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
