### PR TITLE
Switch to libbpf_1 dependency in nix

### DIFF
--- a/nix/derivation-bpf.nix
+++ b/nix/derivation-bpf.nix
@@ -7,7 +7,7 @@ with pkgs; buildGo119Module rec {
   doCheck = false;
   outputs = [ "out" ];
   nativeBuildInputs = with buildPackages; [
-    bpftool
+    bpftools
     git
     llvmPackages_14.clang-unwrapped
     llvm_14
@@ -17,7 +17,7 @@ with pkgs; buildGo119Module rec {
   buildInputs = [
     glibc
     glibc.static
-    libbpf
+    libbpf_1
     libseccomp
     zlib.static
   ];

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -16,7 +16,7 @@ with pkgs; buildGo119Module rec {
     glibc
     glibc.static
     libapparmor
-    libbpf
+    libbpf_1
     libseccomp
     zlib.static
   ];

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,9 +1,9 @@
 {
   "url": "https://github.com/nixos/nixpkgs",
-  "rev": "a13d59408da1108fc6c9ffe4750ab7a33c581d24",
-  "date": "2022-09-19T11:10:19+02:00",
-  "path": "/nix/store/mycyaj7cirrs3j493l8g0dkjwzn1fb35-nixpkgs",
-  "sha256": "1b2m1yypz5rd5ww46id6a0pbxxh0z0w7xm5h6nv9iqibj9fhkn4h",
+  "rev": "1237bfb999d269c46868b34bb4b33b5ff084ac5f",
+  "date": "2022-10-05T09:03:37+01:00",
+  "path": "/nix/store/hdgm4bsbwj5yc8imqpv7xn5g7llyif3b-nixpkgs",
+  "sha256": "1dsp9g6sp3sc06iy3d0qr18azpvnbgx17f0a9kapfpfb072bbqvd",
   "fetchLFS": false,
   "fetchSubmodules": false,
   "deepClone": false,

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -4,14 +4,4 @@ self: super:
     doCheck = false;
     dontDisableStatic = true;
   });
-  # TODO: remove when https://github.com/NixOS/nixpkgs/pull/187978 got merged
-  libbpf = super.libbpf.overrideAttrs (x: {
-    version = "1.0.0";
-    src = super.fetchFromGitHub {
-      owner = "libbpf";
-      repo = "libbpf";
-      rev = "v1.0.0";
-      sha256 = "sha256-JU/Ia85V4L1DtwRcIn9OF/qt52hYSQhkw2Iz2ovEwqo=";
-    };
-  });
 }


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We now have an official libbpf version in upstream nix after the merge of: https://github.com/NixOS/nixpkgs/pull/193591

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated libbpf to v1.0.1.
```
