### PR TITLE
feat: make the selinux type configurable in the SPOD CRD

### DIFF
--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -43,6 +43,9 @@ type SPODSpec struct {
 	// tells the operator whether or not to enable SELinux support for this
 	// SPOD instance.
 	EnableSelinux *bool `json:"enableSelinux,omitempty"`
+	// If specified, the SELinux type tag applied to the security context of SPOD.
+	// +optional
+	SelinuxTypeTag string `json:"selinuxTypeTag,omitempty"`
 	// tells the operator whether or not to enable log enrichment support for this
 	// SPOD instance.
 	EnableLogEnricher bool `json:"enableLogEnricher,omitempty"`

--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -45,6 +45,7 @@ type SPODSpec struct {
 	EnableSelinux *bool `json:"enableSelinux,omitempty"`
 	// If specified, the SELinux type tag applied to the security context of SPOD.
 	// +optional
+	// +kubebuilder:default="spc_t"
 	SelinuxTypeTag string `json:"selinuxTypeTag,omitempty"`
 	// tells the operator whether or not to enable log enrichment support for this
 	// SPOD instance.

--- a/deploy/base/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base/crds/securityprofilesoperatordaemon.yaml
@@ -82,6 +82,10 @@ spec:
                       type: string
                     type: array
                 type: object
+              selinuxTypeTag:
+                description: If specified, the SELinux type tag applied to the security
+                  context of SPOD.
+                type: string
               tolerations:
                 description: If specified, the SPOD's tolerations.
                 items:

--- a/deploy/base/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base/crds/securityprofilesoperatordaemon.yaml
@@ -83,6 +83,7 @@ spec:
                     type: array
                 type: object
               selinuxTypeTag:
+                default: spc_t
                 description: If specified, the SELinux type tag applied to the security
                   context of SPOD.
                 type: string

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -622,6 +622,7 @@ spec:
                     type: array
                 type: object
               selinuxTypeTag:
+                default: spc_t
                 description: If specified, the SELinux type tag applied to the security
                   context of SPOD.
                 type: string

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -621,6 +621,10 @@ spec:
                       type: string
                     type: array
                 type: object
+              selinuxTypeTag:
+                description: If specified, the SELinux type tag applied to the security
+                  context of SPOD.
+                type: string
               tolerations:
                 description: If specified, the SPOD's tolerations.
                 items:

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -622,6 +622,7 @@ spec:
                     type: array
                 type: object
               selinuxTypeTag:
+                default: spc_t
                 description: If specified, the SELinux type tag applied to the security
                   context of SPOD.
                 type: string

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -621,6 +621,10 @@ spec:
                       type: string
                     type: array
                 type: object
+              selinuxTypeTag:
+                description: If specified, the SELinux type tag applied to the security
+                  context of SPOD.
+                type: string
               tolerations:
                 description: If specified, the SPOD's tolerations.
                 items:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -622,6 +622,7 @@ spec:
                     type: array
                 type: object
               selinuxTypeTag:
+                default: spc_t
                 description: If specified, the SELinux type tag applied to the security
                   context of SPOD.
                 type: string

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -621,6 +621,10 @@ spec:
                       type: string
                     type: array
                 type: object
+              selinuxTypeTag:
+                description: If specified, the SELinux type tag applied to the security
+                  context of SPOD.
+                type: string
               tolerations:
                 description: If specified, the SPOD's tolerations.
                 items:

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -1,11 +1,11 @@
 # Installation and Usage
 
 <!-- toc -->
-
 - [Features](#features)
 - [Tutorials and Demos](#tutorials-and-demos)
 - [Install operator](#install-operator)
 - [Set logging verbosity](#set-logging-verbosity)
+- [Configure the SELinux type](#configure-the-selinux-type)
 - [Create Profile](#create-profile)
   - [Apply profile to pod](#apply-profile-to-pod)
   - [Base syscalls for a container runtime](#base-syscalls-for-a-container-runtime)

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -80,6 +80,33 @@ The daemon should now indicate that it's using the new logging verbosity:
 I1111 15:13:16.942837       1 main.go:182]  "msg"="Set logging verbosity to 1"
 ```
 
+## Configure the SELinux type
+
+The operator uses by default the `spc_t` SELinux type in the security context of the daemon pod. This can be easily 
+changed to a different SELinux type by patching the spod config as follows:
+
+```
+> kubectl -n security-profiles-operator patch spod spod --type=merge -p '{"spec":{"selinuxTypeTag":"unconfined_t"}}'
+securityprofilesoperatordaemon.security-profiles-operator.x-k8s.io/spod patched
+```
+
+The `ds/spod` should now be updated by the manager with the new SELinux type, and all daemon pods recreated:
+
+```
+ kubectl get ds spod -o yaml | grep unconfined_t -B2
+          runAsUser: 65535
+          seLinuxOptions:
+            type: unconfined_t
+--
+          runAsUser: 0
+          seLinuxOptions:
+            type: unconfined_t
+--
+          runAsUser: 0
+          seLinuxOptions:
+            type: unconfined_t
+```
+
 ## Create Profile
 
 Use the `SeccompProfile` kind to create profiles. Example:

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -550,6 +550,11 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 
 		// Set the logging verbosity
 		templateSpec.InitContainers[i].Env = append(templateSpec.InitContainers[i].Env, verbosityEnv(cfg.Spec.Verbosity))
+
+		// Update the SELinux type tag when is defined in the configuration
+		if cfg.Spec.SelinuxTypeTag != "" {
+			templateSpec.InitContainers[i].SecurityContext.SELinuxOptions.Type = cfg.Spec.SelinuxTypeTag
+		}
 	}
 
 	for i := range templateSpec.Containers {
@@ -566,6 +571,10 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 		// Enable profiling if requested
 		if cfg.Spec.EnableProfiling {
 			enableContainerProfiling(templateSpec, i)
+		}
+		// Update the SELinux type tag when is defined in the configuration
+		if cfg.Spec.SelinuxTypeTag != "" {
+			templateSpec.Containers[i].SecurityContext.SELinuxOptions.Type = cfg.Spec.SelinuxTypeTag
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Cosmin Cojocar <gcojocar@adobe.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

This extends the SPOD CRD with a field which allow to configure the SELinux type tag used in the security context of SPOd deployment. This is helpful to change the default `spc_t` SELinux type to either a more restrictive type or to `unconfined_t` when SELinux is not enforced. For instance `unconfined_t` can be used with the Flatcar Linux distribution. 

See other solutions proposed in:
https://github.com/kubernetes-sigs/security-profiles-operator/pull/850
https://github.com/kubernetes-sigs/security-profiles-operator/pull/828
https://github.com/kubernetes-sigs/security-profiles-operator/pull/826

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

Add a new field selinuxTypeTag in the SPOD CRD which allows to configure the SELinux type in the SPOd deployment

```
