### PR TITLE
Use go 1.18 buildinfo for version output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,6 @@ else
     BUILD_DATE ?= $(shell date -u "$(DATE_FMT)")
 endif
 
-GIT_COMMIT := $(shell git rev-parse HEAD 2> /dev/null || echo unknown)
-GIT_TREE_STATE := $(if $(shell git status --porcelain --untracked-files=no),dirty,clean)
 VERSION := $(shell cat VERSION)
 
 ifneq ($(shell uname -s), Darwin)
@@ -89,8 +87,6 @@ export GOFLAGS?=-mod=vendor
 GO_PROJECT := sigs.k8s.io/$(PROJECT)
 LDVARS := \
 	-X $(GO_PROJECT)/internal/pkg/version.buildDate=$(BUILD_DATE) \
-	-X $(GO_PROJECT)/internal/pkg/version.gitCommit=$(GIT_COMMIT) \
-	-X $(GO_PROJECT)/internal/pkg/version.gitTreeState=$(GIT_TREE_STATE) \
 	-X $(GO_PROJECT)/internal/pkg/version.version=$(VERSION)
 LINKMODE_EXTERNAL ?= yes
 ifeq ($(LINKMODE_EXTERNAL), yes)

--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -107,12 +107,14 @@ func main() {
 			},
 		},
 		&cli.Command{
+			Before:  initialize,
 			Name:    "manager",
 			Aliases: []string{"m"},
 			Usage:   "run the manager",
 			Action:  runManager,
 		},
 		&cli.Command{
+			Before:  initialize,
 			Name:    "daemon",
 			Aliases: []string{"d"},
 			Usage:   "run the daemon",
@@ -131,6 +133,7 @@ func main() {
 			},
 		},
 		&cli.Command{
+			Before:  initialize,
 			Name:    "webhook",
 			Aliases: []string{"w"},
 			Usage:   "run the webhook",
@@ -145,17 +148,20 @@ func main() {
 			},
 		},
 		&cli.Command{
+			Before: initialize,
 			Name:   "non-root-enabler",
 			Usage:  "run the non root enabler",
 			Action: runNonRootEnabler,
 		},
 		&cli.Command{
+			Before:  initialize,
 			Name:    "log-enricher",
 			Aliases: []string{"l"},
 			Usage:   "run the audit's log enricher",
 			Action:  runLogEnricher,
 		},
 		&cli.Command{
+			Before:  initialize,
 			Name:    "bpf-recorder",
 			Aliases: []string{"b"},
 			Usage:   "run the bpf recorder",
@@ -183,7 +189,6 @@ func main() {
 			EnvVars: []string{config.ProfilingPortEnvKey},
 		},
 	}
-	app.Before = initialize
 
 	if err := app.Run(os.Args); err != nil {
 		setupLog.Error(err, "running security-profiles-operator")

--- a/internal/pkg/version/version.go
+++ b/internal/pkg/version/version.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime"
+	"runtime/debug"
 	"strings"
 	"text/tabwriter"
 
@@ -27,35 +28,85 @@ import (
 )
 
 var (
-	buildDate    string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
-	gitCommit    string // sha1 from git, output of $(git rev-parse HEAD)
-	gitTreeState string // state of git tree, either "clean" or "dirty"
-	version      string // the current version of the operator
+	buildDate string // build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ')
+	version   string // the current version of the operator
 )
 
 type Info struct {
-	Version      string `json:"version,omitempty"`
-	GitCommit    string `json:"gitCommit,omitempty"`
-	GitTreeState string `json:"gitTreeState,omitempty"`
-	BuildDate    string `json:"buildDate,omitempty"`
-	GoVersion    string `json:"goVersion,omitempty"`
-	Compiler     string `json:"compiler,omitempty"`
-	Platform     string `json:"platform,omitempty"`
-	Libseccomp   string `json:"libseccomp,omitempty"`
-	Libbpf       string `json:"libbpf,omitempty"`
+	Version       string   `json:"version,omitempty"`
+	GitCommit     string   `json:"gitCommit,omitempty"`
+	GitCommitDate string   `json:"gitCommitDate,omitempty"`
+	GitTreeState  string   `json:"gitTreeState,omitempty"`
+	BuildDate     string   `json:"buildDate,omitempty"`
+	GoVersion     string   `json:"goVersion,omitempty"`
+	Compiler      string   `json:"compiler,omitempty"`
+	Platform      string   `json:"platform,omitempty"`
+	Libseccomp    string   `json:"libseccomp,omitempty"`
+	Libbpf        string   `json:"libbpf,omitempty"`
+	BuildTags     string   `json:"buildTags,omitempty"`
+	LDFlags       string   `json:"ldFlags,omitempty"`
+	CGOLDFlags    string   `json:"cgoLdflags,omitempty"`
+	Dependencies  []string `json:"dependencies,omitempty"`
 }
 
 func Get() *Info {
+	info, _ := debug.ReadBuildInfo()
+
+	const unknown = "unknown"
+	gitCommit := unknown
+	gitTreeState := "clean"
+	gitCommitDate := unknown
+	buildTags := unknown
+	ldFlags := unknown
+	cgoLdflags := unknown
+
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			gitCommit = s.Value
+
+		case "vcs.modified":
+			if s.Value == "true" {
+				gitTreeState = "dirty"
+			}
+
+		case "vcs.time":
+			gitCommitDate = s.Value
+
+		case "-tags":
+			buildTags = s.Value
+
+		case "-ldflags":
+			ldFlags = s.Value
+
+		case "CGO_LDFLAGS":
+			cgoLdflags = s.Value
+		}
+	}
+
+	dependencies := []string{}
+	for _, d := range info.Deps {
+		dependencies = append(
+			dependencies,
+			fmt.Sprintf("%s %s %s", d.Path, d.Version, d.Sum),
+		)
+	}
+
 	return &Info{
-		Version:      version,
-		GitCommit:    gitCommit,
-		GitTreeState: gitTreeState,
-		BuildDate:    buildDate,
-		GoVersion:    runtime.Version(),
-		Compiler:     runtime.Compiler,
-		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
-		Libseccomp:   libseccompVersion(),
-		Libbpf:       libbpfVersion(),
+		Version:       version,
+		GitCommit:     gitCommit,
+		GitCommitDate: gitCommitDate,
+		GitTreeState:  gitTreeState,
+		BuildDate:     buildDate,
+		GoVersion:     info.GoVersion,
+		Compiler:      runtime.Compiler,
+		Platform:      fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+		Libseccomp:    libseccompVersion(),
+		Libbpf:        libbpfVersion(),
+		BuildTags:     buildTags,
+		LDFlags:       ldFlags,
+		CGOLDFlags:    cgoLdflags,
+		Dependencies:  dependencies,
 	}
 }
 
@@ -67,6 +118,7 @@ func (i *Info) String() string {
 
 	fmt.Fprintf(w, "Version:\t%s\n", i.Version)
 	fmt.Fprintf(w, "GitCommit:\t%s\n", i.GitCommit)
+	fmt.Fprintf(w, "GitCommitDate:\t%s\n", i.GitCommitDate)
 	fmt.Fprintf(w, "GitTreeState:\t%s\n", i.GitTreeState)
 	fmt.Fprintf(w, "BuildDate:\t%s\n", i.BuildDate)
 	fmt.Fprintf(w, "GoVersion:\t%s\n", i.GoVersion)
@@ -74,6 +126,10 @@ func (i *Info) String() string {
 	fmt.Fprintf(w, "Platform:\t%s\n", i.Platform)
 	fmt.Fprintf(w, "Libseccomp:\t%s\n", i.Libseccomp)
 	fmt.Fprintf(w, "Libbpf:\t%s\n", i.Libbpf)
+	fmt.Fprintf(w, "BuildTags:\t%s\n", i.BuildTags)
+	fmt.Fprintf(w, "LDFlags:\t%s\n", i.LDFlags)
+	fmt.Fprintf(w, "CGOLDFlags:\t%s\n", i.CGOLDFlags)
+	fmt.Fprintf(w, "Dependencies:\n  %s\n", strings.Join(i.Dependencies, "\n  "))
 
 	w.Flush()
 	return b.String()
@@ -93,6 +149,7 @@ func (i *Info) AsKeyValues() []interface{} {
 	return []interface{}{
 		"version", i.Version,
 		"gitCommit", i.GitCommit,
+		"gitCommitDate", i.GitCommitDate,
 		"gitTreeState", i.GitTreeState,
 		"buildDate", i.BuildDate,
 		"goVersion", i.GoVersion,
@@ -100,5 +157,9 @@ func (i *Info) AsKeyValues() []interface{} {
 		"platform", i.Platform,
 		"libseccomp", i.Libseccomp,
 		"libbpf", i.Libbpf,
+		"buildTags", i.BuildTags,
+		"ldFlags", i.LDFlags,
+		"cgoldFlags", i.CGOLDFlags,
+		"dependencies", strings.Join(i.Dependencies, ","),
 	}
 }

--- a/internal/pkg/version/version_test.go
+++ b/internal/pkg/version/version_test.go
@@ -47,5 +47,5 @@ func TestVersionJSON(t *testing.T) {
 func TestAsKeyValues(t *testing.T) {
 	t.Parallel()
 	sut := Get().AsKeyValues()
-	require.Len(t, sut, 2*9)
+	require.Len(t, sut, 2*14)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:
This allows adding more information to the version output of the operator, for example listing all of its dependencies.

Example output:

```
> ./build/security-profiles-operator v
Version:        0.4.2-dev
GitCommit:      f91a93e0bff085c0296c6876beb1370fc252b94e
GitCommitDate:  2022-03-23T10:05:41Z
GitTreeState:   clean
BuildDate:      1980-01-01T00:00:00Z
GoVersion:      go1.18rc1
Compiler:       gc
Platform:       linux/amd64
Libseccomp:     2.5.3
Libbpf:         v0.7
BuildTags:      netgo,osusergo,seccomp,apparmor
LDFlags:        -s -w -linkmode external -extldflags "-static" -X sigs.k8s.io/security-profiles-operator/internal/pkg/version.buildDate=1980-01-01T00:00:00Z -X sigs.k8s.io/security-profiles-operator/internal/pkg/version.version=0.4.2-dev
CGOLDFlags:     -lseccomp -lelf -lz -lbpf
Dependencies:
  github.com/ReneKroon/ttlcache/v2 v2.11.0 h1:OvlcYFYi941SBN3v9dsDcC2N8vRxyHcCmJb3Vl4QMoM=
  github.com/acobaugh/osrelease v0.0.0-20181218015638-a93a0a55a249 h1:fMi9ZZ/it4orHj3xWrM6cLkVFcCbkXQALFUiNtHtCPs=
  github.com/aquasecurity/libbpfgo v0.2.5-libbpf-0.7.0 h1:BpW7qxkveYXx8TCtvYWIvmliPqaTCz/IYs1i+Gyj0MQ=
  github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
  github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
  github.com/cespare/xxhash/v2 v2.1.2 h1:YRXhKfTDauu4ajMg1TPgFO5jnlC2HCbmLXMcTG5cbYE=
  github.com/containers/common v0.47.4 h1:kS202Z/bTQIM/pwyuJ+lF8143Uli6AB9Q9OVR0xa9CM=
  github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
  github.com/crossplane/crossplane-runtime v0.14.1-0.20210713194031-85b19c28ea88 h1:JntebucOC129rP7Lsd1lbvn1GBTOhZkzPkJOSJ96pXI=
  github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
  github.com/evanphx/json-patch v4.12.0+incompatible h1:4onqiflcdA9EOZ4RxV643DvftH5pOlLGNtQ5lPWQu84=
  github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
  github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
  github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
  github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
  github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
  github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
  github.com/google/gofuzz v1.2.0 h1:xRy4A+RhZaiKjJ1bPfwQ8sedCA+YS2YcCHW6ec7JMi0=
  github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
  github.com/googleapis/gnostic v0.5.5 h1:9fHAtK0uDfpveeqqo1hkEZJcFvYXAiCN3UutL8F9xHw=
  github.com/imdario/mergo v0.3.12 h1:b6R2BslTbIEToALKP7LxUvijTsNI9TAe80pLWN2g/HU=
  github.com/jetstack/cert-manager v1.7.1 h1:qIIP0RN5FzBChJLJ3uGCGJmdAAonwDMdcsJExATa64I=
  github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
  github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
  github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
  github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9Gz0M=
  github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
  github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417 h1:3snG66yBm59tKhhSPQrQ/0bCrv1LQbKt40LnUPiUxdc=
  github.com/openshift/api v0.0.0-20220209124712-b632c5fc10c0 h1:Jy6cKRjMOC4c2EzTfYWofQnwtt3eGVsti88KM0qZhfQ=
  github.com/pjbgf/go-apparmor v0.0.7 h1:HEs8iA7tAMNEWz52LSJWzyltqU1BbVYFNkE/QRYAmLc=
  github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
  github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.55.0 h1:l4d6R3lZTiEZ644vTpcwk2d4OvL1xWpOe3auuD3lhgI=
  github.com/prometheus/client_golang v1.12.1 h1:ZiaPsmm9uiBeaSMRznKsCDNtPCS0T3JVDGF+06gjBzk=
  github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
  github.com/prometheus/common v0.32.1 h1:hWIdL3N2HoUx3B8j3YN9mWor0qhY/NlEKZEaXxuIRh4=
  github.com/prometheus/procfs v0.7.3 h1:4jVXhlkAyzOScmCkXBTOLRLTz8EeU+eyjrwB/EPq0VU=
  github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
  github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921 h1:58EBmR2dMNL2n/FnbQewK3D14nXr0V9CObDSvMJLq+Y=
  github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
  github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
  github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
  github.com/urfave/cli/v2 v2.4.0 h1:m2pxjjDFgDxSPtO8WSdbndj17Wu2y8vOT86wE/tjr+I=
  golang.org/x/net v0.0.0-20220225172249-27dd8689420f h1:oA4XRj0qtSt8Yo1Zms0CUlsT3KG69V2UGQWPBxujDmc=
  golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 h1:RerP+noqYHUQ8CMRcPlC2nvTa4dcBIjegkuWdcUDuqg=
  golang.org/x/sync v0.0.0-20210220032951-036812b2e83c h1:5KslGYwFpkhGh+Q16bwMP3cOontH8FOep7tGV86Y7SQ=
  golang.org/x/sys v0.0.0-20220315194320-039c03cc5b86 h1:A9i04dxx7Cribqbs8jf3FQLogkL/CV2YN7hj9KWJCkc=
  golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
  golang.org/x/text v0.3.7 h1:olpwvP2KacW1ZWvsR7uQhoyTYvKAupfQrRGBFM352Gk=
  golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac h1:7zkz7BUtwNFFqcowJ+RIgu2MaV/MapERkDIy+mwPyjs=
  gomodules.xyz/jsonpatch/v2 v2.2.0 h1:4pT439QV83L+G9FkcCriY6EkpcK6r6bK+A5FBUMI7qY=
  google.golang.org/genproto v0.0.0-20220118154757-00ab72f36ad5 h1:zzNejm+EgrbLfDZ6lu9Uud2IVvHySPl8vQzf04laR5Q=
  google.golang.org/grpc v1.45.0 h1:NEpgUqV3Z+ZjkqMsxMg11IaDrXY4RY6CQukSGK0uI1M=
  google.golang.org/protobuf v1.27.1 h1:SnqbnDw1V7RiZcXPx5MEeqPv2s79L9i7BJUlG/+RurQ=
  gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
  gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 h1:uRGJdciOHaEIrze2W8Q3AKkepLTh2hOroT7a+7czfdQ=
  gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
  gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b h1:h8qDotaEPuJATrMmW04NCwg7v22aHH28wwpauUhK9Oo=
  k8s.io/api v0.23.5 h1:zno3LUiMubxD/V1Zw3ijyKO3wxrhbUF1Ck+VjBvfaoA=
  k8s.io/apiextensions-apiserver v0.23.1 h1:xxE0q1vLOVZiWORu1KwNRQFsGWtImueOrqSl13sS5EU=
  k8s.io/apimachinery v0.23.5 h1:Va7dwhp8wgkUPWsEXk6XglXWU4IKYLKNlv8VkX7SDM0=
  k8s.io/client-go v0.23.5 h1:zUXHmEuqx0RY4+CsnkOn5l0GU+skkRXKGJrhmE2SLd8=
  k8s.io/component-base v0.23.1 h1:j/BqdZUWeWKCy2v/jcgnOJAzpRYWSbGcjGVYICko8Uc=
  k8s.io/klog/v2 v2.60.1
  k8s.io/kube-openapi v0.0.0-20211115234752-e816edb12b65 h1:E3J9oCLlaobFUqsjG9DfKbP2BmgwBL2p7pn0A3dG9W4=
  k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 h1:HNSDgDCrr/6Ly3WEGKZftiE7IY19Vz2GdbOCyI4qqhc=
  sigs.k8s.io/controller-runtime v0.11.1 h1:7YIHT2QnHJArj/dk9aUkYhfqfK5cIxPOX5gPECfdZLU=
  sigs.k8s.io/json v0.0.0-20211020170558-c049b76a60c6 h1:fD1pz4yfdADVNfFmcP2aBEtudwUQ1AlLnRBALr33v3s=
  sigs.k8s.io/release-utils v0.5.0 h1:TVJUoFLjfYYdJ11+mIw6eb44XIOC5BI3QQKiKYCtk/8=
  sigs.k8s.io/structured-merge-diff/v4 v4.2.1 h1:bKCqE9GvQ5tiVHn5rfn1r+yao3aLQEaLzkkmAkf+A6Y=
  sigs.k8s.io/yaml v1.3.0 h1:a2VclLzOGrwOHDiV8EfBGhvjHvP46CtW5j6POvhYGGo=
```
#### Which issue(s) this PR fixes:


None


#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added more verbose output to operator version information.
```
