### PR TITLE
Remove configmap RBAC from manager

### DIFF
--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -233,15 +233,9 @@ spec:
         - apiGroups:
           - ""
           resources:
-          - configmaps
           - events
           verbs:
           - create
-          - get
-          - list
-          - patch
-          - update
-          - watch
         - apiGroups:
           - ""
           resources:

--- a/deploy/base/role.yaml
+++ b/deploy/base/role.yaml
@@ -80,15 +80,9 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
   - events
   verbs:
   - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1230,15 +1230,9 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
   - events
   verbs:
   - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -1230,15 +1230,9 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
   - events
   verbs:
   - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - ""
   resources:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1230,15 +1230,9 @@ rules:
 - apiGroups:
   - ""
   resources:
-  - configmaps
   - events
   verbs:
   - create
-  - get
-  - list
-  - patch
-  - update
-  - watch
 - apiGroups:
   - ""
   resources:

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -86,8 +86,8 @@ func (r *ReconcileSPOd) Healthz(*http.Request) error {
 // Security Profiles Operator RBAC permissions to manage its own configuration
 // nolint:lll // required for kubebuilder
 //
-// Used for leader election:
-// +kubebuilder:rbac:groups=core,resources=configmaps;events,verbs=get;list;watch;create;update;patch
+// Used for event generation:
+// +kubebuilder:rbac:groups=core,resources=events,verbs=create
 //
 // Operand:
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Those rules do not seem to be required any more.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Remove unnecessary configmap RBAC rules.
```
