### PR TITLE
handle node deletion

### DIFF
--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -162,6 +162,14 @@ spec:
         - apiGroups:
           - ""
           resources:
+          - nodes
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - ""
+          resources:
           - services
           verbs:
           - create
@@ -335,6 +343,7 @@ spec:
           resources:
           - securityprofilenodestatuses
           verbs:
+          - delete
           - get
           - list
           - watch

--- a/deploy/base/role.yaml
+++ b/deploy/base/role.yaml
@@ -8,6 +8,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create
@@ -181,6 +189,7 @@ rules:
   resources:
   - securityprofilenodestatuses
   verbs:
+  - delete
   - get
   - list
   - watch

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -44,6 +44,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create
@@ -217,6 +225,7 @@ rules:
   resources:
   - securityprofilenodestatuses
   verbs:
+  - delete
   - get
   - list
   - watch

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2018,6 +2018,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create
@@ -2191,6 +2199,7 @@ rules:
   resources:
   - securityprofilenodestatuses
   verbs:
+  - delete
   - get
   - list
   - watch

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -2018,6 +2018,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create
@@ -2191,6 +2199,7 @@ rules:
   resources:
   - securityprofilenodestatuses
   verbs:
+  - delete
   - get
   - list
   - watch

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2018,6 +2018,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create
@@ -2191,6 +2199,7 @@ rules:
   resources:
   - securityprofilenodestatuses
   verbs:
+  - delete
   - get
   - list
   - watch

--- a/deploy/overlays/webhook/role.yaml
+++ b/deploy/overlays/webhook/role.yaml
@@ -1,3 +1,3 @@
 ---
-- path: /rules/1
+- path: /rules/2
   op: remove

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -2090,6 +2090,14 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - services
   verbs:
   - create
@@ -2252,6 +2260,7 @@ rules:
   resources:
   - securityprofilenodestatuses
   verbs:
+  - delete
   - get
   - list
   - watch

--- a/internal/pkg/nodestatus/nodestatus.go
+++ b/internal/pkg/nodestatus/nodestatus.go
@@ -25,7 +25,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -246,12 +245,7 @@ func getFinalizerString(pol profilebase.SecurityProfileBase, nodeName string) st
 	if pol.IsPartial() {
 		return partialProfileFinalizer
 	}
-
-	finalizerString := nodeName + "-deleted"
-	// Make sure the length of finalizer is not longer than 63 characters
-	if len(nodeName)+len("-deleted") > validation.DNS1123LabelMaxLength {
-		finalizerString = nodeName[:validation.DNS1123LabelMaxLength-len("-deleted")] + "-deleted"
-	}
+	finalizerString := util.GetFinalizerNodeString(nodeName)
 	return finalizerString
 }
 

--- a/internal/pkg/util/finalizers.go
+++ b/internal/pkg/util/finalizers.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
@@ -46,4 +47,14 @@ func RemoveFinalizer(ctx context.Context, c client.Client, pol client.Object, fi
 	}
 	controllerutil.RemoveFinalizer(pol, finalizer)
 	return c.Update(ctx, pol)
+}
+
+// GetFinalizerNodeString gets finalizer string from Node Name.
+func GetFinalizerNodeString(nodeName string) string {
+	finalizerString := nodeName + "-deleted"
+	// Make sure the length of finalizer is not longer than 63 characters
+	if len(nodeName)+len("-deleted") > validation.DNS1123LabelMaxLength {
+		finalizerString = nodeName[:validation.DNS1123LabelMaxLength-len("-deleted")] + "-deleted"
+	}
+	return finalizerString
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:

This pr fixes seccompprofiles deletion when a node is removed, we added a check to see if the node finalizer is a deleted node, if so, we remove such finalizer so the seccompprofile can be deleted without any issues.

The nodestatus controller detect the extra nodestatus object, and if it can't find the node associated with it, it will try to remove the node status object and node finalizer from corresponding the seccomp profile


#### Which issue(s) this PR fixes:

Fixes #1152


#### Does this PR have test?

Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE

```release-note
This pr fixes seccompprofiles deletion when a node is removed, we added a check to see if the node finalizer is a deleted node, if so, we remove such finalizer so the seccompprofile can be deleted without any issues.
```
