### PR TITLE
Fix image-cross script

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,3 +22,7 @@ substitutions:
 images:
   - 'gcr.io/$PROJECT_ID/security-profiles-operator-amd64:$_GIT_TAG'
   - 'gcr.io/$PROJECT_ID/security-profiles-operator-amd64:latest'
+  - 'gcr.io/$PROJECT_ID/security-profiles-operator-catalog:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/security-profiles-operator-catalog:latest'
+  - 'gcr.io/$PROJECT_ID/security-profiles-operator-bundle:$_GIT_TAG'
+  - 'gcr.io/$PROJECT_ID/security-profiles-operator-bundle:latest'


### PR DESCRIPTION
#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
Fixing the image-cross build script to make the catalog and bundle push succeed.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Manual run:
```
> gcloud builds submit --verbosity info \
    --config cloudbuild.yaml \
    --substitutions _GIT_TAG=v20220331-v0.4.1-82-g91de7970 \
    --project k8s-staging-sp-operator \
    --gcs-log-dir gs://k8s-staging-sp-operator-gcb/logs \
    --gcs-source-staging-dir gs://k8s-staging-sp-operator-gcb/source
INFO: Using ignore file at [./.gcloudignore].
Creating temporary tarball archive of 10743 file(s) totalling 108.8 MiB before compression.
Uploading tarball of [.] to [gs://k8s-staging-sp-operator-gcb/source/1648797890.851485-4220f356700445c69c11a3bbe2f82749.tgz]
INFO: Uploading [/tmp/tmpmvzwq_st/file.tgz] to [k8s-staging-sp-operator-gcb/source/1648797890.851485-4220f356700445c69c11a3bbe2f82749.tgz]
Created [https://cloudbuild.googleapis.com/v1/projects/k8s-staging-sp-operator/locations/global/builds/b464fe12-e0ca-4c90-bf9d-14bc0657ef03].
Logs are available at [https://console.cloud.google.com/cloud-build/builds/b464fe12-e0ca-4c90-bf9d-14bc0657ef03?project=448637284062].
```
Results: https://console.cloud.google.com/cloud-build/builds/b464fe12-e0ca-4c90-bf9d-14bc0657ef03?project=448637284062
Images: https://console.cloud.google.com/gcr/images/k8s-staging-sp-operator/GLOBAL

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
