### PR TITLE
workflows: Set the E2E_TEST_FLAKY_TESTS_ONLY=true variable inside the test VM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,9 +97,9 @@ jobs:
         run: $RUN hack/ci/e2e-fedora.sh
       - name: Run Flaky E2E tests
         continue-on-error: true
-        run: $RUN hack/ci/e2e-fedora.sh
-        env:
-          E2E_TEST_FLAKY_TESTS_ONLY: true
+        run: |
+          $RUN "echo \"export E2E_TEST_FLAKY_TESTS_ONLY=true\" >> /vagrant/hack/ci/env-fedora.sh"
+          $RUN hack/ci/e2e-fedora.sh
       - name: Print generated RBAC rules
         run: $RUN hack/ci/print-rbac.sh
 
@@ -135,9 +135,9 @@ jobs:
         run: $RUN hack/ci/e2e-ubuntu.sh
       - name: Run Flaky E2E tests
         continue-on-error: true
-        run: $RUN hack/ci/e2e-ubuntu.sh
-        env:
-          E2E_TEST_FLAKY_TESTS_ONLY: true
+        run: |
+          $RUN "echo \"export E2E_TEST_FLAKY_TESTS_ONLY=true\" >> /vagrant/hack/ci/env-ubuntu.sh"
+          $RUN hack/ci/e2e-ubuntu.sh
 
   e2e-flatcar:
    needs: image
@@ -177,6 +177,6 @@ jobs:
         run: $RUN hack/ci/e2e-flatcar-dev-container.sh
       - name: Run Flaky E2E tests
         continue-on-error: true
-        run: $RUN hack/ci/e2e-flatcar-dev-container.sh
-        env:
-          E2E_TEST_FLAKY_TESTS_ONLY: true
+        run: |
+          $RUN "echo \"export E2E_TEST_FLAKY_TESTS_ONLY=true\" >> /vagrant/hack/ci/env-flatcar.sh"
+          $RUN hack/ci/e2e-flatcar-dev-container.sh


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Turns out that the flaky e2e tests were not run at all because we were
setting the `E2E_TEST_FLAKY_TESTS_ONLY=true` variable for the $RUN command
that just runs "ssh sudo -c" which clears the environment.

Let's set the variable inside the test VM instead so that the flaky
tests run properly.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
Implicitly

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
