### PR TITLE
Fix flaky unit test which check the default operator namespace

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,9 @@ issues:
     - linters:
         - lll
       source: "^//go:generate " # exclude lll issues for long lines with go:generate
+    - linters:
+        - paralleltest
+      path: internal/pkg/config/config_test.go
 linters:
   disable-all: true
   enable:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2961,8 +2961,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: security-profiles-operator:latest
-        imagePullPolicy: Never
+        image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
+        imagePullPolicy: Always
         name: security-profiles-operator
         resources:
           limits:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2961,8 +2961,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
-        imagePullPolicy: Always
+        image: security-profiles-operator:latest
+        imagePullPolicy: Never
         name: security-profiles-operator
         resources:
           limits:

--- a/internal/pkg/config/config_test.go
+++ b/internal/pkg/config/config_test.go
@@ -17,12 +17,12 @@ limitations under the License.
 package config
 
 import (
-	"os"
 	"testing"
 )
 
 func TestGetOperatorNamespace(t *testing.T) {
-	t.Parallel()
+	// Note: this test cannot run in parallel because environment variables
+	// are global resulting in random failures.
 	tests := []struct {
 		name    string
 		want    string
@@ -42,12 +42,7 @@ func TestGetOperatorNamespace(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			if tt.wantErr {
-				os.Unsetenv("OPERATOR_NAMESPACE")
-			} else {
-				os.Setenv("OPERATOR_NAMESPACE", tt.want)
-			}
+			t.Setenv("OPERATOR_NAMESPACE", tt.want)
 			got, err := TryToGetOperatorNamespace()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetOperatorNamespace() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test 

#### What this PR does / why we need it:

This unit test cannot run in parallel because environment variables are global causing random failures. This happens because one test case invalidates the other.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix flaky unit test which checks default operator namespace.
```
