### PR TITLE
WIP: fix lookup ebpf comms map by pid

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpf/recorder.bpf.c
+++ b/internal/pkg/daemon/bpfrecorder/bpf/recorder.bpf.c
@@ -54,7 +54,7 @@ int sys_enter(struct trace_event_raw_sys_enter * args)
     // Update the command name if required
     char comm[MAX_COMM_LEN];
     bpf_get_current_comm(comm, sizeof(comm));
-    if (bpf_map_lookup_elem(&comms, &comm) == NULL) {
+    if (bpf_map_lookup_elem(&comms, &pid) == NULL) {
         bpf_map_update_elem(&comms, &pid, &comm, BPF_ANY);
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
fix lookup ebpf comms map by pid not comms， because comms is value.
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug
#### What this PR does / why we need it:
The original code query comms map is through comms, it seems to be wrong, it should be queried through pid. During the normal code running process, the comms map value should not be found through comms.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
no
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
