### PR TITLE
fix: add an environment variable for disabling the selinux option from security context of SPOd deployment

### DIFF
--- a/deploy/overlays/flatcar/deployment.yaml
+++ b/deploy/overlays/flatcar/deployment.yaml
@@ -1,0 +1,13 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: security-profiles-operator
+  namespace: security-profiles-operator
+spec:
+  template:
+    spec:
+      containers:
+        - name: security-profiles-operator
+          env:
+            - name: SPOD_SELINUX_DISABLE
+              value: "true"

--- a/deploy/overlays/flatcar/kustomization.yaml
+++ b/deploy/overlays/flatcar/kustomization.yaml
@@ -1,0 +1,12 @@
+# This is a deployment, which does not configure the SElLinux option
+# in the security context of SPOd's containers. This is useful for Linux
+# distributions which don't enforce SELinux by default, and to not provide
+# the "spc_t" SELinux type.
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+bases:
+  - ../cluster
+
+patchesStrategicMerge:
+  - deployment.yaml

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -81,6 +81,10 @@ const (
 	// DefaultProfilingPort is the start port where the profiling endpoint runs.
 	DefaultProfilingPort = 6060
 
+	// SPOdSelinuxDisableEnvKey is the environment variable key for disabling
+	// the SELinux option form security context of SPODd deployment.
+	SPOdSelinuxDisableEnvKey = "SPOD_SELINUX_DISABLE"
+
 	// SeccompProfileRecordHookAnnotationKey is the annotation on a Pod that
 	// triggers the oci-seccomp-bpf-hook to trace the syscalls of a Pod and
 	// created a seccomp profile.


### PR DESCRIPTION
Signed-off-by: Cosmin Cojocar <gcojocar@adobe.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This adds an environment variable for disabling the the selinux option form security context of SPOd deployment. This is required for Linux distributions which doesn't enforce SELinux by default and do not provide the `spc_t` type label (e.g. Flatcar Linux). 

See other solutions proposed in:

https://github.com/kubernetes-sigs/security-profiles-operator/pull/828
https://github.com/kubernetes-sigs/security-profiles-operator/pull/826

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add SPOD_SELINUX_DISABLE environment variable for disabling the the SELinux option from security context of SPOd deployment

```
