### PR TITLE
Dockerfile.ubi: Temporarily upgrade libksba until UBI image is refreshed

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -41,6 +41,11 @@ LABEL name="Security Profiles Operator" \
       version=$version \
       description="The Security Profiles Operator makes it easier for cluster admins to manage their seccomp, SELinux or AppArmor profiles and apply them to Kubernetes' workloads."
 
+RUN true \
+    && microdnf upgrade libksba \
+    && microdnf clean all \
+    && true
+
 COPY --from=build /work/build/security-profiles-operator /usr/bin/
 
 ENTRYPOINT ["/usr/bin/security-profiles-operator"]

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -140,7 +140,7 @@ dependencies:
       match: VERSION
 
   - name: CRI-O
-    version: v1.25.0
+    version: v1.25.1
     refPaths:
     - path: hack/ci/install-cri-o.sh
       match: TAG

--- a/hack/ci/install-cri-o.sh
+++ b/hack/ci/install-cri-o.sh
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-TAG=v1.25.0
+TAG=v1.25.1
 
 export PATH=$PATH:/usr/local/go/bin
 export GOPATH="$HOME/go"


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
RH has fixed CVE-2022-3515 already in an update, but the UBI update
lags behind. Upgrade the package manually in the meantime.

#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

-->

#### Does this PR have test?
Will be tested by Trivy

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
