### PR TITLE
tests: Run the flaky tests, too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -396,7 +396,7 @@ test-e2e: ## Run the end-to-end tests
 test-flaky-e2e: ## Only run the flaky end-to-end tests
 	CGO_LDFLAGS= \
 	E2E_SKIP_FLAKY_TESTS=false \
-	$(GO) test -parallel 1 -testify.m '^(TestSecurityProfilesOperator_Flaky)$$' -timeout 20m -count=1 ./test/... -v
+	$(GO) test -parallel 1 -timeout 20m -count=1 ./test/... -v -testify.m '^(TestSecurityProfilesOperator_Flaky)$$'
 
 # Generate CRD manifests
 manifests: $(BUILD_DIR)/kubernetes-split-yaml $(BUILD_DIR)/kustomize

--- a/test/e2e_flaky_test.go
+++ b/test/e2e_flaky_test.go
@@ -16,11 +16,17 @@ limitations under the License.
 
 package e2e_test
 
+import "sigs.k8s.io/security-profiles-operator/internal/pkg/config"
+
 func (e *e2e) TestSecurityProfilesOperator_Flaky() {
 	if e.skipFlakyTests {
 		e.T().Skip("Skipping flaky tests")
 		return
 	}
+
+	// If we ran the non-flaky tests before, we would have ran them with the
+	// context set to the test-ns namespace. Reset the context.
+	e.kubectl("config", "set-context", "--current", "--namespace", config.OperatorName)
 
 	e.waitForReadyPods()
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Turns out that my previous patch to run the flaky tests was incomplete.
We need some more changes:
    - the `testify.m` parameter must be, for some reason, specified last
      or else the `go test` call fails with "no Go files in XYZ".
    - after the namespaced tests (last in the regular non-flaky tests),
      we need to reset the namespace or else we test everything in the
      test-ns namespace
    - we need to tear down the operator after the namespaced tests to
      be able to roll it out again in the flaky tests

The tests are still flaky, but at least they run now.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

-->

#### Does this PR have test?
implicit

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
