### PR TITLE
test: make the e2e tsts to run on macos

### DIFF
--- a/test/tc_run_pod_test.go
+++ b/test/tc_run_pod_test.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package e2e_test
 
-import "fmt"
-
 func (e *e2e) testCaseRunPod([]string) {
 	e.seccompOnlyTestCase()
 	const (
@@ -27,10 +25,7 @@ func (e *e2e) testCaseRunPod([]string) {
 
 	namespace := e.getCurrentContextNamespace(defaultNamespace)
 	if namespace != defaultNamespace {
-		e.run(
-			"sed", "-i", fmt.Sprintf("s/security-profiles-operator/%s/g", namespace),
-			examplePodPath,
-		)
+		e.updateManifest(examplePodPath, "security-profiles-operator", namespace)
 		defer e.run("git", "checkout", examplePodPath)
 	}
 


### PR DESCRIPTION
Signed-off-by: Cosmin Cojocar <gcojocar@adobe.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

The used sed syntax doesn't work on macos. This replaces the sed with a pure go implementation which is cross-platform.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Make the e2e tests run on macOS

```
