### PR TITLE
Fix Flatcar Linux e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,7 +131,7 @@ jobs:
 
   e2e-flatcar:
    needs: image
-#
+
    runs-on: macos-12
    timeout-minutes: 90
    env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -129,39 +129,39 @@ jobs:
       - name: Run E2E tests
         run: $RUN hack/ci/e2e-ubuntu.sh
 
-  #e2e-flatcar:
-  #  needs: image
-
-  #  runs-on: macos-12
-  #  timeout-minutes: 90
-  #  env:
-  #    RUN: ./hack/ci/run-flatcar.sh
-  #  steps:
-  #    - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
-  #    - name: Vagrant box version
-  #      id: vagrant-box
-  #      run: |
-  #        echo "::set-output name=version::$(curl -s  https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vagrant.json | jq '.versions[0].version' | tr -d '".')"
-  #      shell: bash
-  #    - uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129
-  #      with:
-  #        path: |
-  #          ~/.vagrant.d/boxes
-  #        key: e2e-flatcar-${{ steps.vagrant-box.outputs.version }}-${{ hashFiles('hack/ci/Vagrantfile-flatcar') }}
-  #        restore-keys: e2e-flatcar-${{ steps.vagrant-box.outputs.version }}-
-  #    - name: Upgrade vagrant box
-  #      run: |
-  #        ln -sf hack/ci/Vagrantfile-flatcar Vagrantfile
-  #        vagrant box update
-  #    - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
-  #      with:
-  #        name: image
-  #        path: .
-  #    - name: Boot Virtual Machine
-  #      run: make vagrant-up-flatcar
-  #    - name: Show environment information
-  #      run: |
-  #        $RUN kubectl wait --for=condition=ready --timeout=600s node localhost
-  #        $RUN kubectl get nodes -o wide
-  #    - name: Run E2E tests
-  #      run: $RUN hack/ci/e2e-flatcar-dev-container.sh
+  e2e-flatcar:
+   needs: image
+#
+   runs-on: macos-12
+   timeout-minutes: 90
+   env:
+     RUN: ./hack/ci/run-flatcar.sh
+   steps:
+     - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b
+     - name: Vagrant box version
+       id: vagrant-box
+       run: |
+         echo "::set-output name=version::$(curl -s  https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vagrant.json | jq '.versions[0].version' | tr -d '".')"
+       shell: bash
+     - uses: actions/cache@0865c47f36e68161719c5b124609996bb5c40129
+       with:
+         path: |
+           ~/.vagrant.d/boxes
+         key: e2e-flatcar-${{ steps.vagrant-box.outputs.version }}-${{ hashFiles('hack/ci/Vagrantfile-flatcar') }}
+         restore-keys: e2e-flatcar-${{ steps.vagrant-box.outputs.version }}-
+     - name: Upgrade vagrant box
+       run: |
+         ln -sf hack/ci/Vagrantfile-flatcar Vagrantfile
+         vagrant box update
+     - uses: actions/download-artifact@fb598a63ae348fa914e94cd0ff38f362e927b741
+       with:
+         name: image
+         path: .
+     - name: Boot Virtual Machine
+       run: make vagrant-up-flatcar
+     - name: Show environment information
+       run: |
+         $RUN kubectl wait --for=condition=ready --timeout=600s node localhost
+         $RUN kubectl get nodes -o wide
+     - name: Run E2E tests
+       run: $RUN hack/ci/e2e-flatcar-dev-container.sh

--- a/hack/ci/Vagrantfile-flatcar
+++ b/hack/ci/Vagrantfile-flatcar
@@ -2,9 +2,9 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "flatcar-stable"
+  config.vm.box = "flatcar-lts"
   config.vm.box_check_update = true
-  config.vm.box_url = "https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vagrant.json"
+  config.vm.box_url = "https://lts.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vagrant.json"
   memory = 8192
   cpus = 4 
 
@@ -90,7 +90,7 @@ Vagrant.configure("2") do |config|
       # Install tools
       curl -sSL -o $DOWNLOAD_DIR/jq "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64"
       chmod +x $DOWNLOAD_DIR/jq
-      curl -sSL -o $DOWNLOAD_DIR/flatcar_developer_container.bin.bz2 "https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_developer_container.bin.bz2"
+      curl -sSL -o $DOWNLOAD_DIR/flatcar_developer_container.bin.bz2 "https://lts.release.flatcar-linux.net/amd64-usr/current/flatcar_developer_container.bin.bz2"
       bzcat $DOWNLOAD_DIR/flatcar_developer_container.bin.bz2 > $DOWNLOAD_DIR/flatcar_developer_container.bin
 
       curl -sSL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz


### PR DESCRIPTION
- test: use LTS image instea of stable for Flatcar e2e
- test: enable the Flatcar Linux e2e

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

/kind bug

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

#### What this PR does / why we need it:

It switches the Flatcar Linux vagrant box to LTS image. It seems that the sable image is somehow broken and doesn't boot.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes # 1049

or

None
-->

Fixes #1049

#### Does this PR have test?

yes

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE

```
