### PR TITLE
e2e: Various stabilization fixes for our test suite

### DIFF
--- a/internal/pkg/daemon/enricher/container.go
+++ b/internal/pkg/daemon/enricher/container.go
@@ -121,7 +121,7 @@ func (e *Enricher) populateContainerPodCache(
 }
 
 func (e *Enricher) populateCacheEntryForContainer(
-	ctx context.Context, targetContainerID string, pod *v1.Pod, eg *errgroup.Group,
+	_ context.Context, targetContainerID string, pod *v1.Pod, eg *errgroup.Group,
 ) {
 	eg.Go(func() (errorToRetry error) {
 		// nolint:gocritic // This is what we expect and want
@@ -168,7 +168,7 @@ func (e *Enricher) populateCacheEntryForContainer(
 			if e.labelDenials && rawContainerID == targetContainerID {
 				e.logger.Info("labeling problematic container", "containerID", containerID,
 					"podNamespace", pod.Namespace, "podName", pod.Name)
-				e.labelPodDenials(ctx, info.containerName, pod.DeepCopy(), e.logger)
+				e.labelPodDenials(context.TODO(), info.containerName, pod.DeepCopy(), e.logger)
 			}
 
 			// Update the cache

--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -298,6 +298,11 @@ func (r *Reconciler) reconcileSeccompProfile(
 		r.record.Event(sp, event.Warning(reasonCannotSaveProfile, err))
 		return reconcile.Result{}, fmt.Errorf("cannot save profile into disk: %w", err)
 	}
+	if updated {
+		evstr := fmt.Sprintf("Successfully saved profile to disk on %s", os.Getenv(config.NodeNameEnvKey))
+		r.metrics.IncSeccompProfileUpdate()
+		r.record.Event(sp, event.Normal(reasonSavedProfile, evstr))
+	}
 
 	isAlreadyInstalled, getErr := nodeStatus.Matches(ctx, statusv1alpha1.ProfileStateInstalled)
 	if getErr != nil {
@@ -322,11 +327,6 @@ func (r *Reconciler) reconcileSeccompProfile(
 		"resource version", sp.GetResourceVersion(),
 		"name", sp.GetName(),
 	)
-	if updated {
-		evstr := fmt.Sprintf("Successfully saved profile to disk on %s", os.Getenv(config.NodeNameEnvKey))
-		r.metrics.IncSeccompProfileUpdate()
-		r.record.Event(sp, event.Normal(reasonSavedProfile, evstr))
-	}
 	return reconcile.Result{}, nil
 }
 

--- a/test/tc_selinux_base_usage_test.go
+++ b/test/tc_selinux_base_usage_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	maxNodeIterations      = 3
+	maxNodeIterations      = 6
 	sleepBetweenIterations = 5 * time.Second
 	errorloggerPolicy      = `
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha2


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind flake

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Since selinuxd switched to using policycoreutils, it is a bit slower.
Let's increase the number of iterations we wait for a policy to be
removed in hopes of getting a more stable CI environment.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
