### PR TITLE
e2e: Don't deploy cert-manager on OCP

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -203,7 +203,7 @@ func (e *e2e) TestSecurityProfilesOperator() {
 	e.run("git", "checkout", namespaceManifest)
 }
 
-func (e *e2e) deployCertManager() {
+func doDeployCertManager(e *e2e) {
 	e.logf("Deploying cert-manager")
 	e.kubectl("apply", "-f", certmanager)
 

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -88,6 +88,7 @@ type e2e struct {
 	logger                 logr.Logger
 	execNode               func(node string, args ...string) string
 	waitForReadyPods       func()
+	deployCertManager      func()
 }
 
 func defaultWaitForReadyPods(e *e2e) {
@@ -233,6 +234,7 @@ func (e *kinde2e) SetupSuite() {
 	// Override execNode and waitForReadyPods functions
 	e.e2e.execNode = e.execNodeKind
 	e.e2e.waitForReadyPods = e.waitForReadyPodsKind
+	e.e2e.deployCertManager = e.deployCertManagerKind
 	parentCwd := e.setWorkDir()
 	buildDir := filepath.Join(parentCwd, "build")
 	e.Nil(os.MkdirAll(buildDir, 0o755))
@@ -318,6 +320,10 @@ func (e *e2e) waitForReadyPodsKind() {
 	defaultWaitForReadyPods(e)
 }
 
+func (e *e2e) deployCertManagerKind() {
+	doDeployCertManager(e)
+}
+
 func (e *openShifte2e) SetupSuite() {
 	var err error
 	e.logf("Setting up suite")
@@ -325,6 +331,7 @@ func (e *openShifte2e) SetupSuite() {
 	// Override execNode and waitForReadyPods functions
 	e.e2e.execNode = e.execNodeOCP
 	e.e2e.waitForReadyPods = e.waitForReadyPodsOCP
+	e.e2e.deployCertManager = e.deployCertManagerOCP
 	e.setWorkDir()
 
 	e.kubectlPath, err = exec.LookPath("oc")
@@ -412,6 +419,10 @@ func (e *e2e) waitForReadyPodsOCP() {
 	// ensure the cluster is up before the test runs. At least for now.
 }
 
+func (e *e2e) deployCertManagerOCP() {
+	// intentionally blank, OCP creates certs on its own
+}
+
 func (e *vanilla) SetupSuite() {
 	var err error
 	e.logf("Setting up suite")
@@ -421,6 +432,7 @@ func (e *vanilla) SetupSuite() {
 	e.e2e.execNode = e.execNodeVanilla
 	e.kubectlPath, err = exec.LookPath("kubectl")
 	e.e2e.waitForReadyPods = e.waitForReadyPodsVanilla
+	e.e2e.deployCertManager = e.deployCertManagerVanilla
 	e.Nil(err)
 }
 
@@ -440,6 +452,10 @@ func (e *vanilla) execNodeVanilla(node string, args ...string) string {
 
 func (e *e2e) waitForReadyPodsVanilla() {
 	defaultWaitForReadyPods(e)
+}
+
+func (e *e2e) deployCertManagerVanilla() {
+	doDeployCertManager(e)
 }
 
 func (e *e2e) setWorkDir() string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
tl;dr I'm trying to run our e2e tests on openshift continuously (a fork of main)

We provision certificates on OCP with OCP-specific service annotations
instead of cert-manager. Deploying cert-manager on OCP is thus not
needed and because newer versions of OCP ship a cert-manager-operator
itself, it might even be harmful.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
