### PR TITLE
Update Ubuntu Vagrant image to 22.04

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -96,7 +96,7 @@ dependencies:
       match: fedora
 
   - name: e2e-ubuntu
-    version: ubuntu2110
+    version: ubuntu2204
     refPaths:
     - path: hack/ci/Vagrantfile-ubuntu
       match: config.vm.box

--- a/hack/ci/Vagrantfile-ubuntu
+++ b/hack/ci/Vagrantfile-ubuntu
@@ -2,7 +2,7 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "generic/ubuntu2110"
+  config.vm.box = "generic/ubuntu2204"
   memory = 6144
   cpus = 4
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

22.04 is the new LTS and is what we should be using instead. 21.10
(which we were using) is already EOL.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

The Ubuntu e2e tests

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
