### PR TITLE
deploy: Set the NS for spod SA explicitly to allow privileged pods under OCP 4.12+

### DIFF
--- a/bundle/manifests/spod_rbac.authorization.k8s.io_v1_rolebinding.yaml
+++ b/bundle/manifests/spod_rbac.authorization.k8s.io_v1_rolebinding.yaml
@@ -12,3 +12,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: spod
+  namespace: security-profiles-operator

--- a/deploy/base/role_binding.yaml
+++ b/deploy/base/role_binding.yaml
@@ -52,6 +52,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: spod
+  namespace: security-profiles-operator
 roleRef:
   kind: Role
   name: spod

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -657,6 +657,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: spod
+  namespace: security-profiles-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1735,6 +1735,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: spod
+  namespace: security-profiles-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -1735,6 +1735,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: spod
+  namespace: security-profiles-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1735,6 +1735,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: spod
+  namespace: security-profiles-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -1720,6 +1720,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: spod
+  namespace: security-profiles-operator
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
OCP 4.12+ is trying to make PSA and SCCs coexist. In order to find out
whether the workload can avoid being restricted by the default
("restricted") PSA profile, there is a label synchronizer that takes a
look at the available RBAC permissions and if there is an SA that is
allowed to use a privilged SCC, then the namespace is allowed to be
labeled with `pod-security.kubernetes.io/enforce: privileged`.
More details can be found at:
    https://github.com/openshift/enhancements/blob/master/enhancements/authentication/pod-security-admission-autolabeling.md

It seems that this mechanism relies on having the namespace set
explicitly for RoleBinding's `.subjects[].namespace` to be set when
`.subjects[].kind` is ServiceAccount even though this is not required by
the RBAC system to successfully bind the SA to a Role

This might be a bug:
    https://issues.redhat.com/browse/OCPBUGS-160
however, setting the namespace explicitly does no harm and lets us run
the pods in a privileged manner on OCP 4.12+


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
