### PR TITLE
nodestatus: Only list nodestatuses from the same namespace as the profile

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -170,6 +170,10 @@ func (e *e2e) TestSecurityProfilesOperator() {
 		e.testCaseBpfRecorderSelectContainer()
 	})
 
+	e.Run("cluster-wide: Same profile in multiple namespaces", func() {
+		e.testCaseSameProfileMultipleNs()
+	})
+
 	// Clean up cluster-wide deployment to prepare for namespace deployment
 	e.cleanupOperator(manifest)
 	e.run("git", "checkout", manifest)

--- a/test/tc_same_profile_multiple_ns_test.go
+++ b/test/tc_same_profile_multiple_ns_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"fmt"
+
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
+)
+
+const (
+	dupNsName          = "dup-profile-ns"
+	currentNsManifest  = "dup-policy-current.yml"
+	newNsManifest      = "dup-policy-new.yml"
+	dupProfileName     = "duplicate-profile"
+	dupProfileTemplate = `
+    apiVersion: security-profiles-operator.x-k8s.io/v1beta1
+    kind: SeccompProfile
+    metadata:
+      name: %s
+      namespace: %s
+    spec:
+      defaultAction: "SCMP_ACT_ALLOW"
+`
+)
+
+func (e *e2e) testCaseSameProfileMultipleNs() {
+	e.seccompOnlyTestCase()
+	e.logf("Create the same profile in two namespaces")
+
+	e.logf("creating policy in the current namespace")
+	manifest := fmt.Sprintf(dupProfileTemplate, dupProfileName, config.OperatorName)
+	deleteCurNsFn := e.writeAndCreate(manifest, currentNsManifest)
+	defer deleteCurNsFn()
+
+	e.logf("Waiting for profile in the operator NS to be reconciled")
+	e.waitInOperatorNSFor("condition=ready", "sp", dupProfileName)
+
+	e.logf("Create a new NS")
+	e.kubectl("create", "ns", dupNsName)
+	manifest = fmt.Sprintf(dupProfileTemplate, dupProfileName, dupNsName)
+	deleteNewNsFn := e.writeAndCreate(manifest, newNsManifest)
+	defer deleteNewNsFn()
+
+	e.logf("Waiting for profile in the new NS to be reconciled")
+	e.kubectl("-n", dupNsName, "wait", "--timeout", defaultWaitTimeout, "--for", "condition=ready", "sp", dupProfileName)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
In case there were two profiles with identical names in two namespaces,
the operator would list them all, from both namespaces and then fail
with:

nodestatus.go:179 nodestatus "msg"="Not updating policy: not all statuses are ready"
    "namespace"="default"
    "nodeStatus"="sleep-sh-pod-ip-10-0-164-225.us-east-2.compute.internal"
    "has"=18 "wants"=6

note that has > wants.

This patch adjusts the list so that only nodestatuses from the same
namespace are listed.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
Yes

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
