### PR TITLE
tests: Only check the worker nodes testCaseLongSeccompProfileName

### DIFF
--- a/test/tc_long_profile_name_test.go
+++ b/test/tc_long_profile_name_test.go
@@ -19,6 +19,7 @@ package e2e_test
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	secprofnodestatusv1alpha1 "sigs.k8s.io/security-profiles-operator/api/secprofnodestatus/v1alpha1"
@@ -49,7 +50,9 @@ func (e *e2e) testCaseLongSeccompProfileName(nodes []string) {
 	e.logf("List all node statuses for policy by ID")
 	id := e.getSeccompPolicyID(policyName)
 	namespace := e.getCurrentContextNamespace(defaultNamespace)
-	selector := fmt.Sprintf("spo.x-k8s.io/profile-id=%s", id)
+	selector := fmt.Sprintf(
+		"spo.x-k8s.io/profile-id in (%s),spo.x-k8s.io/node-name in (%s)",
+		id, strings.Join(nodes, ","))
 
 	const maxTries = 10
 	for i := 0; i < maxTries; i++ {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
/kind failing-test

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The test testCaseLongSeccompProfileName was written with assumption that
the profile being tested is only deployed on worker nodes, probably
because the upstream test platforms only schedule spod there.

On clusters where spod is scheduled on all nodes (OCP), this assumption
breaks and the test would list node statuses of both controlplane and
worker nodes but compare that with the number of workers only.

Let's list nodestatuses on worker nodes only to work around that issue.


#### Which issue(s) this PR fixes:
N/A

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
implicit

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
This was debugged as part of merging the latest upstream to OCP: https://github.com/openshift/security-profiles-operator/pull/3

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
