### PR TITLE
fix: make the webhook tolerations configurable

### DIFF
--- a/internal/pkg/manager/spod/bindata/webhook.go
+++ b/internal/pkg/manager/spod/bindata/webhook.go
@@ -123,9 +123,13 @@ func GetWebhook(
 	image string,
 	pullPolicy corev1.PullPolicy,
 	caInjectType CAInjectType,
+	tolerations []corev1.Toleration,
 ) *Webhook {
 	deployment := webhookDeployment.DeepCopy()
 	deployment.Namespace = namespace
+	if len(tolerations) > 0 {
+		deployment.Spec.Template.Spec.Tolerations = tolerations
+	}
 
 	ctr := &deployment.Spec.Template.Spec.Containers[0]
 	ctr.Image = image

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -157,7 +157,8 @@ func (r *ReconcileSPOd) Reconcile(_ context.Context, req reconcile.Request) (rec
 	}
 	configuredSPOd := r.getConfiguredSPOd(spod, image, pullPolicy, caInjectType)
 
-	webhook := bindata.GetWebhook(r.log, r.namespace, spod.Spec.WebhookOpts, image, pullPolicy, caInjectType)
+	webhook := bindata.GetWebhook(r.log, r.namespace, spod.Spec.WebhookOpts, image,
+		pullPolicy, caInjectType, spod.Spec.Tolerations)
 	metricsService := bindata.GetMetricsService(r.namespace, caInjectType)
 
 	var certManagerResources *bindata.CertManagerResources


### PR DESCRIPTION
Signed-off-by: Cosmin Cojocar <gcojocar@adobe.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

/kind feature

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

It makes the tolerations of the webhook configurable via the SPOD configuration. We have policies which prevents the scheduling of pods on master nodes. This change will allow us to change the default tolerations of the webhook which violates our security policy. 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

Makes the tolerations of the webhook configurable via the SPOD configuration

```
