### PR TITLE
Fix tag usage and image loading in image builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,7 +96,7 @@ jobs:
       - name: Run container image vulnerability scanner
         uses: aquasecurity/trivy-action@d63413b0a4a4482237085319f7f4a1ce99a8f2ac
         with:
-          image-ref: ${{ steps.meta.outputs.tags[0] }}
+          image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: 'table'
           # TODO(jaosorior): Fix this once we bump the NixOS dependencies.
           exit-code: '0'
@@ -144,7 +144,7 @@ jobs:
       - name: Run container image vulnerability scanner
         uses: aquasecurity/trivy-action@d63413b0a4a4482237085319f7f4a1ce99a8f2ac
         with:
-          image-ref: ${{ steps.meta.outputs.tags[0] }}
+          image-ref: ${{ fromJSON(steps.meta.outputs.json).tags[0] }}
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,8 @@ jobs:
             quay.io/security-profiles-operator/security-profiles-operator
           tags: |
             type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
             type=sha,format=long
       - name: Build (and push if needed)
         uses: docker/build-push-action@c84f38281176d4c9cdb1626ffafcd6b3911b5d94
@@ -127,6 +129,8 @@ jobs:
             suffix=-ubi
           tags: |
             type=ref,event=branch
+            type=ref,event=pr
+            type=ref,event=tag
             type=sha,format=long
       # TODO(jaosorior): Push UBI image too
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,11 +89,12 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           push: ${{ github.ref == 'refs/heads/main' }}
-          load: true
+          # Only load on PR builds
+          load: ${{ github.ref != 'refs/heads/main' }}
       - name: Run container image vulnerability scanner
         uses: aquasecurity/trivy-action@d63413b0a4a4482237085319f7f4a1ce99a8f2ac
         with:
-          image-ref: ${{ steps.meta.outputs.tags }}
+          image-ref: ${{ steps.meta.outputs.tags[0] }}
           format: 'table'
           # TODO(jaosorior): Fix this once we bump the NixOS dependencies.
           exit-code: '0'
@@ -139,7 +140,7 @@ jobs:
       - name: Run container image vulnerability scanner
         uses: aquasecurity/trivy-action@d63413b0a4a4482237085319f7f4a1ce99a8f2ac
         with:
-          image-ref: ${{ steps.meta.outputs.tags }}
+          image-ref: ${{ steps.meta.outputs.tags[0] }}
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

We cannot both push and load at the same time, so logic was added to
make that work. We also now only do container scanning on the first tag
since we cannot use multiple tags as the output of the metadata-action
would normally provide.

#### Which issue(s) this PR fixes:

Fixes #1104

#### Does this PR have test?

The image build tests

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
