### PR TITLE
Add command argument to the daemon which allows to disable profile recorder controller

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -153,9 +153,10 @@ func main() {
 					Value: false,
 				},
 				&cli.BoolFlag{
-					Name:  recordingFlag,
-					Usage: "Listen for ProfileRecording API recources",
-					Value: false,
+					Name:    recordingFlag,
+					Usage:   "Listen for ProfileRecording API recources",
+					Value:   false,
+					EnvVars: []string{config.EnableRecordingEnvKey},
 				},
 			},
 		},

--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -66,6 +66,7 @@ import (
 
 const (
 	jsonFlag           string = "json"
+	recordingFlag      string = "with-recording"
 	selinuxFlag        string = "with-selinux"
 	apparmorFlag       string = "with-apparmor"
 	webhookFlag        string = "webhook"
@@ -149,6 +150,11 @@ func main() {
 				&cli.BoolFlag{
 					Name:  apparmorFlag,
 					Usage: "Listen for AppArmor API resources",
+					Value: false,
+				},
+				&cli.BoolFlag{
+					Name:  recordingFlag,
+					Usage: "Listen for ProfileRecording API recources",
 					Value: false,
 				},
 			},
@@ -379,7 +385,10 @@ func setControllerOptionsForNamespaces(opts *ctrl.Options) {
 func getEnabledControllers(ctx *cli.Context) []controller.Controller {
 	controllers := []controller.Controller{
 		seccompprofile.NewController(),
-		profilerecorder.NewController(),
+	}
+
+	if ctx.Bool(recordingFlag) {
+		controllers = append(controllers, profilerecorder.NewController())
 	}
 
 	if ctx.Bool(selinuxFlag) {

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -25,6 +25,7 @@
     - [Log enricher based recording](#log-enricher-based-recording)
     - [eBPF based recording](#ebpf-based-recording)
     - [Merging per-container profile instances](#merging-per-container-profile-instances)
+    - [Disable profile recording](#disable-profile-recording)
 - [Create a SELinux Profile](#create-a-selinux-profile)
   - [Apply a SELinux profile to a pod](#apply-a-selinux-profile-to-a-pod)
   - [Make a SELinux profile permissive](#make-a-selinux-profile-permissive)
@@ -767,6 +768,16 @@ including the `mknod` syscall:
 > kubectl get sp test-recording-nginx-record -o yaml | grep mknod
   - mknod
 ```
+
+#### Disable profile recording
+
+Profile recorder controller along with the corresponding sidecar container is disabled
+when neither `enableBpfRecorder` nor `enableLogEnricher` is set in the SPOD configuration, and
+automatically enabled when either one of them is on.
+
+Also, when running the daemon in standalone mode is possible to switch on the profile recorder
+controller by providing the `with-recording` command line argument or setting the `ENABLE_RECORDING`
+environment variable.
 
 ## Create a SELinux Profile
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -70,6 +70,9 @@ const (
 	// EnableLogEnricherEnvKey is the environment variable key for enabling the log enricher.
 	EnableLogEnricherEnvKey = "ENABLE_LOG_ENRICHER"
 
+	// EnableRecordingEnvKey is the environment variable key to enabeling profile recording.
+	EnableRecordingEnvKey = "ENABLE_RECORDING"
+
 	// VerboseLevel is the increased verbosity log level.
 	VerboseLevel = 1
 

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -499,6 +499,10 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 	useCustomHostProc := cfg.Spec.HostProcVolumePath != bindata.DefaultHostProcPath
 	volume, mount := bindata.CustomHostProcVolume(cfg.Spec.HostProcVolumePath)
 
+	// Disable profile recording controller by default
+	templateSpec.Containers[bindata.ContainerIDDaemon].Args = append(
+		templateSpec.Containers[bindata.ContainerIDDaemon].Args,
+		"--with-recording=false")
 	if cfg.Spec.EnableLogEnricher || cfg.Spec.EnableBpfRecorder {
 		if useCustomHostProc {
 			templateSpec.Volumes = append(templateSpec.Volumes, volume)

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -500,9 +500,7 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 	volume, mount := bindata.CustomHostProcVolume(cfg.Spec.HostProcVolumePath)
 
 	// Disable profile recording controller by default
-	templateSpec.Containers[bindata.ContainerIDDaemon].Args = append(
-		templateSpec.Containers[bindata.ContainerIDDaemon].Args,
-		"--with-recording=false")
+	enableRecording := false
 	if cfg.Spec.EnableLogEnricher || cfg.Spec.EnableBpfRecorder {
 		if useCustomHostProc {
 			templateSpec.Volumes = append(templateSpec.Volumes, volume)
@@ -513,10 +511,11 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 		templateSpec.HostPID = true
 
 		// Enable profile recording controller which is disabled by default
-		templateSpec.Containers[bindata.ContainerIDDaemon].Args = append(
-			templateSpec.Containers[bindata.ContainerIDDaemon].Args,
-			"--with-recording=true")
+		enableRecording = true
 	}
+	templateSpec.Containers[bindata.ContainerIDDaemon].Args = append(
+		templateSpec.Containers[bindata.ContainerIDDaemon].Args,
+		fmt.Sprintf("--with-recording=%t", enableRecording))
 
 	// Log enricher parameters. The spod setting takes precedence over the env var.
 	enableLogEnricherEnv, err := strconv.ParseBool(os.Getenv(config.EnableLogEnricherEnvKey))

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -507,6 +507,11 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 		// HostPID is required for the log-enricher and bpf recorder
 		// and is used to access cgroup files to map Process IDs to Pod IDs
 		templateSpec.HostPID = true
+
+		// Enable profile recording controller which is disabled by default
+		templateSpec.Containers[bindata.ContainerIDDaemon].Args = append(
+			templateSpec.Containers[bindata.ContainerIDDaemon].Args,
+			"--with-recording=true")
 	}
 
 	// Log enricher parameters. The spod setting takes precedence over the env var.

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -124,6 +124,10 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			"SPOD: Change webhook config",
 			e.testCaseWebhookOptionsChange,
 		},
+		{
+			"SPOD: Enable profile recorder",
+			e.testCaseSPODEnableProfileRecorder,
+		},
 	}
 	for _, testCase := range testCases {
 		tc := testCase

--- a/test/tc_enable_profile_recorder_test.go
+++ b/test/tc_enable_profile_recorder_test.go
@@ -34,7 +34,7 @@ func (e *e2e) testCaseSPODEnableProfileRecorder(nodes []string) {
 
 	e.logf("assert profile recorder is disabled in the spod DS when log enricher is disabled")
 	selinuxDisabledInSPODDS := e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
-	e.NotContains(selinuxDisabledInSPODDS, "--with-recording=false")
+	e.Contains(selinuxDisabledInSPODDS, "--with-recording=false")
 
 	e.enableBpfRecorderInSpod()
 	e.logf("assert profile recorder is enabled in the spod DS when bpf recorder is enabled")
@@ -50,5 +50,5 @@ func (e *e2e) testCaseSPODEnableProfileRecorder(nodes []string) {
 
 	e.logf("assert profile recorder is disabled in the spod DS when bpf recorder is disabled")
 	selinuxDisabledInSPODDS = e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
-	e.NotContains(selinuxDisabledInSPODDS, "--with-recording=false")
+	e.Contains(selinuxDisabledInSPODDS, "--with-recording=false")
 }

--- a/test/tc_enable_profile_recorder_test.go
+++ b/test/tc_enable_profile_recorder_test.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package e2e_test
 
-import "time"
-
 func (e *e2e) testCaseSPODEnableProfileRecorder(nodes []string) {
 	e.enableLogEnricherInSpod()
 
@@ -25,30 +23,8 @@ func (e *e2e) testCaseSPODEnableProfileRecorder(nodes []string) {
 	profileRecorderEnabledInSPODDS := e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
 	e.Contains(profileRecorderEnabledInSPODDS, "--with-recording=true")
 
-	e.logf("Disable log enricher from SPOD")
-	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableLogEnricher": false}}`, "--type=merge")
-
-	time.Sleep(defaultWaitTime)
-	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
-	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultBpfRecorderOpTimeout)
-
-	e.logf("assert profile recorder is disabled in the spod DS when log enricher is disabled")
-	selinuxDisabledInSPODDS := e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
-	e.Contains(selinuxDisabledInSPODDS, "--with-recording=false")
-
 	e.enableBpfRecorderInSpod()
 	e.logf("assert profile recorder is enabled in the spod DS when bpf recorder is enabled")
 	profileRecorderEnabledInSPODDS = e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
 	e.Contains(profileRecorderEnabledInSPODDS, "--with-recording=true")
-
-	e.logf("Disable bpf recorder from SPOD")
-	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableBpfRecorder": false}}`, "--type=merge")
-
-	time.Sleep(defaultWaitTime)
-	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
-	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultBpfRecorderOpTimeout)
-
-	e.logf("assert profile recorder is disabled in the spod DS when bpf recorder is disabled")
-	selinuxDisabledInSPODDS = e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
-	e.Contains(selinuxDisabledInSPODDS, "--with-recording=false")
 }

--- a/test/tc_enable_profile_recorder_test.go
+++ b/test/tc_enable_profile_recorder_test.go
@@ -30,6 +30,7 @@ func (e *e2e) testCaseSPODEnableProfileRecorder(nodes []string) {
 
 	time.Sleep(defaultWaitTime)
 	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultBpfRecorderOpTimeout)
 
 	e.logf("assert profile recorder is disabled in the spod DS when log enricher is disabled")
 	selinuxDisabledInSPODDS := e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
@@ -45,6 +46,7 @@ func (e *e2e) testCaseSPODEnableProfileRecorder(nodes []string) {
 
 	time.Sleep(defaultWaitTime)
 	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultBpfRecorderOpTimeout)
 
 	e.logf("assert profile recorder is disabled in the spod DS when bpf recorder is disabled")
 	selinuxDisabledInSPODDS = e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")

--- a/test/tc_enable_profile_recorder_test.go
+++ b/test/tc_enable_profile_recorder_test.go
@@ -16,6 +16,10 @@ limitations under the License.
 
 package e2e_test
 
+import (
+	"time"
+)
+
 func (e *e2e) testCaseSPODEnableProfileRecorder(nodes []string) {
 	e.enableLogEnricherInSpod()
 
@@ -23,8 +27,14 @@ func (e *e2e) testCaseSPODEnableProfileRecorder(nodes []string) {
 	profileRecorderEnabledInSPODDS := e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
 	e.Contains(profileRecorderEnabledInSPODDS, "--with-recording=true")
 
-	e.enableBpfRecorderInSpod()
-	e.logf("assert profile recorder is enabled in the spod DS when bpf recorder is enabled")
-	profileRecorderEnabledInSPODDS = e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
-	e.Contains(profileRecorderEnabledInSPODDS, "--with-recording=true")
+	e.logf("Disable log enricher from SPOD")
+	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableLogEnricher": false}}`, "--type=merge")
+
+	time.Sleep(defaultWaitTime)
+	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultBpfRecorderOpTimeout)
+
+	e.logf("assert profile recorder is disabled in the spod DS when log enricher is disabled")
+	selinuxDisabledInSPODDS := e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
+	e.Contains(selinuxDisabledInSPODDS, "--with-recording=false")
 }

--- a/test/tc_enable_profile_recorder_test.go
+++ b/test/tc_enable_profile_recorder_test.go
@@ -16,25 +16,10 @@ limitations under the License.
 
 package e2e_test
 
-import (
-	"time"
-)
-
 func (e *e2e) testCaseSPODEnableProfileRecorder(nodes []string) {
 	e.enableLogEnricherInSpod()
 
 	e.logf("assert profile recorder is enabled in the spod DS when log enricher is enabled")
 	profileRecorderEnabledInSPODDS := e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
 	e.Contains(profileRecorderEnabledInSPODDS, "--with-recording=true")
-
-	e.logf("Disable log enricher from SPOD")
-	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableLogEnricher": false}}`, "--type=merge")
-
-	time.Sleep(defaultWaitTime)
-	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
-	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultBpfRecorderOpTimeout)
-
-	e.logf("assert profile recorder is disabled in the spod DS when log enricher is disabled")
-	selinuxDisabledInSPODDS := e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
-	e.Contains(selinuxDisabledInSPODDS, "--with-recording=false")
 }

--- a/test/tc_enable_profile_recorder_test.go
+++ b/test/tc_enable_profile_recorder_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2022 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import "time"
+
+func (e *e2e) testCaseSPODEnableProfileRecorder(nodes []string) {
+	e.enableLogEnricherInSpod()
+
+	e.logf("assert profile recorder is enabled in the spod DS when log enricher is enabled")
+	profileRecorderEnabledInSPODDS := e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
+	e.Contains(profileRecorderEnabledInSPODDS, "--with-recording=true")
+
+	e.logf("Disable log enricher from SPOD")
+	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableLogEnricher": false}}`, "--type=merge")
+
+	time.Sleep(defaultWaitTime)
+	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+
+	e.logf("assert profile recorder is disabled in the spod DS when log enricher is disabled")
+	selinuxDisabledInSPODDS := e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
+	e.NotContains(selinuxDisabledInSPODDS, "--with-recording=false")
+
+	e.enableBpfRecorderInSpod()
+	e.logf("assert profile recorder is enabled in the spod DS when bpf recorder is enabled")
+	profileRecorderEnabledInSPODDS = e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
+	e.Contains(profileRecorderEnabledInSPODDS, "--with-recording=true")
+
+	e.logf("Disable bpf recorder from SPOD")
+	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableBpfRecorder": false}}`, "--type=merge")
+
+	time.Sleep(defaultWaitTime)
+	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+
+	e.logf("assert profile recorder is disabled in the spod DS when bpf recorder is disabled")
+	selinuxDisabledInSPODDS = e.kubectlOperatorNS("get", "ds", "spod", "-o", "yaml")
+	e.NotContains(selinuxDisabledInSPODDS, "--with-recording=false")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

This PR adds an command argument to the daemon which allows to disable the profile recorder controller when neither bpf-recorder or log-enricher are enabled. 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add a command argument to the daemon which allows to disable the profile recorder controller.
```
