### PR TITLE
Fix catalog-build in `post-security-profiles-operator-push-image` job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -530,7 +530,7 @@ catalog-build: opm ## Build a catalog image.
 	cp deploy/catalog-preamble.json $(TMP_DIR)/security-profiles-operator-catalog.json
 	$(OPM) $(OPM_EXTRA_ARGS) render $(BUNDLE_IMGS) >> $(TMP_DIR)/security-profiles-operator-catalog.json
 	$(OPM) generate dockerfile $(TMP_DIR)
-	$(CONTAINER_RUNTIME) build -f $(CATALOG_DOCKERFILE) -t $(CATALOG_IMG)
+	$(CONTAINER_RUNTIME) build -f $(CATALOG_DOCKERFILE) -t $(CATALOG_IMG) $(shell dirname $(TMP_DIR))
 	rm -rf $(TMP_DIR) $(CATALOG_DOCKERFILE)
 
 # Push the catalog image.


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
The job fails because of:

```
…
mkdir -p build
cp deploy/catalog-preamble.json /tmp/tmp.eLOoOE/security-profiles-operator-catalog.json
build/opm  render gcr.io/k8s-staging-sp-operator/security-profiles-operator-bundle:v0.5.1-dev >> /tmp/tmp.eLOoOE/security-profiles-operator-catalog.json
build/opm generate dockerfile /tmp/tmp.eLOoOE
docker build -f /tmp/tmp.eLOoOE.Dockerfile -t gcr.io/k8s-staging-sp-operator/security-profiles-operator-catalog:v0.5.1-dev
"docker build" requires exactly 1 argument.
See 'docker build --help'.

Usage:  docker build [OPTIONS] PATH | URL | -
…
```
https://storage.googleapis.com/kubernetes-jenkins/logs/post-security-profiles-operator-push-image/1588470681220157440/build-log.txt
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
