### PR TITLE
deploy: Annotate the NS to allow running privileged

### DIFF
--- a/deploy/base/ns.yaml
+++ b/deploy/base/ns.yaml
@@ -3,3 +3,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: security-profiles-operator 
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1121,6 +1121,9 @@ kind: Namespace
 metadata:
   labels:
     app: security-profiles-operator
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: security-profiles-operator
 ---
 apiVersion: v1

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -1121,6 +1121,9 @@ kind: Namespace
 metadata:
   labels:
     app: security-profiles-operator
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: security-profiles-operator
 ---
 apiVersion: v1

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1121,6 +1121,9 @@ kind: Namespace
 metadata:
   labels:
     app: security-profiles-operator
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/warn: privileged
   name: security-profiles-operator
 ---
 apiVersion: v1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
On some distributions, like OCP 4.11, where PSA is enabled and the
restricted PSA is the default, pods must either run with a very limited
privileges or the namespace must be annotated to allow privileged pods.

Because SPO can't run with such limited privileges (for example selinuxd
or the non-root-enabler must run as root), we need to take the second
option and annotate the namespace.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
Should I also amend the docs?

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The security-profiles-operator namespace is now labeled with the following labels:
    pod-security.kubernetes.io/enforce: privileged
    pod-security.kubernetes.io/audit: privileged
    pod-security.kubernetes.io/warn: privileged
To account for clusters that are enabling PSA and defaulting to the restricted one.

When using another namespace or creating the namespace with other means,
please ensure that the namespace has the above labels.
```
