### PR TITLE
Dockerfile.ubi: Bump the sha hash to use the latest image

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -33,7 +33,7 @@ ARG BPF_ENABLED=0
 RUN make
 
 # hash below referred to latest
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:9a9149dbba8dc5a961dfec460018c245b49da0f52e9934e1a70dd4d42f9fc5b7
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:33931dce809712888d1a8061bfa676963f517daca993984afed3251bc1fb5987
 ARG version
 USER root
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -152,13 +152,13 @@ dependencies:
       match: VERSION
 
   - name: cosign
-    version: v1.11.1
+    version: v1.13.1
     refPaths:
     - path: hack/ci/install-cri-o.sh
       match: COSIGN_VERSION
 
   - name: bom
-    version: v0.3.0
+    version: v0.4.1
     refPaths:
     - path: hack/ci/install-cri-o.sh
       match: BOM_VERSION

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -140,7 +140,7 @@ dependencies:
       match: VERSION
 
   - name: CRI-O
-    version: v1.25.0
+    version: v1.25.1
     refPaths:
     - path: hack/ci/install-cri-o.sh
       match: TAG

--- a/hack/ci/install-cri-o.sh
+++ b/hack/ci/install-cri-o.sh
@@ -24,12 +24,12 @@ export GOBIN="$GOPATH/bin"
 # We need cosign as well as the bom tool here because the CRI-O installation
 # script will automatically verify the signatures based on their existence in
 # $PATH.
-COSIGN_VERSION=v1.11.1
+COSIGN_VERSION=v1.13.1
 go install github.com/sigstore/cosign/cmd/cosign@$COSIGN_VERSION
 cp "$GOBIN/cosign" /usr/bin
 cosign version
 
-BOM_VERSION=v0.3.0
+BOM_VERSION=v0.4.1
 go install sigs.k8s.io/bom/cmd/bom@$BOM_VERSION
 cp "$GOBIN/bom" /usr/bin
 bom version

--- a/hack/ci/install-cri-o.sh
+++ b/hack/ci/install-cri-o.sh
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-TAG=v1.25.0
+TAG=v1.25.1
 
 export PATH=$PATH:/usr/local/go/bin
 export GOPATH="$HOME/go"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The latest image fixes CVE-2022-3515 and should unblock the trivy scans
in our CI.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

-->

#### Does this PR have test?
Will be tested by the existing GH actions.

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
