### PR TITLE
tests: Explicitly set the context to the SPO namespace before creating the recording SA/role/rolebinding on OCP

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -427,6 +427,11 @@ func (e *e2e) deployCertManagerOCP() {
 }
 
 func (e *e2e) deployRecordingSaOcp() {
+	// this is a kludge to help run the tests on OCP CI where there's a ephemeral namespace that goes away
+	// as the test is starting. Without explicitly setting the namespace, the OCP CI tests fail with:
+	// error when creating "test/recording_sa.yaml": namespaces "ci-op-hq1cv14k" not found
+	e.kubectl("config", "set-context", "--current", "--namespace", "security-profiles-operator")
+
 	e.deployRecordingSa()
 
 	e.kubectl("create", "-f", "test/recording_role.yaml")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind failing-test

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This is a workaround for how the OCP's ci-operator work. There's a
namespace created when the tests start which is then removed, but
apparently the context is still set there. Creating resources then fails
with:
    error when creating "test/recording_sa.yaml": namespaces
    "ci-op-hq1cv14k" not found


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
