### PR TITLE
feat: make the allowed seccomp actions configurable in SPOD configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -92,6 +92,9 @@ jobs:
         run: |
           $RUN kubectl wait --for=condition=ready --timeout=60s node 127.0.0.1
           $RUN kubectl get nodes -o wide
+      - name: Set up git config
+        run: |
+          $RUN git config --global --add safe.directory /vagrant 
       - name: Run E2E tests
         run: $RUN hack/ci/e2e-fedora.sh
 
@@ -122,6 +125,9 @@ jobs:
         run: |
           $RUN kubectl wait --for=condition=ready --timeout=60s node ubuntu2110
           $RUN kubectl get nodes -o wide
+      - name: Set up git config
+        run: |
+          $RUN git config --global --add safe.directory /vagrant 
       - name: Run E2E tests
         run: $RUN hack/ci/e2e-ubuntu.sh
 

--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -17,6 +17,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/containers/common/pkg/seccomp"
 	rcommonv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -91,6 +92,9 @@ type SPODSpec struct {
 	// in seccomp profiles.
 	// +optional
 	AllowedSyscalls []string `json:"allowedSyscalls,omitempty"`
+	// AllowedSeccompActions if specified, a list of allowed seccomp actions.
+	// +optional
+	AllowedSeccompActions []seccomp.Action `json:"allowedSeccompActions"`
 }
 
 // SPODState defines the state that the spod is in.

--- a/api/spod/v1alpha1/zz_generated.deepcopy.go
+++ b/api/spod/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"github.com/containers/common/pkg/seccomp"
 	"k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,6 +55,11 @@ func (in *SPODSpec) DeepCopyInto(out *SPODSpec) {
 	if in.AllowedSyscalls != nil {
 		in, out := &in.AllowedSyscalls, &out.AllowedSyscalls
 		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
+	if in.AllowedSeccompActions != nil {
+		in, out := &in.AllowedSeccompActions, &out.AllowedSeccompActions
+		*out = make([]seccomp.Action, len(*in))
 		copy(*out, *in)
 	}
 }

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_securityprofilesoperatordaemons.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_securityprofilesoperatordaemons.yaml
@@ -43,6 +43,13 @@ spec:
           spec:
             description: SPODStatus defines the desired state of SPOD.
             properties:
+              allowedSeccompActions:
+                description: AllowedSeccompActions if specified, a list of allowed
+                  seccomp actions.
+                items:
+                  description: Action taken upon Seccomp rule match
+                  type: string
+                type: array
               allowedSyscalls:
                 description: AllowedSyscalls if specified, a list of system calls
                   which are allowed in seccomp profiles.

--- a/deploy/base/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base/crds/securityprofilesoperatordaemon.yaml
@@ -41,6 +41,13 @@ spec:
           spec:
             description: SPODStatus defines the desired state of SPOD.
             properties:
+              allowedSeccompActions:
+                description: AllowedSeccompActions if specified, a list of allowed
+                  seccomp actions.
+                items:
+                  description: Action taken upon Seccomp rule match
+                  type: string
+                type: array
               allowedSyscalls:
                 description: AllowedSyscalls if specified, a list of system calls
                   which are allowed in seccomp profiles.

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -583,6 +583,13 @@ spec:
           spec:
             description: SPODStatus defines the desired state of SPOD.
             properties:
+              allowedSeccompActions:
+                description: AllowedSeccompActions if specified, a list of allowed
+                  seccomp actions.
+                items:
+                  description: Action taken upon Seccomp rule match
+                  type: string
+                type: array
               allowedSyscalls:
                 description: AllowedSyscalls if specified, a list of system calls
                   which are allowed in seccomp profiles.

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -583,6 +583,13 @@ spec:
           spec:
             description: SPODStatus defines the desired state of SPOD.
             properties:
+              allowedSeccompActions:
+                description: AllowedSeccompActions if specified, a list of allowed
+                  seccomp actions.
+                items:
+                  description: Action taken upon Seccomp rule match
+                  type: string
+                type: array
               allowedSyscalls:
                 description: AllowedSyscalls if specified, a list of system calls
                   which are allowed in seccomp profiles.

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -583,6 +583,13 @@ spec:
           spec:
             description: SPODStatus defines the desired state of SPOD.
             properties:
+              allowedSeccompActions:
+                description: AllowedSeccompActions if specified, a list of allowed
+                  seccomp actions.
+                items:
+                  description: Action taken upon Seccomp rule match
+                  type: string
+                type: array
               allowedSyscalls:
                 description: AllowedSyscalls if specified, a list of system calls
                   which are allowed in seccomp profiles.

--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -549,7 +549,7 @@ func allowProfile(profile *OutputProfile, allowedSyscalls []string, allowedActio
 		allowedActions = allAllowedActions
 	}
 	for _, allowedAction := range allowedActions {
-		if !util.Contains(allAllowedActions, allowedAction) {
+		if !containsAction(allAllowedActions, allowedAction) {
 			return fmt.Errorf("%s: %s", errForbiddenAction, allowedAction)
 		}
 	}
@@ -566,4 +566,13 @@ func allowProfile(profile *OutputProfile, allowedSyscalls []string, allowedActio
 		}
 	}
 	return nil
+}
+
+func containsAction(actions []seccomp.Action, action seccomp.Action) bool {
+	for _, act := range actions {
+		if act == action {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/pkg/util/names.go
+++ b/internal/pkg/util/names.go
@@ -34,7 +34,7 @@ func NamespacedName(name, namespace string) types.NamespacedName {
 }
 
 // Contains returns true if the slice a contains string b.
-func Contains(a []string, b string) bool {
+func Contains[T comparable](a []T, b T) bool {
 	for _, s := range a {
 		if s == b {
 			return true

--- a/internal/pkg/util/names.go
+++ b/internal/pkg/util/names.go
@@ -34,7 +34,7 @@ func NamespacedName(name, namespace string) types.NamespacedName {
 }
 
 // Contains returns true if the slice a contains string b.
-func Contains[T comparable](a []T, b T) bool {
+func Contains(a []string, b string) bool {
 	for _, s := range a {
 		if s == b {
 			return true


### PR DESCRIPTION
Make the allowed seccomp actions configurable in SPOD configuration

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Make allowed seccomp actions configurable in the SPOD configuration.

```
