### PR TITLE
Allow the access() syscall from the operator seccomp profile

### DIFF
--- a/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
+++ b/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
@@ -8,6 +8,7 @@ data:
         {
           "names": [
             "accept4",
+            "access",
             "arch_prctl",
             "bind",
             "brk",

--- a/deploy/base/profiles/security-profiles-operator.json
+++ b/deploy/base/profiles/security-profiles-operator.json
@@ -5,6 +5,7 @@
     {
       "names": [
         "accept4",
+        "access",
         "arch_prctl",
         "bind",
         "brk",

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -755,6 +755,7 @@ data:
         {
           "names": [
             "accept4",
+            "access",
             "arch_prctl",
             "bind",
             "brk",

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1832,6 +1832,7 @@ data:
         {
           "names": [
             "accept4",
+            "access",
             "arch_prctl",
             "bind",
             "brk",

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -1832,6 +1832,7 @@ data:
         {
           "names": [
             "accept4",
+            "access",
             "arch_prctl",
             "bind",
             "brk",

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1832,6 +1832,7 @@ data:
         {
           "names": [
             "accept4",
+            "access",
             "arch_prctl",
             "bind",
             "brk",

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -1803,6 +1803,7 @@ data:
         {
           "names": [
             "accept4",
+            "access",
             "arch_prctl",
             "bind",
             "brk",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
OpenShift uses a fork of Go which in turn uses OpenSSL for crypto
instead of BoringSSL:
https://developers.redhat.com/blog/2019/06/24/go-and-fips-140-2-on-red-hat-enterprise-linux

In order to support running SPO that was compiled with that version of
Go, we need to allow the access() system call to avoid a crash.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A, I tested manually on OCP 4.12

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
