### PR TITLE
helm: Package and save chart in a GitHub release.

### DIFF
--- a/.github/workflows/helm-chart-package.yaml
+++ b/.github/workflows/helm-chart-package.yaml
@@ -1,0 +1,53 @@
+name: helm-chart-package
+on:
+  pull_request:
+  release:
+    types: [published]
+permissions:
+  actions: none
+  checks: none
+  contents: write
+  deployments: none
+  id-token: none
+  issues: none
+  discussions: none
+  packages: none
+  pull-requests: none
+  repository-projects: none
+  security-events: none
+  statuses: none
+jobs:
+  helm-package:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.1
+      - run: mkdir -p build
+      - id: package
+        run: |
+          helm_output="$(helm package -d build deploy/helm)"
+          tgz_path="${helm_output##*saved it to: }"
+          echo "helm chart tgz path: '${tgz_path}'"
+          [ ! -f "${tgz_path}" ] && echo "failed to find helm chart from 'helm package' stdout" && exit 1
+          echo "::set-output name=helm_tgz_path::${tgz_path}"
+          echo "::set-output name=helm_tgz_name::${tgz_path##*/}"
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ steps.package.outputs.helm_tgz_name}}
+          path: ${{ steps.package.outputs.helm_tgz_path}}
+          if-no-files-found: error
+      - uses: actions/upload-release-asset@v1
+        if: github.event_name == 'release'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ${{ steps.package.outputs.helm_tgz_path}}
+          asset_name: ${{ steps.package.outputs.helm_tgz_name}}
+          asset_content_type: 'application/x-tar'


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This adds a GitHub Actions workflow that runs "helm package"
on the helm chart and saves it as a workflow artifact. If the
workflow was triggered by a GitHub release being published,
it automatically adds the package to the release that triggered
the workflow.

Note: The package is only attached to a release when it is
published. A draft release will not trigger the workflow.
Refer to the GitHub documentation for more information:
https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release

The reason for running "helm package" on both pull requests
and release-publishings is to ensure a change introduced in
a PR does not break the workflow automation (it would be very
unfortunate to discover that the workflow broke when we create
a GitHub release).

#### Which issue(s) this PR fixes:
None

#### Does this PR have test?
The workflow tests that "helm package" creates a file and that
the file exists. The GitHub "upload-artifact" action is configured
to fail if it cannot find a file to upload (sadly, like GitLab, this is not
the default behavior).

#### Special notes for your reviewer:
I spoke with @saschagrunert and @JAORMX about the automation
working this way (that is: packaging the chart and attaching it to
an existing release).

#### Does this PR introduce a user-facing change?

```release-note
NONE
```