### PR TITLE
chore: Use operator-sdk v1.22.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GO ?= go
 GOLANGCI_LINT_VERSION = v1.46.2
 REPO_INFRA_VERSION = v0.2.5
 KUSTOMIZE_VERSION = 4.5.5
-OPERATOR_SDK_VERSION ?= v1.17.0
+OPERATOR_SDK_VERSION ?= v1.22.2
 OPM_VERSION ?= v1.19.1
 
 CONTROLLER_GEN_CMD := CGO_LDFLAGS= $(GO) run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -32,7 +32,7 @@ dependencies:
       match: KUSTOMIZE_VERSION
 
   - name: operator-sdk
-    version: v1.17.0
+    version: v1.22.2
     refPaths:
     - path: Makefile
       match: OPERATOR_SDK_VERSION


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

We were using v1.17.0 which was released in February.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
