### PR TITLE
Bump Kubernetes to v1.23.5 and CRI-O to v1.23.2

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -56,7 +56,7 @@ dependencies:
       match: QEMUVERSION
 
   - name: e2e-kubernetes
-    version: 1.23.4
+    version: 1.23.5
     refPaths:
     - path: hack/ci/install-kubernetes.sh
       match: VERSION
@@ -120,7 +120,7 @@ dependencies:
       match: VERSION
 
   - name: CRI-O
-    version: v1.23.1
+    version: v1.23.2
     refPaths:
     - path: hack/ci/install-cri-o.sh
       match: TAG

--- a/hack/ci/Vagrantfile-ubuntu
+++ b/hack/ci/Vagrantfile-ubuntu
@@ -30,7 +30,7 @@ Vagrant.configure("2") do |config|
       curl -sSfL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
       echo "deb http://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
       apt-get update
-      KUBERNETES_VERSION=1.23.4-00
+      KUBERNETES_VERSION=1.23.5-00
       apt-get install -y \
         build-essential \
         kubelet=$KUBERNETES_VERSION \

--- a/hack/ci/install-cri-o.sh
+++ b/hack/ci/install-cri-o.sh
@@ -15,8 +15,8 @@
 
 set -euo pipefail
 
-COMMIT_ID=c4c89c6e426bf574c345465f7fab81b56fcfb1a8
-TAG=v1.23.1
+COMMIT_ID=9222794e513040ccb6adeea0703e7a57424606db
+TAG=v1.23.2
 
 curl "https://raw.githubusercontent.com/cri-o/cri-o/$COMMIT_ID/scripts/get" | bash -s -- -t "$TAG"
 

--- a/hack/ci/install-kubernetes.sh
+++ b/hack/ci/install-kubernetes.sh
@@ -19,7 +19,7 @@ ENVFILE=$(dirname "${BASH_SOURCE[0]}")/env-fedora.sh
 . "$ENVFILE"
 
 K8SPATH="$GOPATH/src/k8s.io"
-VERSION=v1.23.4
+VERSION=v1.23.5
 
 download-kubernetes() {
     export KUBERNETES_RELEASE=$VERSION


### PR DESCRIPTION
#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Bump both dependencies to their latest release.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
