### PR TITLE
Add cert-manager helm dependency

### DIFF
--- a/.github/workflows/helm-chart-package.yaml
+++ b/.github/workflows/helm-chart-package.yaml
@@ -31,6 +31,7 @@ jobs:
       - run: mkdir -p build
       - id: package
         run: |
+          helm dep up deploy/helm
           helm_output="$(helm package -d build deploy/helm)"
           tgz_path="${helm_output##*saved it to: }"
           echo "helm chart tgz path: '${tgz_path}'"

--- a/deploy/helm/Chart.yaml
+++ b/deploy/helm/Chart.yaml
@@ -4,3 +4,8 @@ description: "The Kubernetes Security Profiles Operator."
 type: application
 version: "0.4.4-dev"
 appVersion: "0.4.4-dev"
+dependencies:
+  - name: cert-manager
+    version: v1.9.1
+    repository: https://charts.jetstack.io
+    condition: cert-manager.enabled

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -37,3 +37,6 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+cert-manager:
+  enabled: false


### PR DESCRIPTION

#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds the ability to deploy cert-manager as a dependency of the helm chart with:
```
cert-manager:
  enabled: true
```

I've set this to `false` by default as cert-manager is deployed standalone in a majority of clusters and doesn't currently play nice with having multiple instances on the same cluster. For this reason, we want users to actively decide to deploy this alongside SPO.

#### Which issue(s) this PR fixes:

fixes #1062 

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

Yes.

```release-note
By default, the existing behavior is persisted as the default. SPO is installed by itself and expects cert-manager to be installed separately. NewFunctionality is added that allows for deploying cert-manager alongside the SPO deployment.
```
