### PR TITLE
Change syscalls corresponding to pid to syscalls corresponding to mntns

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpfrecorderfakes/fake_impl.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorderfakes/fake_impl.go
@@ -146,6 +146,18 @@ type FakeImpl struct {
 	deleteKeyReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DeleteKey64Stub        func(*libbpfgo.BPFMap, uint64) error
+	deleteKey64Mutex       sync.RWMutex
+	deleteKey64ArgsForCall []struct {
+		arg1 *libbpfgo.BPFMap
+		arg2 uint64
+	}
+	deleteKey64Returns struct {
+		result1 error
+	}
+	deleteKey64ReturnsOnCall map[int]struct {
+		result1 error
+	}
 	DialMetricsStub        func() (*grpc.ClientConn, context.CancelFunc, error)
 	dialMetricsMutex       sync.RWMutex
 	dialMetricsArgsForCall []struct {
@@ -212,6 +224,20 @@ type FakeImpl struct {
 		result2 error
 	}
 	getValueReturnsOnCall map[int]struct {
+		result1 []byte
+		result2 error
+	}
+	GetValue64Stub        func(*libbpfgo.BPFMap, uint64) ([]byte, error)
+	getValue64Mutex       sync.RWMutex
+	getValue64ArgsForCall []struct {
+		arg1 *libbpfgo.BPFMap
+		arg2 uint64
+	}
+	getValue64Returns struct {
+		result1 []byte
+		result2 error
+	}
+	getValue64ReturnsOnCall map[int]struct {
 		result1 []byte
 		result2 error
 	}
@@ -444,6 +470,19 @@ type FakeImpl struct {
 		result1 error
 	}
 	updateValueReturnsOnCall map[int]struct {
+		result1 error
+	}
+	UpdateValue8Stub        func(*libbpfgo.BPFMap, uint64, uint8) error
+	updateValue8Mutex       sync.RWMutex
+	updateValue8ArgsForCall []struct {
+		arg1 *libbpfgo.BPFMap
+		arg2 uint64
+		arg3 uint8
+	}
+	updateValue8Returns struct {
+		result1 error
+	}
+	updateValue8ReturnsOnCall map[int]struct {
 		result1 error
 	}
 	WriteStub        func(*os.File, []byte) (int, error)
@@ -1002,6 +1041,68 @@ func (fake *FakeImpl) DeleteKeyReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeImpl) DeleteKey64(arg1 *libbpfgo.BPFMap, arg2 uint64) error {
+	fake.deleteKey64Mutex.Lock()
+	ret, specificReturn := fake.deleteKey64ReturnsOnCall[len(fake.deleteKey64ArgsForCall)]
+	fake.deleteKey64ArgsForCall = append(fake.deleteKey64ArgsForCall, struct {
+		arg1 *libbpfgo.BPFMap
+		arg2 uint64
+	}{arg1, arg2})
+	stub := fake.DeleteKey64Stub
+	fakeReturns := fake.deleteKey64Returns
+	fake.recordInvocation("DeleteKey64", []interface{}{arg1, arg2})
+	fake.deleteKey64Mutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) DeleteKey64CallCount() int {
+	fake.deleteKey64Mutex.RLock()
+	defer fake.deleteKey64Mutex.RUnlock()
+	return len(fake.deleteKey64ArgsForCall)
+}
+
+func (fake *FakeImpl) DeleteKey64Calls(stub func(*libbpfgo.BPFMap, uint64) error) {
+	fake.deleteKey64Mutex.Lock()
+	defer fake.deleteKey64Mutex.Unlock()
+	fake.DeleteKey64Stub = stub
+}
+
+func (fake *FakeImpl) DeleteKey64ArgsForCall(i int) (*libbpfgo.BPFMap, uint64) {
+	fake.deleteKey64Mutex.RLock()
+	defer fake.deleteKey64Mutex.RUnlock()
+	argsForCall := fake.deleteKey64ArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeImpl) DeleteKey64Returns(result1 error) {
+	fake.deleteKey64Mutex.Lock()
+	defer fake.deleteKey64Mutex.Unlock()
+	fake.DeleteKey64Stub = nil
+	fake.deleteKey64Returns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) DeleteKey64ReturnsOnCall(i int, result1 error) {
+	fake.deleteKey64Mutex.Lock()
+	defer fake.deleteKey64Mutex.Unlock()
+	fake.DeleteKey64Stub = nil
+	if fake.deleteKey64ReturnsOnCall == nil {
+		fake.deleteKey64ReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteKey64ReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeImpl) DialMetrics() (*grpc.ClientConn, context.CancelFunc, error) {
 	fake.dialMetricsMutex.Lock()
 	ret, specificReturn := fake.dialMetricsReturnsOnCall[len(fake.dialMetricsArgsForCall)]
@@ -1315,6 +1416,71 @@ func (fake *FakeImpl) GetValueReturnsOnCall(i int, result1 []byte, result2 error
 		})
 	}
 	fake.getValueReturnsOnCall[i] = struct {
+		result1 []byte
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) GetValue64(arg1 *libbpfgo.BPFMap, arg2 uint64) ([]byte, error) {
+	fake.getValue64Mutex.Lock()
+	ret, specificReturn := fake.getValue64ReturnsOnCall[len(fake.getValue64ArgsForCall)]
+	fake.getValue64ArgsForCall = append(fake.getValue64ArgsForCall, struct {
+		arg1 *libbpfgo.BPFMap
+		arg2 uint64
+	}{arg1, arg2})
+	stub := fake.GetValue64Stub
+	fakeReturns := fake.getValue64Returns
+	fake.recordInvocation("GetValue64", []interface{}{arg1, arg2})
+	fake.getValue64Mutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) GetValue64CallCount() int {
+	fake.getValue64Mutex.RLock()
+	defer fake.getValue64Mutex.RUnlock()
+	return len(fake.getValue64ArgsForCall)
+}
+
+func (fake *FakeImpl) GetValue64Calls(stub func(*libbpfgo.BPFMap, uint64) ([]byte, error)) {
+	fake.getValue64Mutex.Lock()
+	defer fake.getValue64Mutex.Unlock()
+	fake.GetValue64Stub = stub
+}
+
+func (fake *FakeImpl) GetValue64ArgsForCall(i int) (*libbpfgo.BPFMap, uint64) {
+	fake.getValue64Mutex.RLock()
+	defer fake.getValue64Mutex.RUnlock()
+	argsForCall := fake.getValue64ArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeImpl) GetValue64Returns(result1 []byte, result2 error) {
+	fake.getValue64Mutex.Lock()
+	defer fake.getValue64Mutex.Unlock()
+	fake.GetValue64Stub = nil
+	fake.getValue64Returns = struct {
+		result1 []byte
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) GetValue64ReturnsOnCall(i int, result1 []byte, result2 error) {
+	fake.getValue64Mutex.Lock()
+	defer fake.getValue64Mutex.Unlock()
+	fake.GetValue64Stub = nil
+	if fake.getValue64ReturnsOnCall == nil {
+		fake.getValue64ReturnsOnCall = make(map[int]struct {
+			result1 []byte
+			result2 error
+		})
+	}
+	fake.getValue64ReturnsOnCall[i] = struct {
 		result1 []byte
 		result2 error
 	}{result1, result2}
@@ -2477,6 +2643,69 @@ func (fake *FakeImpl) UpdateValueReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeImpl) UpdateValue8(arg1 *libbpfgo.BPFMap, arg2 uint64, arg3 uint8) error {
+	fake.updateValue8Mutex.Lock()
+	ret, specificReturn := fake.updateValue8ReturnsOnCall[len(fake.updateValue8ArgsForCall)]
+	fake.updateValue8ArgsForCall = append(fake.updateValue8ArgsForCall, struct {
+		arg1 *libbpfgo.BPFMap
+		arg2 uint64
+		arg3 uint8
+	}{arg1, arg2, arg3})
+	stub := fake.UpdateValue8Stub
+	fakeReturns := fake.updateValue8Returns
+	fake.recordInvocation("UpdateValue8", []interface{}{arg1, arg2, arg3})
+	fake.updateValue8Mutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) UpdateValue8CallCount() int {
+	fake.updateValue8Mutex.RLock()
+	defer fake.updateValue8Mutex.RUnlock()
+	return len(fake.updateValue8ArgsForCall)
+}
+
+func (fake *FakeImpl) UpdateValue8Calls(stub func(*libbpfgo.BPFMap, uint64, uint8) error) {
+	fake.updateValue8Mutex.Lock()
+	defer fake.updateValue8Mutex.Unlock()
+	fake.UpdateValue8Stub = stub
+}
+
+func (fake *FakeImpl) UpdateValue8ArgsForCall(i int) (*libbpfgo.BPFMap, uint64, uint8) {
+	fake.updateValue8Mutex.RLock()
+	defer fake.updateValue8Mutex.RUnlock()
+	argsForCall := fake.updateValue8ArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeImpl) UpdateValue8Returns(result1 error) {
+	fake.updateValue8Mutex.Lock()
+	defer fake.updateValue8Mutex.Unlock()
+	fake.UpdateValue8Stub = nil
+	fake.updateValue8Returns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) UpdateValue8ReturnsOnCall(i int, result1 error) {
+	fake.updateValue8Mutex.Lock()
+	defer fake.updateValue8Mutex.Unlock()
+	fake.UpdateValue8Stub = nil
+	if fake.updateValue8ReturnsOnCall == nil {
+		fake.updateValue8ReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.updateValue8ReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeImpl) Write(arg1 *os.File, arg2 []byte) (int, error) {
 	var arg2Copy []byte
 	if arg2 != nil {
@@ -2568,6 +2797,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.containerIDForPIDMutex.RUnlock()
 	fake.deleteKeyMutex.RLock()
 	defer fake.deleteKeyMutex.RUnlock()
+	fake.deleteKey64Mutex.RLock()
+	defer fake.deleteKey64Mutex.RUnlock()
 	fake.dialMetricsMutex.RLock()
 	defer fake.dialMetricsMutex.RUnlock()
 	fake.getMapMutex.RLock()
@@ -2578,6 +2809,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.getProgramMutex.RUnlock()
 	fake.getValueMutex.RLock()
 	defer fake.getValueMutex.RUnlock()
+	fake.getValue64Mutex.RLock()
+	defer fake.getValue64Mutex.RUnlock()
 	fake.getenvMutex.RLock()
 	defer fake.getenvMutex.RUnlock()
 	fake.goArchMutex.RLock()
@@ -2616,6 +2849,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.unmarshalMutex.RUnlock()
 	fake.updateValueMutex.RLock()
 	defer fake.updateValueMutex.RUnlock()
+	fake.updateValue8Mutex.RLock()
+	defer fake.updateValue8Mutex.RUnlock()
 	fake.writeMutex.RLock()
 	defer fake.writeMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/internal/pkg/daemon/bpfrecorder/impl.go
+++ b/internal/pkg/daemon/bpfrecorder/impl.go
@@ -69,8 +69,11 @@ type impl interface {
 	Write(*os.File, []byte) (int, error)
 	ContainerIDForPID(*ttlcache.Cache[string, string], int) (string, error)
 	GetValue(*bpf.BPFMap, uint32) ([]byte, error)
+	GetValue64(*bpf.BPFMap, uint64) ([]byte, error)
 	UpdateValue(*bpf.BPFMap, uint32, []byte) error
+	UpdateValue8(*bpf.BPFMap, uint64, uint8) error
 	DeleteKey(*bpf.BPFMap, uint32) error
+	DeleteKey64(*bpf.BPFMap, uint64) error
 	ListPods(context.Context, *kubernetes.Clientset, string) (*v1.PodList, error)
 	GetName(seccomp.ScmpSyscall) (string, error)
 	RemoveAll(string) error
@@ -167,6 +170,13 @@ func (d *defaultImpl) GetValue(m *bpf.BPFMap, key uint32) ([]byte, error) {
 	return m.GetValue(unsafe.Pointer(&key))
 }
 
+func (d *defaultImpl) GetValue64(m *bpf.BPFMap, key uint64) ([]byte, error) {
+	if m == nil {
+		return nil, errors.New("provided bpf map is nil")
+	}
+	return m.GetValue(unsafe.Pointer(&key))
+}
+
 func (d *defaultImpl) UpdateValue(m *bpf.BPFMap, key uint32, value []byte) error {
 	if m == nil {
 		return errors.New("provided bpf map is nil")
@@ -174,7 +184,21 @@ func (d *defaultImpl) UpdateValue(m *bpf.BPFMap, key uint32, value []byte) error
 	return m.Update(unsafe.Pointer(&key), unsafe.Pointer(&value[0]))
 }
 
+func (d *defaultImpl) UpdateValue8(m *bpf.BPFMap, key uint64, value uint8) error {
+	if m == nil {
+		return errors.New("provided bpf map is nil")
+	}
+	return m.Update(unsafe.Pointer(&key), unsafe.Pointer(&value))
+}
+
 func (d *defaultImpl) DeleteKey(m *bpf.BPFMap, key uint32) error {
+	if m == nil {
+		return errors.New("provided bpf map is nil")
+	}
+	return m.DeleteKey(unsafe.Pointer(&key))
+}
+
+func (d *defaultImpl) DeleteKey64(m *bpf.BPFMap, key uint64) error {
 	if m == nil {
 		return errors.New("provided bpf map is nil")
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #1188 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
#1188 
Fixes #1188 

or

None
-->

#### Does this PR have test?
NONE
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
The existing pid-to-syscall relationship is flawed. Because a container will generate many pids, if the pids are logged frequently this will have an impact on the kernel performance. A container in its life cycle mntns is unchanged, so using mntns to record syscall will greatly reduce the system overhead.
#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
