### PR TITLE
Manually install `opm` on image build

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -38,9 +38,11 @@ dependencies:
       match: OPERATOR_SDK_VERSION
 
   - name: opm
-    version: v1.19.1
+    version: 1.19.1
     refPaths:
     - path: Makefile
+      match: OPM_VERSION
+    - path: hack/image-cross.sh
       match: OPM_VERSION
 
   - name: olm

--- a/hack/image-cross.sh
+++ b/hack/image-cross.sh
@@ -66,6 +66,20 @@ done
 # Build and push the catalog image
 export BUNDLE_IMG=$IMAGE-bundle:$VERSION
 export CATALOG_IMG=$IMAGE-catalog:$VERSION
+
+# Manually install OPM because of failing symbol relocation of the non-static
+# upstream binary build
+OPM_VERSION=1.19.1
+OPM_REPO=operator-registry
+OPM_DIR=$OPM_REPO-$OPM_VERSION
+apk add --no-cache gcc libc-dev
+curl -sSfL --retry 5 --retry-delay 3 \
+    "https://github.com/operator-framework/$OPM_REPO/archive/refs/tags/v$OPM_VERSION.tar.gz" -o- |
+    tar xfz -
+make -C $OPM_DIR bin/opm
+mkdir -p build
+cp $OPM_DIR/bin/opm build/opm
+
 make bundle-build \
     bundle-push \
     catalog-build \


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
The upstream opm binary is not built statically so the alpine based
build image has troubles because of the symbol relocation:

```
build/opm  index add --container-tool docker --mode semver --tag gcr.io/k8s-staging-sp-operator/security-profiles-operator-catalog:v0.4.2-dev --bundles gcr.io/k8s-staging-sp-operator/security-profiles-operator-bundle:v0.4.2-dev
Error relocating build/opm: __memcpy_chk: symbol not found
Error relocating build/opm: __memset_chk: symbol not found
Error relocating build/opm: fcntl64: symbol not found
```

To avoid that we now build it ahead of time.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
