### PR TITLE
Run metrics e2e tests in single-node environments only

### DIFF
--- a/examples/pod.yaml
+++ b/examples/pod.yaml
@@ -17,4 +17,4 @@ spec:
       # seccompProfile:
         # type: Localhost
         # localhostProfile: operator/security-profiles-operator/nginx-1.19.1.json
-    image: nginx:1.19.1
+    image: docker.io/nginx:1.19.1

--- a/hack/ci/e2e-ubuntu.sh
+++ b/hack/ci/e2e-ubuntu.sh
@@ -17,6 +17,5 @@ set -euo pipefail
 
 export E2E_CLUSTER_TYPE=vanilla
 export E2E_TEST_LOG_ENRICHER=true
-export E2E_TEST_SECCOMP=false
 
 make test-e2e

--- a/hack/ci/env-ubuntu.sh
+++ b/hack/ci/env-ubuntu.sh
@@ -12,9 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+local_ip() {
+    ip route get 1.2.3.4 | cut -d ' ' -f7 | tr -d '[:space:]'
+}
+
 export PATH="/usr/local/go/bin:$PATH"
 export GOPATH="$HOME/go"
 export GOBIN="$GOPATH/bin"
+
+export KUBE_CONTAINER_RUNTIME=remote
+export KUBECONFIG=/etc/kubernetes/admin.conf
+export PATH="$GOPATH/src/k8s.io/kubernetes/_output/bin:$PATH"
+
+IP=$(local_ip)
+export KUBE_MASTER_URL=$IP
+export KUBE_MASTER_IP=$IP
+export KUBE_MASTER=$IP
 
 # Added for faster debugging with lower verbosity
 alias k=kubectl

--- a/hack/ci/run-ubuntu.sh
+++ b/hack/ci/run-ubuntu.sh
@@ -15,4 +15,4 @@
 
 set -euo pipefail
 
-exec vagrant ssh -- "bash -c 'cd /vagrant && . hack/ci/env-ubuntu.sh && $*'"
+exec vagrant ssh -- sudo "bash -c 'cd /vagrant && . hack/ci/env-ubuntu.sh && $*'"

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -95,6 +95,7 @@ type e2e struct {
 	bpfRecorderEnabled     bool
 	skipNamespacedTests    bool
 	testWebhookConfig      bool
+	singleNodeEnvironment  bool
 	logger                 logr.Logger
 	execNode               func(node string, args ...string) string
 	waitForReadyPods       func()
@@ -254,6 +255,9 @@ func TestSuite(t *testing.T) {
 				skipNamespacedTests:    skipNamespacedTests,
 				operatorManifest:       operatorManifest,
 				testWebhookConfig:      testWebhookConfig,
+				// NOTE(jaosorior): Our current vanilla jobs are
+				// single-node only.
+				singleNodeEnvironment: true,
 			},
 		})
 	default:
@@ -689,6 +693,12 @@ func (e *e2e) bpfRecorderOnlyTestCase() {
 	}
 
 	e.enableBpfRecorderInSpod()
+}
+
+func (e *e2e) singleNodeTestCase() {
+	if !e.singleNodeEnvironment {
+		e.T().Skip("Skipping test because we're in a multi-node environment.")
+	}
 }
 
 func (e *e2e) enableBpfRecorderInSpod() {

--- a/test/tc_metrics_test.go
+++ b/test/tc_metrics_test.go
@@ -27,6 +27,7 @@ const profileName = "metrics-profile"
 
 func (e *e2e) testCaseSeccompMetrics(nodes []string) {
 	e.seccompOnlyTestCase()
+	e.singleNodeTestCase()
 
 	const (
 		operationDelete = `security_profiles_operator_seccomp_profile_total{operation="delete"}`
@@ -72,6 +73,7 @@ spec:
 
 func (e *e2e) testCaseSelinuxMetrics(nodes []string) {
 	e.selinuxOnlyTestCase()
+	e.singleNodeTestCase()
 
 	const (
 		operationDelete = `security_profiles_operator_selinux_profile_total{operation="delete"}`


### PR DESCRIPTION
#### What type of PR is this?

/kind flake

#### What this PR does / why we need it:

This is meant to remove some of the flakiness in our tests. We make the
assumption that our vanilla tests are running in single-node mode only,
so we take advantage of that fact and set a boolean that indicates that
it's a single-node test environment.

Note that this also does changes necessary for the ubuntu setup to
run the Seccomp tests.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Yes, the metrics e2e tests

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
