### PR TITLE
Fix flatcar e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -246,7 +246,7 @@ define vagrant-up
 	ln -sf hack/ci/Vagrantfile-$(1) Vagrantfile
 	# Retry in case provisioning failed because of some temporarily unavailable
 	# remote resource (like the VM image)
-	vagrant up || vagrant up || vagrant up
+	vagrant up
 endef
 
 .PHONY: vagrant-up-fedora

--- a/hack/ci/Vagrantfile-flatcar
+++ b/hack/ci/Vagrantfile-flatcar
@@ -122,7 +122,6 @@ Vagrant.configure("2") do |config|
       export KUBECONFIG=/etc/kubernetes/admin.conf
 
       # Configure cluster
-      kubectl taint nodes --all node-role.kubernetes.io/master-
       kubectl taint nodes --all node-role.kubernetes.io/control-plane-
 
       # Install CNI


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
The taint `node-role.kubernetes.io/master` does not seem to exist any
more so we have to remove it. Beside that, running `vagrant up` multiple
times will not help re-provision if the bootstrap already has begun.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
