### PR TITLE
selinux: Add a permissive boolean

### DIFF
--- a/api/selinuxprofile/v1alpha2/selinuxprofile_types.go
+++ b/api/selinuxprofile/v1alpha2/selinuxprofile_types.go
@@ -57,6 +57,11 @@ type SelinuxProfileSpec struct {
 	// +optional
 	// +kubebuilder:default={{kind:"System",name:"container"}}
 	Inherit []PolicyRef `json:"inherit,omitempty"`
+	// Permissive, when true will cause the SELinux profile to only
+	// log violations instead of enforcing them.
+	// +optional
+	// +kubebuilder:default=false
+	Permissive bool `json:"permissive,omitempty"`
 	// Defines the allow policy for the profile
 	Allow Allow `json:"allow,omitempty"`
 }

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_selinuxprofiles.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_selinuxprofiles.yaml
@@ -77,6 +77,11 @@ spec:
                   - name
                   type: object
                 type: array
+              permissive:
+                default: false
+                description: Permissive, when true will cause the SELinux profile
+                  to only log violations instead of enforcing them.
+                type: boolean
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.

--- a/deploy/base-crds/crds/selinuxpolicy.yaml
+++ b/deploy/base-crds/crds/selinuxpolicy.yaml
@@ -178,6 +178,11 @@ spec:
                   - name
                   type: object
                 type: array
+              permissive:
+                default: false
+                description: Permissive, when true will cause the SELinux profile
+                  to only log violations instead of enforcing them.
+                type: boolean
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -1854,6 +1854,11 @@ spec:
                   - name
                   type: object
                 type: array
+              permissive:
+                default: false
+                description: Permissive, when true will cause the SELinux profile
+                  to only log violations instead of enforcing them.
+                type: boolean
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1854,6 +1854,11 @@ spec:
                   - name
                   type: object
                 type: array
+              permissive:
+                default: false
+                description: Permissive, when true will cause the SELinux profile
+                  to only log violations instead of enforcing them.
+                type: boolean
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -1854,6 +1854,11 @@ spec:
                   - name
                   type: object
                 type: array
+              permissive:
+                default: false
+                description: Permissive, when true will cause the SELinux profile
+                  to only log violations instead of enforcing them.
+                type: boolean
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1854,6 +1854,11 @@ spec:
                   - name
                   type: object
                 type: array
+              permissive:
+                default: false
+                description: Permissive, when true will cause the SELinux profile
+                  to only log violations instead of enforcing them.
+                type: boolean
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -1925,6 +1925,11 @@ spec:
                   - name
                   type: object
                 type: array
+              permissive:
+                default: false
+                description: Permissive, when true will cause the SELinux profile
+                  to only log violations instead of enforcing them.
+                type: boolean
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -26,6 +26,7 @@
     - [Merging per-container profile instances](#merging-per-container-profile-instances)
 - [Create a SELinux Profile](#create-a-selinux-profile)
   - [Apply a SELinux profile to a pod](#apply-a-selinux-profile-to-a-pod)
+  - [Make a SELinux profile permissive](#make-a-selinux-profile-permissive)
   - [Record a SELinux profile](#record-a-selinux-profile)
 - [Restricting to a Single Namespace](#restricting-to-a-single-namespace)
   - [Restricting to a Single Namespace with upstream deployment manifests](#restricting-to-a-single-namespace-with-upstream-deployment-manifests)
@@ -849,6 +850,15 @@ spec:
 ```
 
 Note that the SELinux type must exist before creating the workload.
+
+### Make a SELinux profile permissive
+
+Similarly to how a `SeccompProfile` might have a default action `SCMP_ACT_LOG`
+which would merely log violations of the policy, but not actually block the
+container from executing, a `SelinuxProfile` can be marked as "permissive"
+by setting `.spec.permissive` to `true`. This mode might be useful e.g. when
+the policy is known or suspected to be incomplete and you'd prefer to just
+watch for subsequent AVC denials after deploying the policy.
 
 ### Record a SELinux profile
 

--- a/internal/pkg/translator/obj2cil.go
+++ b/internal/pkg/translator/obj2cil.go
@@ -26,6 +26,10 @@ import (
 	selxv1alpha2 "sigs.k8s.io/security-profiles-operator/api/selinuxprofile/v1alpha2"
 )
 
+const (
+	typePermissive = "(typepermissive process)"
+)
+
 func Object2CIL(
 	systemInherits []string,
 	objInherits []selxv1alpha2.SelinuxProfileObject,
@@ -38,6 +42,10 @@ func Object2CIL(
 	}
 	for _, inherit := range objInherits {
 		cilbuilder.WriteString(getCILInheritline(inherit.GetPolicyUsage()))
+	}
+	if sp.Spec.Permissive {
+		cilbuilder.WriteString(typePermissive)
+		cilbuilder.WriteString("\n")
 	}
 	for ttype, tclassMap := range sp.Spec.Allow {
 		for tclass, perms := range tclassMap {

--- a/internal/pkg/translator/obj2cil_test.go
+++ b/internal/pkg/translator/obj2cil_test.go
@@ -190,6 +190,75 @@ func TestObject2CIL(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Test errorlogger translation with permissive mode",
+			profile: &selxv1alpha2.SelinuxProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo-permissive",
+					Namespace: "bar",
+				},
+				Spec: selxv1alpha2.SelinuxProfileSpec{
+					Permissive: true,
+					Inherit: []selxv1alpha2.PolicyRef{
+						{
+							Name: "container",
+						},
+					},
+					Allow: selxv1alpha2.Allow{
+						"var_log_t": {
+							"dir": []string{
+								"open",
+								"read",
+								"getattr",
+								"lock",
+								"search",
+								"ioctl",
+								"add_name",
+								"remove_name",
+								"write",
+							},
+							"file": []string{
+								"getattr",
+								"read",
+								"write",
+								"append",
+								"ioctl",
+								"lock",
+								"map",
+								"open",
+								"create",
+							},
+							"sock_file": []string{
+								"getattr",
+								"read",
+								"write",
+								"append",
+								"open",
+							},
+						},
+					},
+				},
+			},
+			wantMatches: []string{
+				"\\(block foo-permissive_bar",
+				"\\(blockinherit container\\)",
+				"\\(typepermissive process\\)",
+				// We match on several lines since we don't care about the order
+				"\\(allow process var_log_t \\( dir \\(.*open.*\\)\\)\\)\n",
+				"\\(allow process var_log_t \\( dir \\(.*read.*\\)\\)\\)\n",
+				"\\(allow process var_log_t \\( dir \\(.*remove_name.*\\)\\)\\)\n",
+				"\\(allow process var_log_t \\( dir \\(.*write.*\\)\\)\\)\n",
+				"\\(allow process var_log_t \\( file \\(.*getattr.*\\)\\)\\)\n",
+				"\\(allow process var_log_t \\( file \\(.*map.*\\)\\)\\)\n",
+				"\\(allow process var_log_t \\( file \\(.*create.*\\)\\)\\)\n",
+				"\\(allow process var_log_t \\( sock_file \\(.*getattr.*\\)\\)\\)\n",
+				"\\(allow process var_log_t \\( sock_file \\(.*append.*\\)\\)\\)\n",
+				"\\(allow process var_log_t \\( sock_file \\(.*open.*\\)\\)\\)\n",
+			},
+			inheritsys: []string{
+				"container",
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -133,6 +133,11 @@ func (e *e2e) TestSecurityProfilesOperator() {
 		e.testCaseSelinuxProfileBindingNsNotEnabled()
 	})
 
+	e.Run("cluster-wide: Selinux: Verify the policy can be marked as permissive", func() {
+		e.testCaseSelinuxIncompletePolicy()
+		e.testCaseSelinuxIncompletePermissivePolicy()
+	})
+
 	e.Run("cluster-wide: Selinux: Verify SELinux profile recording logs", func() {
 		e.testCaseProfileRecordingStaticPodSELinuxLogs()
 		e.testCaseProfileRecordingMultiContainerSELinuxLogs()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
/kind api-change

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design

Optionally add one or more of the following kinds if applicable:
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Similarly to how seccomp profiles allow setting the default action to
LOG, let's allow the selinux profiles to be set to permissive mode. This
way, all calls would have still be allowed, but would appear in
audit.log.

This is useful in case the user is just iterating on a policy and wants
to deploy a first version of the policy in the wild without causing AVC
denials.


#### Which issue(s) this PR fixes:
Fixes #1269

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.


or

None
-->

#### Does this PR have test?
Yes

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
SELinux profiles gained a new attribute .spec.permissive which defaults to false. When set to true, the profile will
run in a permissive mode, that means that all actions would be allowed, but logged. This allows for a more iterative
approach for profile development.
```
