### PR TITLE
Fix flaky e2e issue

### DIFF
--- a/test/tc_seccomp_profilebindings_test.go
+++ b/test/tc_seccomp_profilebindings_test.go
@@ -47,6 +47,13 @@ spec:
   - image: quay.io/security-profiles-operator/test-hello-world:latest
     name: hello
     resources: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+      runAsNonRoot: true
   restartPolicy: Never
 `
 


### PR DESCRIPTION
#### What type of PR is this?

<!--
/kind failing-test

-->

#### What this PR does / why we need it:
Fix the pod creation error in seccomp profile binding test, and fix seccomp profile finalizer test.

In seccomp profile finalizer test, when we first delete the profile recording before the pod is removed, it will not be removed because of the finalizer, however as soon as the pod is removed, the profile recording will be removed, hence in the next step, we were not able to find the object.

#### Which issue(s) this PR fixes:
Flaky e2e issue

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None

```release-note

```
