### PR TITLE
Enable OpenShift cluster monitoring for namespace

### DIFF
--- a/deploy/base/ns.yaml
+++ b/deploy/base/ns.yaml
@@ -2,8 +2,9 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: security-profiles-operator 
+  name: security-profiles-operator
   labels:
+    openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/warn: privileged

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   labels:
     app: security-profiles-operator
+    openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1081,6 +1081,7 @@ kind: Namespace
 metadata:
   labels:
     app: security-profiles-operator
+    openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -1081,6 +1081,7 @@ kind: Namespace
 metadata:
   labels:
     app: security-profiles-operator
+    openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1081,6 +1081,7 @@ kind: Namespace
 metadata:
   labels:
     app: security-profiles-operator
+    openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   labels:
     app: security-profiles-operator
+    openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/audit: privileged
     pod-security.kubernetes.io/enforce: privileged
     pod-security.kubernetes.io/warn: privileged

--- a/examples/olm/install-resources.yaml
+++ b/examples/olm/install-resources.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
     name: security-profiles-operator
+    openshift.io/cluster-monitoring: "true"
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource

--- a/examples/olm/operatorhub-io.yaml
+++ b/examples/olm/operatorhub-io.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
     name: security-profiles-operator
+    openshift.io/cluster-monitoring: "true"
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
We per default ship a service monitor which will get rejected by the
OpenShift user workload monitoring because we miss the label. We now add
the label per default to avoid this error.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Automatically add `openshift.io/cluster-monitoring=true` to the operator namespace to allow the service monitor to work as intended.
```
