### PR TITLE
recording: Emit event when attempting to record a privileged container + add docs

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -514,7 +514,7 @@ func runWebhook(ctx *cli.Context, info *version.Info) error {
 	setupLog.Info("registering webhooks")
 	hookserver := mgr.GetWebhookServer()
 	binding.RegisterWebhook(hookserver, mgr.GetClient())
-	recording.RegisterWebhook(hookserver, mgr.GetClient())
+	recording.RegisterWebhook(hookserver, mgr.GetEventRecorderFor("recording-webhook"), mgr.GetClient())
 
 	sigHandler := ctrl.SetupSignalHandler()
 	setupLog.Info("starting webhook")

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -453,6 +453,12 @@ test-recording-redis   Installed   15s
 Recording a SELinux profile would work the same, except you'd use `kind: SelinuxProfile`
 in the `ProfileRecording` object.
 
+Please note that log based recording does not have any effect if the recorded container
+is privileged, that is, the container's security context sets `privileged: true`. This
+is because privileged containers are not subject to SELinux or seccomp policies at all
+and the log based recording makes use of a special seccomp or SELinux profile respectively
+to record the syscalls or SELinux events.
+
 #### eBPF based recording
 
 The operator also supports an [eBPF](https://ebpf.io) based recorder. This

--- a/internal/pkg/webhooks/recording/recording_test.go
+++ b/internal/pkg/webhooks/recording/recording_test.go
@@ -36,6 +36,7 @@ import (
 
 	"sigs.k8s.io/security-profiles-operator/api/profilerecording/v1alpha1"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/webhooks/recording/recordingfakes"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/webhooks/utils"
 )
 
 var (
@@ -499,7 +500,7 @@ func TestHandle(t *testing.T) {
 		mock := &recordingfakes.FakeImpl{}
 		tc.prepare(mock)
 
-		recorder := podSeccompRecorder{impl: mock, log: logr.Discard()}
+		recorder := podSeccompRecorder{impl: mock, log: logr.Discard(), record: utils.NewSafeRecorder(nil)}
 		resp := recorder.Handle(context.Background(), tc.request)
 		tc.assert(resp)
 	}

--- a/internal/pkg/webhooks/utils/safe_events.go
+++ b/internal/pkg/webhooks/utils/safe_events.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+)
+
+type SafeRecorder struct {
+	recorder record.EventRecorder
+}
+
+func NewSafeRecorder(recorder record.EventRecorder) *SafeRecorder {
+	return &SafeRecorder{recorder: recorder}
+}
+
+func (sr *SafeRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	if sr.recorder == nil {
+		return
+	}
+
+	sr.recorder.Event(object, eventtype, reason, message)
+}
+
+// Eventf is just like Event, but with Sprintf for the message field.
+func (sr *SafeRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	if sr.recorder == nil {
+		return
+	}
+
+	sr.recorder.Eventf(object, eventtype, reason, messageFmt, args...)
+}
+
+// AnnotatedEventf is just like eventf, but with annotations attached.
+func (sr *SafeRecorder) AnnotatedEventf(
+	object runtime.Object,
+	annotations map[string]string,
+	eventtype, reason, messageFmt string,
+	args ...interface{},
+) {
+	if sr.recorder == nil {
+		return
+	}
+
+	sr.recorder.AnnotatedEventf(object, annotations, eventtype, reason, messageFmt, args...)
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
/kind documentation

<!--
Add one of the following kinds:
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- docs: Document that the log based recorder can't record privileged pods - adds docs that make it clear that we can't record privileged containers using the log enricher
- recording: Issue an event if a privileged pod is recorded with a log-based recorder - when log enricher is used to record privileged containers, attach an event to the recording object

#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
No

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
If the log-based recorder is in use and the user attempts to either record a container which already had its SecurityContext set or attempts to record a privileged container (which ignores both seccomp profiles and selinux contexts), the profile recording webhook issues a warning event.
```
