### PR TITLE
olm: Use file-based catalog instead of SQLite based catalog

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,6 @@ GOLANGCI_LINT_VERSION = v1.49.0
 REPO_INFRA_VERSION = v0.2.5
 KUSTOMIZE_VERSION = 4.5.5
 OPERATOR_SDK_VERSION ?= v1.22.2
-OPM_VERSION ?= v1.19.1
 
 CONTROLLER_GEN_CMD := CGO_LDFLAGS= $(GO) run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen
 
@@ -505,7 +504,7 @@ ifeq (,$(shell which opm 2>/dev/null))
 	set -e ;\
 	mkdir -p $(dir $(OPM)) ;\
 	OS=$(shell go env GOOS) && ARCH=$(shell go env GOARCH) && \
-	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPM_VERSION)/$${OS}-$${ARCH}-opm ;\
+	curl -sSLo $(OPM) https://github.com/operator-framework/operator-registry/releases/download/$(OPERATOR_SDK_VERSION)/$${OS}-$${ARCH}-opm ;\
 	chmod +x $(OPM) ;\
 	}
 else

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GO ?= go
 GOLANGCI_LINT_VERSION = v1.49.0
 REPO_INFRA_VERSION = v0.2.5
 KUSTOMIZE_VERSION = 4.5.5
-OPERATOR_SDK_VERSION ?= v1.22.2
+OPERATOR_SDK_VERSION ?= v1.25.0
 
 CONTROLLER_GEN_CMD := CGO_LDFLAGS= $(GO) run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen
 
@@ -528,7 +528,7 @@ catalog-build: opm ## Build a catalog image.
 	$(eval TMP_DIR := $(shell mktemp -d))
 	$(eval CATALOG_DOCKERFILE := $(TMP_DIR).Dockerfile)
 	cp deploy/catalog-preamble.json $(TMP_DIR)/security-profiles-operator-catalog.json
-	$(OPM) render $(BUNDLE_IMGS) >> $(TMP_DIR)/security-profiles-operator-catalog.json
+	$(OPM) $(OPM_EXTRA_ARGS) render $(BUNDLE_IMGS) >> $(TMP_DIR)/security-profiles-operator-catalog.json
 	$(OPM) generate dockerfile $(TMP_DIR)
 	$(CONTAINER_RUNTIME) build -f $(CATALOG_DOCKERFILE) -t $(CATALOG_IMG)
 	rm -rf $(TMP_DIR) $(CATALOG_DOCKERFILE)

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -7,7 +7,7 @@ LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=security-profiles-operator
 LABEL operators.operatorframework.io.bundle.channels.v1=stable
 LABEL operators.operatorframework.io.bundle.channel.default.v1=stable
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.22.2
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.25.0
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -100,7 +100,7 @@ metadata:
     categories: Security
     olm.skipRange: '>=0.4.1 <0.5.1-dev'
     operatorframework.io/suggested-namespace: security-profiles-operator
-    operators.operatorframework.io/builder: operator-sdk-v1.22.2
+    operators.operatorframework.io/builder: operator-sdk-v1.25.0
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
   name: security-profiles-operator.v0.5.1-dev
   namespace: placeholder

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -6,7 +6,7 @@ annotations:
   operators.operatorframework.io.bundle.package.v1: security-profiles-operator
   operators.operatorframework.io.bundle.channels.v1: stable
   operators.operatorframework.io.bundle.channel.default.v1: stable
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.22.2
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.25.0
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -39,14 +39,6 @@ dependencies:
     - path: Makefile
       match: OPERATOR_SDK_VERSION
 
-  - name: opm
-    version: 1.19.1
-    refPaths:
-    - path: Makefile
-      match: OPM_VERSION
-    - path: hack/image-cross.sh
-      match: OPM_VERSION
-
   - name: olm
     version: v0.18.2
     refPaths:

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -34,7 +34,7 @@ dependencies:
       match: KUSTOMIZE_VERSION
 
   - name: operator-sdk
-    version: v1.22.2
+    version: v1.25.0
     refPaths:
     - path: Makefile
       match: OPERATOR_SDK_VERSION

--- a/deploy/catalog-preamble.json
+++ b/deploy/catalog-preamble.json
@@ -1,0 +1,20 @@
+{
+    "schema": "olm.package",
+    "name": "security-profiles-operator",
+    "defaultChannel": "stable",
+    "icon": {
+        "base64data": "PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyNTguNTEgMjU4LjUxIj48ZGVmcz48c3R5bGU+LmNscy0xe2ZpbGw6I2QxZDFkMTt9LmNscy0ye2ZpbGw6IzhkOGQ4Zjt9PC9zdHlsZT48L2RlZnM+PHRpdGxlPkFzc2V0IDQ8L3RpdGxlPjxnIGlkPSJMYXllcl8yIiBkYXRhLW5hbWU9IkxheWVyIDIiPjxnIGlkPSJMYXllcl8xLTIiIGRhdGEtbmFtZT0iTGF5ZXIgMSI+PHBhdGggY2xhc3M9ImNscy0xIiBkPSJNMTI5LjI1LDIwQTEwOS4xLDEwOS4xLDAsMCwxLDIwNi40LDIwNi40LDEwOS4xLDEwOS4xLDAsMSwxLDUyLjExLDUyLjExLDEwOC40NSwxMDguNDUsMCwwLDEsMTI5LjI1LDIwbTAtMjBoMEM1OC4xNiwwLDAsNTguMTYsMCwxMjkuMjVIMGMwLDcxLjA5LDU4LjE2LDEyOS4yNiwxMjkuMjUsMTI5LjI2aDBjNzEuMDksMCwxMjkuMjYtNTguMTcsMTI5LjI2LTEyOS4yNmgwQzI1OC41MSw1OC4xNiwyMDAuMzQsMCwxMjkuMjUsMFoiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0xNzcuNTQsMTAzLjQxSDE0MS42NkwxNTQuOSw2NS43NmMxLjI1LTQuNC0yLjMzLTguNzYtNy4yMS04Ljc2SDEwMi45M2E3LjMyLDcuMzIsMCwwLDAtNy40LDZsLTEwLDY5LjYxYy0uNTksNC4xNywyLjg5LDcuODksNy40LDcuODloMzYuOUwxMTUuNTUsMTk3Yy0xLjEyLDQuNDEsMi40OCw4LjU1LDcuMjQsOC41NWE3LjU4LDcuNTgsMCwwLDAsNi40Ny0zLjQ4TDE4NCwxMTMuODVDMTg2Ljg2LDEwOS4yNCwxODMuMjksMTAzLjQxLDE3Ny41NCwxMDMuNDFaIi8+PC9nPjwvZz48L3N2Zz4=",
+        "mediatype": "image/svg+xml"
+    }
+}
+{
+    "schema": "olm.channel",
+    "name": "stable",
+    "package": "security-profiles-operator",
+    "entries": [
+        {
+            "name": "security-profiles-operator.v0.5.1-dev",
+            "skipRange": ">=0.4.1 <0.5.1-dev"
+        }
+    ]
+}

--- a/hack/ci/e2e-olm.sh
+++ b/hack/ci/e2e-olm.sh
@@ -45,7 +45,7 @@ function build_and_push_packages() {
     podman push --tls-verify=false ${BUNDLE_IMG}
 
     # create catalog image, push catalog
-    make catalog-build OPM_EXTRA_ARGS=" --skip-tls" BUNDLE_IMGS=${BUNDLE_IMG} CATALOG_IMG=${CATALOG_IMG}
+    make catalog-build OPM_EXTRA_ARGS=" --use-http" BUNDLE_IMGS=${BUNDLE_IMG} CATALOG_IMG=${CATALOG_IMG}
     podman push --tls-verify=false ${CATALOG_IMG}
 }
 

--- a/hack/image-cross.sh
+++ b/hack/image-cross.sh
@@ -63,21 +63,6 @@ for T in "${TAGS[@]}"; do
     docker manifest push --purge "$IMAGE:$T"
 done
 
-# Manually install OPM because of failing symbol relocation of the non-static
-# upstream binary build.
-# TODO: remove me when switching to a new OPM version, which are nowadays
-# correctly statically linked.
-OPM_VERSION=1.19.1
-OPM_REPO=operator-registry
-OPM_DIR=$OPM_REPO-$OPM_VERSION
-apk add --no-cache gcc libc-dev
-curl -sSfL --retry 5 --retry-delay 3 \
-    "https://github.com/operator-framework/$OPM_REPO/archive/refs/tags/v$OPM_VERSION.tar.gz" -o- |
-    tar xfz -
-make -C $OPM_DIR bin/opm CGO_LDFLAGS=
-mkdir -p build
-cp $OPM_DIR/bin/opm build/opm
-
 # Build and push the bundle and catalog image
 BUNDLE_IMG_BASE=$IMAGE-bundle
 CATALOG_IMG_BASE=$IMAGE-catalog


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup
<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Since OLM is deprecating the SQLite based catalog we are currently
using, while at the same time, the SQLite based catalogs have issues
interacting with OpenShift clusters that implement the recent PSA
changes, let's switch to file-based catalog:
    https://olm.operatorframework.io/docs/reference/file-based-catalogs/

Note: this change only affects upstream. Downstream catalogs (such as the
one OCP produces for RH-shipped operators) already employed a workaround.

Most of the work is done by the "opm render" command except for some
metadata that is stored at catalog/preamble.json, for example the icon.


#### Which issue(s) this PR fixes:
Fixes #1203

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.


or

None
-->

#### Does this PR have test?
will be tested by the OLM test

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
