### PR TITLE
e2e: Add a breakpoint func

### DIFF
--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -516,6 +516,36 @@ func (e *e2e) setWorkDir() string {
 	return parentCwd
 }
 
+// Use the breakPoint function at a point where you want to pause a test.
+// The test will log a tempfile created bythe breakPoint() function and
+// wait for the file to be removed by the test user.
+//
+// (jhrozek): Maybe we should set a global timeout to continue?
+func (e *e2e) breakPoint() { // nolint:unused // used on demand
+	tmpfile, err := os.CreateTemp("", "testBreakpoint*.lock")
+	if err != nil {
+		e.logger.Error(err, "Can't create breakpoint file")
+		return
+	}
+	tmpfile.Close()
+
+	delChannel := make(chan struct{})
+	go func() {
+		for {
+			_, err := os.Stat(tmpfile.Name())
+			if err == nil {
+				e.logger.Info("breakpoint: File exists, waiting 5 secs", "fileName", tmpfile.Name())
+				time.Sleep(time.Second * 5)
+				continue
+			}
+			break
+		}
+		delChannel <- struct{}{}
+	}()
+
+	<-delChannel
+}
+
 func (e *e2e) run(cmd string, args ...string) string {
 	output, err := command.New(cmd, args...).RunSuccessOutput()
 	e.Nil(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Adds a utility function breakPoint(), which is currently unused but can
be used by a developer to pause a test at a certain location. Useful to
checking logs in case of flakes etc..

Signed-off-by: Jakub Hrozek <jhrozek@redhat.com>


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A but I used the patch in my development

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
