### PR TITLE
nodestatus: Only log low-level messages if verbosity is increased

### DIFF
--- a/internal/pkg/manager/nodestatus/nodestatus.go
+++ b/internal/pkg/manager/nodestatus/nodestatus.go
@@ -114,7 +114,7 @@ func (r *StatusReconciler) Reconcile(_ context.Context, req reconcile.Request) (
 	defer cancel()
 
 	logger := r.log.WithValues("nodeStatus", req.Name, "namespace", req.Namespace)
-	logger.Info("Reconciling node status")
+	logger.V(config.VerboseLevel).Info("Reconciling node status")
 
 	// get the status to be reconciled
 	instance := &statusv1alpha1.SecurityProfileNodeStatus{}
@@ -186,7 +186,7 @@ func (r *StatusReconciler) Reconcile(_ context.Context, req reconcile.Request) (
 	for i := range nodeStatusList.Items {
 		lowestCommonState = statusv1alpha1.LowerOfTwoStates(lowestCommonState, nodeStatusList.Items[i].Status)
 	}
-	logger.Info("Setting the status to", "Status", lowestCommonState)
+	logger.V(config.VerboseLevel).Info("Setting the status to", "Status", lowestCommonState)
 
 	return r.reconcileStatus(ctx, prof, lowestCommonState, lprof)
 }
@@ -275,7 +275,7 @@ func (r *StatusReconciler) reconcileStatus(
 		outStatus.SetConditions(rcommonv1.Unavailable())
 	}
 
-	l.Info("Updating status")
+	l.V(config.VerboseLevel).Info("Updating status")
 	if updateErr := r.client.Status().Update(ctx, pCopy); updateErr != nil {
 		return reconcile.Result{}, fmt.Errorf("updating policy status: %w", updateErr)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Unless the nodestatus controller is being debugged, then these messages
are really not that important.

#### Which issue(s) this PR fixes:
Fixes #1066

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.


or

None
-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
