### PR TITLE
config: Allow enabling the log enricher on install time using the `ENABLE_LOG_ENRICHER` variable

### DIFF
--- a/installation-usage.md
+++ b/installation-usage.md
@@ -1054,6 +1054,12 @@ If all requirements are met, then the feature can be enabled by patching the
 securityprofilesoperatordaemon.security-profiles-operator.x-k8s.io/spod patched
 ```
 
+Alternatively, make sure the operator deployment sets the `ENABLE_LOG_ENRICHER` variable,
+to `true`, either by setting the environment variable in the deployment or by enabling
+the variable trough a `Subscription` resource, when installing the operator using OLM
+(see [Restricting the operator to specific nodes](#restricting-the-operator-to-specific-nodes)
+for an example of setting another variable).
+
 Now the operator will take care of re-deploying the `spod` DaemonSet and the
 enricher should listening on new changes to the audit logs:
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -67,6 +67,9 @@ const (
 	// VerbosityEnvKey is the environment variable key for the logging verbosity.
 	VerbosityEnvKey = "SPO_VERBOSITY"
 
+	// EnableLogEnricherEnvKey is the environment variable key for enabling the log enricher.
+	EnableLogEnricherEnvKey = "ENABLE_LOG_ENRICHER"
+
 	// VerboseLevel is the increased verbosity log level.
 	VerboseLevel = 1
 

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
+	"strconv"
 
 	"github.com/crossplane/crossplane-runtime/pkg/event"
 	"github.com/go-logr/logr"
@@ -499,8 +501,12 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 		templateSpec.HostPID = true
 	}
 
-	// Log enricher parameters
-	if cfg.Spec.EnableLogEnricher {
+	// Log enricher parameters. The spod setting takes precedence over the env var.
+	enableLogEnricherEnv, err := strconv.ParseBool(os.Getenv(config.EnableLogEnricherEnvKey))
+	if err != nil {
+		enableLogEnricherEnv = false
+	}
+	if cfg.Spec.EnableLogEnricher || enableLogEnricherEnv {
 		ctr := r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDLogEnricher]
 		ctr.Image = image
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Some installations might want to enable the log enricher at install
time. Using an environment variable seems like a nice way of doing that,
for example because then it's possible to use a Subscription object when
installing using OLM.


#### Which issue(s) this PR fixes:
Fixes #1167

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.


or

None
-->

#### Does this PR have test?
no

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
It is now possible to enable the log enricher at install time by setting the
ENABLE_LOG_ENRICHER environment value to true.
```
