### PR TITLE
Run metrics e2e tests in single-node environments only (cherry-pick)

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -95,6 +95,7 @@ type e2e struct {
 	bpfRecorderEnabled     bool
 	skipNamespacedTests    bool
 	testWebhookConfig      bool
+	singleNodeEnvironment  bool
 	logger                 logr.Logger
 	execNode               func(node string, args ...string) string
 	waitForReadyPods       func()
@@ -254,6 +255,9 @@ func TestSuite(t *testing.T) {
 				skipNamespacedTests:    skipNamespacedTests,
 				operatorManifest:       operatorManifest,
 				testWebhookConfig:      testWebhookConfig,
+				// NOTE(jaosorior): Our current vanilla jobs are
+				// single-node only.
+				singleNodeEnvironment: true,
 			},
 		})
 	default:
@@ -689,6 +693,12 @@ func (e *e2e) bpfRecorderOnlyTestCase() {
 	}
 
 	e.enableBpfRecorderInSpod()
+}
+
+func (e *e2e) singleNodeTestCase() {
+	if !e.singleNodeEnvironment {
+		e.T().Skip("Skipping test because we're in a multi-node environment.")
+	}
 }
 
 func (e *e2e) enableBpfRecorderInSpod() {

--- a/test/tc_log_enricher_test.go
+++ b/test/tc_log_enricher_test.go
@@ -106,14 +106,19 @@ spec:
 	e.Contains(output, `"syscallName"="listen"`)
 	e.Contains(output, `"syscallID"=50`)
 
-	metrics := e.getSpodMetrics()
-	e.Regexp(fmt.Sprintf(`(?m)security_profiles_operator_seccomp_profile_audit_total{`+
-		`container="%s",`+
-		`executable="/usr/sbin/nginx",`+
-		`namespace="%s",`+
-		`node=".*",`+
-		`pod="%s",`+
-		`syscall="listen"} \d+`,
-		containerName, namespace, podName,
-	), metrics)
+	if e.singleNodeEnvironment {
+		// we only run the metrics checks in a single node environment because otherwise it's a lottery
+		// which spod instance do we hit and the test is not stable
+
+		metrics := e.getSpodMetrics()
+		e.Regexp(fmt.Sprintf(`(?m)security_profiles_operator_seccomp_profile_audit_total{`+
+			`container="%s",`+
+			`executable="/usr/sbin/nginx",`+
+			`namespace="%s",`+
+			`node=".*",`+
+			`pod="%s",`+
+			`syscall="listen"} \d+`,
+			containerName, namespace, podName,
+		), metrics)
+	}
 }

--- a/test/tc_metrics_test.go
+++ b/test/tc_metrics_test.go
@@ -27,6 +27,7 @@ const profileName = "metrics-profile"
 
 func (e *e2e) testCaseSeccompMetrics(nodes []string) {
 	e.seccompOnlyTestCase()
+	e.singleNodeTestCase()
 
 	const (
 		operationDelete = `security_profiles_operator_seccomp_profile_total{operation="delete"}`
@@ -72,6 +73,7 @@ spec:
 
 func (e *e2e) testCaseSelinuxMetrics(nodes []string) {
 	e.selinuxOnlyTestCase()
+	e.singleNodeTestCase()
 
 	const (
 		operationDelete = `security_profiles_operator_selinux_profile_total{operation="delete"}`


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:
This PR cherry-picks one patch from PR #1059 and adds one more patch in
a similar manner, also running a metrics check in a single-node environment
only.

The second patch prevents frequent flakes in an OCP six-node environment.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
