### PR TITLE
deploy: Make kube-rbac-proxy image configurable

### DIFF
--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -402,6 +402,8 @@ spec:
               - args:
                 - manager
                 env:
+                - name: RELATED_IMAGE_RBAC_PROXY
+                  value: quay.io/brancz/kube-rbac-proxy:v0.11.0
                 - name: RELATED_IMAGE_SELINUXD
                   value: quay.io/security-profiles-operator/selinuxd
                 - name: OPERATOR_NAMESPACE

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -10,22 +10,6 @@ images:
     # newName: k8s.gcr.io/security-profiles-operator/security-profiles-operator
     # newTag: v0.4.3
 
-patchesStrategicMerge:
-- |-
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: security-profiles-operator
-    namespace: security-profiles-operator
-  spec:
-    template:
-      spec:
-        containers:
-          - name: security-profiles-operator
-            env:
-              - name: RELATED_IMAGE_SELINUXD
-                value: quay.io/security-profiles-operator/selinuxd
-
 commonLabels:
   app: security-profiles-operator
 

--- a/deploy/base/manager_deployment.yaml
+++ b/deploy/base/manager_deployment.yaml
@@ -33,6 +33,8 @@ spec:
             limits:
               memory: 128Mi
           env:
+            - name: RELATED_IMAGE_RBAC_PROXY
+              value: quay.io/brancz/kube-rbac-proxy:v0.11.0
             - name: RELATED_IMAGE_SELINUXD
               value: quay.io/security-profiles-operator/selinuxd
             - name: OPERATOR_NAMESPACE

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1855,6 +1855,8 @@ spec:
         env:
         - name: RESTRICT_TO_NAMESPACE
           value: NS_REPLACE
+        - name: RELATED_IMAGE_RBAC_PROXY
+          value: quay.io/brancz/kube-rbac-proxy:v0.11.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -1853,6 +1853,8 @@ spec:
       - args:
         - manager
         env:
+        - name: RELATED_IMAGE_RBAC_PROXY
+          value: quay.io/brancz/kube-rbac-proxy:v0.11.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1853,6 +1853,8 @@ spec:
       - args:
         - manager
         env:
+        - name: RELATED_IMAGE_RBAC_PROXY
+          value: quay.io/brancz/kube-rbac-proxy:v0.11.0
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -62,6 +62,7 @@ const (
 	ContainerIDBpfRecorder                     = 3
 	ContainerIDMetrics                         = 4
 	DefaultHostProcPath                        = "/proc"
+	MetricsContainerName                       = "metrics"
 )
 
 var DefaultSPOD = &spodv1alpha1.SecurityProfilesOperatorDaemon{
@@ -525,7 +526,7 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 						},
 					},
 					{
-						Name:            "metrics",
+						Name:            MetricsContainerName,
 						Image:           MetricsImage,
 						ImagePullPolicy: corev1.PullIfNotPresent,
 						Args: []string{

--- a/internal/pkg/manager/spod/setup.go
+++ b/internal/pkg/manager/spod/setup.go
@@ -37,13 +37,15 @@ import (
 )
 
 const (
-	selinuxdImageKey string = "RELATED_IMAGE_SELINUXD"
+	selinuxdImageKey  string = "RELATED_IMAGE_SELINUXD"
+	rbacProxyImageKey string = "RELATED_IMAGE_RBAC_PROXY"
 )
 
 // daemonTunables defines the parameters to tune/modify for the
 // Security-Profiles-Operator-Daemon.
 type daemonTunables struct {
 	selinuxdImage    string
+	rbacProxyImage   string
 	logEnricherImage string
 	watchNamespace   string
 }
@@ -101,6 +103,12 @@ func getTunables() (*daemonTunables, error) {
 		return dt, errors.New("invalid selinuxd image")
 	}
 	dt.selinuxdImage = selinuxdImage
+
+	rbacProxyImage := os.Getenv(rbacProxyImageKey)
+	if rbacProxyImage == "" {
+		return dt, errors.New("invalid rbac proxy image")
+	}
+	dt.rbacProxyImage = rbacProxyImage
 	return dt, nil
 }
 
@@ -121,6 +129,9 @@ func getEffectiveSPOd(dt *daemonTunables) *appsv1.DaemonSet {
 
 	logEnricher := &refSPOd.Spec.Template.Spec.Containers[2]
 	logEnricher.Image = dt.logEnricherImage
+
+	metrixCtr := &refSPOd.Spec.Template.Spec.Containers[4]
+	metrixCtr.Image = dt.rbacProxyImage
 
 	sepolImage := &refSPOd.Spec.Template.Spec.InitContainers[1]
 	sepolImage.Image = dt.selinuxdImage // selinuxd ships the policies as well

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -561,7 +561,7 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 
 	for i := range templateSpec.Containers {
 		// The metrics image should be pulled always as IfNotPresent
-		if templateSpec.Containers[i].Image == bindata.MetricsImage {
+		if templateSpec.Containers[i].Name == bindata.MetricsContainerName {
 			continue
 		}
 		// Set image pull policy


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Downstreams (in particular OpenShift) might not allow an image from a
third-party container registry to be downloaded, but instead have their
own forks and mirrors.

To be able to point to an OpenShift-approved version of the rbac-proxy,
we need to make the RBAC-proy container image configurable with an
environment variable called `RELATED_IMAGE_RBAC_PROXY`


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
