### PR TITLE
Add SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV

### DIFF
--- a/api/seccompprofile/v1beta1/seccompprofile_types.go
+++ b/api/seccompprofile/v1beta1/seccompprofile_types.go
@@ -69,7 +69,9 @@ type SeccompProfileSpec struct {
 //nolint:lll // required for kubebuilder
 type Arch string
 
-// +kubebuilder:validation:Enum=SECCOMP_FILTER_FLAG_TSYNC;SECCOMP_FILTER_FLAG_LOG;SECCOMP_FILTER_FLAG_SPEC_ALLOW
+// +kubebuilder:validation:Enum=SECCOMP_FILTER_FLAG_TSYNC;SECCOMP_FILTER_FLAG_LOG;SECCOMP_FILTER_FLAG_SPEC_ALLOW;SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
+//
+//nolint:lll // required for kubebuilder
 type Flag string
 
 // Syscall defines a syscall in seccomp.

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_seccompprofiles.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_seccompprofiles.yaml
@@ -100,6 +100,7 @@ spec:
                   - SECCOMP_FILTER_FLAG_TSYNC
                   - SECCOMP_FILTER_FLAG_LOG
                   - SECCOMP_FILTER_FLAG_SPEC_ALLOW
+                  - SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
                   type: string
                 type: array
               listenerMetadata:

--- a/deploy/base-crds/crd.yaml
+++ b/deploy/base-crds/crd.yaml
@@ -313,6 +313,7 @@ spec:
                   - SECCOMP_FILTER_FLAG_TSYNC
                   - SECCOMP_FILTER_FLAG_LOG
                   - SECCOMP_FILTER_FLAG_SPEC_ALLOW
+                  - SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
                   type: string
                 type: array
               syscalls:

--- a/deploy/base-crds/crds/seccompprofile.yaml
+++ b/deploy/base-crds/crds/seccompprofile.yaml
@@ -98,6 +98,7 @@ spec:
                   - SECCOMP_FILTER_FLAG_TSYNC
                   - SECCOMP_FILTER_FLAG_LOG
                   - SECCOMP_FILTER_FLAG_SPEC_ALLOW
+                  - SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
                   type: string
                 type: array
               listenerMetadata:

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -305,6 +305,7 @@ spec:
                   - SECCOMP_FILTER_FLAG_TSYNC
                   - SECCOMP_FILTER_FLAG_LOG
                   - SECCOMP_FILTER_FLAG_SPEC_ALLOW
+                  - SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
                   type: string
                 type: array
               listenerMetadata:

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -305,6 +305,7 @@ spec:
                   - SECCOMP_FILTER_FLAG_TSYNC
                   - SECCOMP_FILTER_FLAG_LOG
                   - SECCOMP_FILTER_FLAG_SPEC_ALLOW
+                  - SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
                   type: string
                 type: array
               listenerMetadata:

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -305,6 +305,7 @@ spec:
                   - SECCOMP_FILTER_FLAG_TSYNC
                   - SECCOMP_FILTER_FLAG_LOG
                   - SECCOMP_FILTER_FLAG_SPEC_ALLOW
+                  - SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
                   type: string
                 type: array
               listenerMetadata:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -305,6 +305,7 @@ spec:
                   - SECCOMP_FILTER_FLAG_TSYNC
                   - SECCOMP_FILTER_FLAG_LOG
                   - SECCOMP_FILTER_FLAG_SPEC_ALLOW
+                  - SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
                   type: string
                 type: array
               listenerMetadata:

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -481,6 +481,7 @@ spec:
                   - SECCOMP_FILTER_FLAG_TSYNC
                   - SECCOMP_FILTER_FLAG_LOG
                   - SECCOMP_FILTER_FLAG_SPEC_ALLOW
+                  - SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
                   type: string
                 type: array
               listenerMetadata:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Linux 5.19 introduced a new seccomp flag:
SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV
https://git.kernel.org/pub/scm/linux/kernel/git/kees/linux.git/commit/?id=c2aa2dfef243

It is useful for seccomp notify when handling notification from Golang programs which are often preempted by the runtime with SIGURG.

#### Which issue(s) this PR fixes:

None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

N/A
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

The flag was added in runtime-spec:
https://github.com/opencontainers/runtime-spec/commit/4bcd065f2430a9e8ebfea8e7de95c97eeb6269eb

and implemented in crun:
https://github.com/containers/crun/commit/396ac888867e840060aab6bcffee17377371771a

But not yet in runc. We need https://github.com/seccomp/libseccomp/issues/387 first.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add support for Seccomp Profiles that make use of the Seccomp Notify feature with the wait_killable semantic (SECCOMP_FILTER_FLAG_WAIT_KILLABLE_RECV).
```

cc @rata