### PR TITLE
Add ability to patch "problematic" pods

### DIFF
--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -68,6 +68,10 @@ type SPODSpec struct {
 	// tells the operator whether or not to enable AppArmor support for this
 	// SPOD instance.
 	EnableAppArmor bool `json:"enableAppArmor,omitempty"`
+	// tells the operator whether or not to apply labels to pods that present
+	// security policy-related denials. Note that this will be done cluster-wide.
+	// Note that this currently requires the log enricher to be enabled.
+	LabelPodDenials bool `json:"labelPodDenials,omitempty"`
 	// If specified, the SPOD's tolerations.
 	// +optional
 	Tolerations []corev1.Toleration `json:"tolerations,omitempty"`

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_securityprofilesoperatordaemons.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_securityprofilesoperatordaemons.yaml
@@ -69,6 +69,12 @@ spec:
                   as bpf-recorder to retrieve the container ID for a process ID. This
                   can be helpful for nested environments, for example when using "kind".
                 type: string
+              labelPodDenials:
+                description: tells the operator whether or not to apply labels to
+                  pods that present security policy-related denials. Note that this
+                  will be done cluster-wide. Note that this currently requires the
+                  log enricher to be enabled.
+                type: boolean
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator

--- a/bundle/manifests/spod_rbac.authorization.k8s.io_v1_clusterrole.yaml
+++ b/bundle/manifests/spod_rbac.authorization.k8s.io_v1_clusterrole.yaml
@@ -49,6 +49,8 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - security-profiles-operator.x-k8s.io

--- a/deploy/base/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base/crds/securityprofilesoperatordaemon.yaml
@@ -67,6 +67,12 @@ spec:
                   as bpf-recorder to retrieve the container ID for a process ID. This
                   can be helpful for nested environments, for example when using "kind".
                 type: string
+              labelPodDenials:
+                description: tells the operator whether or not to apply labels to
+                  pods that present security policy-related denials. Note that this
+                  will be done cluster-wide. Note that this currently requires the
+                  log enricher to be enabled.
+                type: boolean
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator

--- a/deploy/base/role.yaml
+++ b/deploy/base/role.yaml
@@ -299,6 +299,8 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - security-profiles-operator.x-k8s.io

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -609,6 +609,12 @@ spec:
                   as bpf-recorder to retrieve the container ID for a process ID. This
                   can be helpful for nested environments, for example when using "kind".
                 type: string
+              labelPodDenials:
+                description: tells the operator whether or not to apply labels to
+                  pods that present security policy-related denials. Note that this
+                  will be done cluster-wide. Note that this currently requires the
+                  log enricher to be enabled.
+                type: boolean
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator
@@ -1434,6 +1440,8 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - security-profiles-operator.x-k8s.io

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -609,6 +609,12 @@ spec:
                   as bpf-recorder to retrieve the container ID for a process ID. This
                   can be helpful for nested environments, for example when using "kind".
                 type: string
+              labelPodDenials:
+                description: tells the operator whether or not to apply labels to
+                  pods that present security policy-related denials. Note that this
+                  will be done cluster-wide. Note that this currently requires the
+                  log enricher to be enabled.
+                type: boolean
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator
@@ -1434,6 +1440,8 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - security-profiles-operator.x-k8s.io

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -609,6 +609,12 @@ spec:
                   as bpf-recorder to retrieve the container ID for a process ID. This
                   can be helpful for nested environments, for example when using "kind".
                 type: string
+              labelPodDenials:
+                description: tells the operator whether or not to apply labels to
+                  pods that present security policy-related denials. Note that this
+                  will be done cluster-wide. Note that this currently requires the
+                  log enricher to be enabled.
+                type: boolean
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator
@@ -1434,6 +1440,8 @@ rules:
   verbs:
   - get
   - list
+  - patch
+  - update
   - watch
 - apiGroups:
   - security-profiles-operator.x-k8s.io

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,8 @@ require (
 	github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921
 	github.com/stretchr/testify v1.7.1
 	github.com/urfave/cli/v2 v2.4.0
+	golang.org/x/net v0.0.0-20220225172249-27dd8689420f
+	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	google.golang.org/grpc v1.45.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.2.0
 	google.golang.org/protobuf v1.28.0
@@ -94,9 +96,7 @@ require (
 	github.com/xanzy/ssh-agent v0.3.1 // indirect
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3 // indirect
 	golang.org/x/mod v0.6.0-dev.0.20220106191415-9b9b3d81d5e3 // indirect
-	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect
-	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c // indirect
 	golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86 // indirect
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect

--- a/hack/ci/e2e-fedora.sh
+++ b/hack/ci/e2e-fedora.sh
@@ -18,6 +18,7 @@ set -euo pipefail
 export E2E_CLUSTER_TYPE=vanilla
 export E2E_TEST_SELINUX=true
 export E2E_TEST_LOG_ENRICHER=true
+export E2E_TEST_LABEL_POD_DENIALS=true
 export E2E_TEST_BPF_RECORDER=true
 export E2E_TEST_PROFILE_RECORDING=true
 

--- a/internal/pkg/daemon/enricher/enricher_test.go
+++ b/internal/pkg/daemon/enricher/enricher_test.go
@@ -330,8 +330,8 @@ func TestRun(t *testing.T) {
 		mock := &enricherfakes.FakeImpl{}
 		tc.prepare(mock, lineChan)
 
-		sut := New(logr.Discard())
-		sut.impl = mock
+		sut, ebuildErr := New(logr.Discard(), false, mock)
+		require.NoError(t, ebuildErr)
 
 		var err error
 		if tc.runAsync {

--- a/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
+++ b/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
@@ -161,6 +161,19 @@ type FakeImpl struct {
 		result1 *rest.Config
 		result2 error
 	}
+	LabelPodDenialsStub        func(context.Context, kubernetes.Interface, *v1.Pod) error
+	labelPodDenialsMutex       sync.RWMutex
+	labelPodDenialsArgsForCall []struct {
+		arg1 context.Context
+		arg2 kubernetes.Interface
+		arg3 *v1.Pod
+	}
+	labelPodDenialsReturns struct {
+		result1 error
+	}
+	labelPodDenialsReturnsOnCall map[int]struct {
+		result1 error
+	}
 	LinesStub        func(*tail.Tail) chan *tail.Line
 	linesMutex       sync.RWMutex
 	linesArgsForCall []struct {
@@ -172,11 +185,12 @@ type FakeImpl struct {
 	linesReturnsOnCall map[int]struct {
 		result1 chan *tail.Line
 	}
-	ListPodsStub        func(*kubernetes.Clientset, string) (*v1.PodList, error)
+	ListPodsStub        func(context.Context, kubernetes.Interface, string) (*v1.PodList, error)
 	listPodsMutex       sync.RWMutex
 	listPodsArgsForCall []struct {
-		arg1 *kubernetes.Clientset
-		arg2 string
+		arg1 context.Context
+		arg2 kubernetes.Interface
+		arg3 string
 	}
 	listPodsReturns struct {
 		result1 *v1.PodList
@@ -921,6 +935,69 @@ func (fake *FakeImpl) InClusterConfigReturnsOnCall(i int, result1 *rest.Config, 
 	}{result1, result2}
 }
 
+func (fake *FakeImpl) LabelPodDenials(arg1 context.Context, arg2 kubernetes.Interface, arg3 *v1.Pod) error {
+	fake.labelPodDenialsMutex.Lock()
+	ret, specificReturn := fake.labelPodDenialsReturnsOnCall[len(fake.labelPodDenialsArgsForCall)]
+	fake.labelPodDenialsArgsForCall = append(fake.labelPodDenialsArgsForCall, struct {
+		arg1 context.Context
+		arg2 kubernetes.Interface
+		arg3 *v1.Pod
+	}{arg1, arg2, arg3})
+	stub := fake.LabelPodDenialsStub
+	fakeReturns := fake.labelPodDenialsReturns
+	fake.recordInvocation("LabelPodDenials", []interface{}{arg1, arg2, arg3})
+	fake.labelPodDenialsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) LabelPodDenialsCallCount() int {
+	fake.labelPodDenialsMutex.RLock()
+	defer fake.labelPodDenialsMutex.RUnlock()
+	return len(fake.labelPodDenialsArgsForCall)
+}
+
+func (fake *FakeImpl) LabelPodDenialsCalls(stub func(context.Context, kubernetes.Interface, *v1.Pod) error) {
+	fake.labelPodDenialsMutex.Lock()
+	defer fake.labelPodDenialsMutex.Unlock()
+	fake.LabelPodDenialsStub = stub
+}
+
+func (fake *FakeImpl) LabelPodDenialsArgsForCall(i int) (context.Context, kubernetes.Interface, *v1.Pod) {
+	fake.labelPodDenialsMutex.RLock()
+	defer fake.labelPodDenialsMutex.RUnlock()
+	argsForCall := fake.labelPodDenialsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeImpl) LabelPodDenialsReturns(result1 error) {
+	fake.labelPodDenialsMutex.Lock()
+	defer fake.labelPodDenialsMutex.Unlock()
+	fake.LabelPodDenialsStub = nil
+	fake.labelPodDenialsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) LabelPodDenialsReturnsOnCall(i int, result1 error) {
+	fake.labelPodDenialsMutex.Lock()
+	defer fake.labelPodDenialsMutex.Unlock()
+	fake.LabelPodDenialsStub = nil
+	if fake.labelPodDenialsReturnsOnCall == nil {
+		fake.labelPodDenialsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.labelPodDenialsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeImpl) Lines(arg1 *tail.Tail) chan *tail.Line {
 	fake.linesMutex.Lock()
 	ret, specificReturn := fake.linesReturnsOnCall[len(fake.linesArgsForCall)]
@@ -982,19 +1059,20 @@ func (fake *FakeImpl) LinesReturnsOnCall(i int, result1 chan *tail.Line) {
 	}{result1}
 }
 
-func (fake *FakeImpl) ListPods(arg1 *kubernetes.Clientset, arg2 string) (*v1.PodList, error) {
+func (fake *FakeImpl) ListPods(arg1 context.Context, arg2 kubernetes.Interface, arg3 string) (*v1.PodList, error) {
 	fake.listPodsMutex.Lock()
 	ret, specificReturn := fake.listPodsReturnsOnCall[len(fake.listPodsArgsForCall)]
 	fake.listPodsArgsForCall = append(fake.listPodsArgsForCall, struct {
-		arg1 *kubernetes.Clientset
-		arg2 string
-	}{arg1, arg2})
+		arg1 context.Context
+		arg2 kubernetes.Interface
+		arg3 string
+	}{arg1, arg2, arg3})
 	stub := fake.ListPodsStub
 	fakeReturns := fake.listPodsReturns
-	fake.recordInvocation("ListPods", []interface{}{arg1, arg2})
+	fake.recordInvocation("ListPods", []interface{}{arg1, arg2, arg3})
 	fake.listPodsMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2)
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -1008,17 +1086,17 @@ func (fake *FakeImpl) ListPodsCallCount() int {
 	return len(fake.listPodsArgsForCall)
 }
 
-func (fake *FakeImpl) ListPodsCalls(stub func(*kubernetes.Clientset, string) (*v1.PodList, error)) {
+func (fake *FakeImpl) ListPodsCalls(stub func(context.Context, kubernetes.Interface, string) (*v1.PodList, error)) {
 	fake.listPodsMutex.Lock()
 	defer fake.listPodsMutex.Unlock()
 	fake.ListPodsStub = stub
 }
 
-func (fake *FakeImpl) ListPodsArgsForCall(i int) (*kubernetes.Clientset, string) {
+func (fake *FakeImpl) ListPodsArgsForCall(i int) (context.Context, kubernetes.Interface, string) {
 	fake.listPodsMutex.RLock()
 	defer fake.listPodsMutex.RUnlock()
 	argsForCall := fake.listPodsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeImpl) ListPodsReturns(result1 *v1.PodList, result2 error) {
@@ -1636,6 +1714,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.getenvMutex.RUnlock()
 	fake.inClusterConfigMutex.RLock()
 	defer fake.inClusterConfigMutex.RUnlock()
+	fake.labelPodDenialsMutex.RLock()
+	defer fake.labelPodDenialsMutex.RUnlock()
 	fake.linesMutex.RLock()
 	defer fake.linesMutex.RUnlock()
 	fake.listPodsMutex.RLock()

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -494,6 +494,10 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 		ctr := r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDLogEnricher]
 		ctr.Image = image
 
+		if cfg.Spec.LabelPodDenials {
+			ctr.Args = []string{"log-enricher", "--label-denials"}
+		}
+
 		if useCustomHostProc {
 			ctr.VolumeMounts = append(ctr.VolumeMounts, mount)
 		}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -40,11 +40,12 @@ const (
 	// NOTE(jaosorior): We should be able to decrease this once we
 	// migrate to a single daemonset-based implementation for the
 	// SELinux pieces.
-	defaultSelinuxOpTimeout     = "360s"
-	defaultLogEnricherOpTimeout = defaultSelinuxOpTimeout
-	defaultBpfRecorderOpTimeout = defaultSelinuxOpTimeout
-	defaultWaitTimeout          = "180s"
-	defaultWaitTime             = 15 * time.Second
+	defaultSelinuxOpTimeout       = "360s"
+	defaultLogEnricherOpTimeout   = defaultSelinuxOpTimeout
+	defaultBpfRecorderOpTimeout   = defaultSelinuxOpTimeout
+	defaultLabelPodDenialsTimeout = defaultSelinuxOpTimeout
+	defaultWaitTimeout            = "180s"
+	defaultWaitTime               = 15 * time.Second
 )
 
 func (e *e2e) TestSecurityProfilesOperator() {
@@ -95,8 +96,8 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			e.testCaseLogEnricher,
 		},
 		{
-			"SELinux: sanity check",
-			e.testCaseSelinuxSanityCheck,
+			"SELinux: label problematic pod",
+			e.testCaseSelinuxLabelPodDenials,
 		},
 		{
 			"SELinux: base case (install policy, run pod and delete)",

--- a/test/tc_selinux_label_problematic_test.go
+++ b/test/tc_selinux_label_problematic_test.go
@@ -16,8 +16,10 @@ limitations under the License.
 
 package e2e_test
 
-func (e *e2e) testCaseSelinuxSanityCheck([]string) {
+func (e *e2e) testCaseSelinuxLabelPodDenials([]string) {
 	e.selinuxOnlyTestCase()
+	e.logEnricherOnlyTestCase()
+	e.labelPodDenialsOnlyTestCase()
 
 	const podWithoutPolicy = `
 apiVersion: v1
@@ -54,6 +56,18 @@ spec:
 	expectedLog := "/bin/bash: /var/log/test.log: Permission denied"
 	log := e.kubectl("logs", "el-no-policy", "-c", "errorlogger")
 	e.Equalf(expectedLog, log, "container should have returned a 'Permissions Denied' error")
+
+	e.logf("Should be marked as a problematic pod")
+
+	// Naive check label is in the pod's metadata
+	podlabels := e.kubectl("get", "pods", "el-no-policy", "-o", "jsonpath={.metadata.labels}")
+	e.NotEmpty(podlabels, "pod should have labels")
+	e.Contains(podlabels, "spo.x-k8s.io/had-denials", "pod should be marked as problematic")
+
+	// Prove that filtering through label works
+	problematicPodList := e.kubectl("get", "pods", "-l", "spo.x-k8s.io/had-denials=",
+		"-o", "jsonpath={.items[*].metadata.name}")
+	e.NotEmpty(problematicPodList, "problematic pod list should not be empty")
 
 	e.kubectl("delete", "pod", "el-no-policy")
 }

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,66 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"sync"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -424,6 +424,7 @@ golang.org/x/oauth2
 golang.org/x/oauth2/internal
 # golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 ## explicit
+golang.org/x/sync/errgroup
 golang.org/x/sync/singleflight
 # golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86
 ## explicit; go 1.17


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind design
/kind api-change

#### What this PR does / why we need it:

It's often useful to know what pods are having issues with policies (be
it SELinux or Seccomp). To enable administrators to easily fetch pods
with denials registered to them, this adds the ability for the log
enricher to detect this and label a pod appropriately with the following
label:

```
spo.x-k8s.io/had-denials: ''
```

By relying on a label, we're able to easily fetch the pods with a call
such as follows:

```
kubectl get pods -A -l spo.x-k8s.io/had-denials=
```

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
This PR includes the ability to tag pods that present denials from either Seccomp or SELinux. This will happen through the 'spo.x-k8s.io/had-denials' label.
```
