### PR TITLE
apparmor: Add log-enricher support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,6 +77,7 @@ ifeq ($(BPF_ENABLED), 1)
 CGO_LDFLAGS := $(CGO_LDFLAGS) -lelf -lz -lbpf
 else
 BUILDTAGS := $(BUILDTAGS) no_bpf
+LINT_BUILDTAGS := $(LINT_BUILDTAGS),no_bpf
 endif
 
 export CGO_LDFLAGS

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Here's the feature parity status across them:
 |----------------------------------|---------|---------|----------|
 |                      Profile CRD |   Yes   |   Yes   |    Yes   |
 |                   ProfileBinding |   Yes   |   No    |    No    |
-|       Deploy profiles into nodes |   Yes   |   Yes   |    WIP   |
-| Remove profiles no longer in use |   Yes   |   Yes   |    WIP   |
+|       Deploy profiles into nodes |   Yes   |   Yes   |    Yes   |
+| Remove profiles no longer in use |   Yes   |   Yes   |    Yes   |
 |   Profile Auto-generation (logs) |   Yes   |   WIP   |    No    |
 |   Profile Auto-generation (ebpf) |   Yes   |   No    |    No    |
 |             Audit log enrichment |   Yes   |   WIP   |    Yes   |

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -1505,6 +1505,16 @@ defined within `spec.policy`. Otherwise the reconciler will fail as it
 won't be able to confirm the policy was correctly loaded.
 - The reconciler will simply load the profiles across the cluster. If an
 existing profile with the same name exists, it will be replaced.
+- The SPO does not validate the profile contents. Invalid profiles
+will error when loading into the kernel. The error can be found on the spod
+pod and the message will roughly look like:
+```
+E1112 08:35:24.072544    8668 controller.go:326]  "msg"="Reconciler error" "error"="cannot load profile into node: running action: exit status 1" "appArmorProfile"={"name":"<NAME_OF_PROFILE>","namespace":"security-profiles-operator"} "controller"="apparmorprofile" "controllerGroup"="security-profiles-operator.x-k8s.io" "controllerKind"="AppArmorProfile" "name"="<NAME_OF_PROFILE>" "namespace"="security-profiles-operator" "reconcileID"="035a4edd-cdd9-4c35-a1be-924939538ce4"
+```.
+- Restrictive profiles may block sub processes to be created, or a container from
+successfully loading. In such cases, the denied rules may not show up in the
+log-enricher logs, as SPO may fail to find the running process to correlate to the
+pod information. To work around the issue, set the AppArmor profile to complain mode.
 
 ## Uninstalling
 

--- a/internal/pkg/daemon/enricher/types/types.go
+++ b/internal/pkg/daemon/enricher/types/types.go
@@ -17,8 +17,9 @@ limitations under the License.
 package types
 
 const (
-	AuditTypeSeccomp = "seccomp"
-	AuditTypeSelinux = "selinux"
+	AuditTypeSeccomp  = "seccomp"
+	AuditTypeSelinux  = "selinux"
+	AuditTypeApparmor = "apparmor"
 )
 
 type AuditLine struct {
@@ -37,6 +38,17 @@ type AuditLine struct {
 	Tcontext string
 	Tclass   string
 	Perm     string
+
+	// apparmor
+	Apparmor  string
+	Operation string
+	// Profile is the name of the AppArmor profile under which the operation took place.
+	Profile string
+	// Name is what the operation wanted to access.
+	Name string
+	// ExtraInfo may contain addition information such as:
+	// requested_mask, denied_mask, fsuid=65534, ouid and target.
+	ExtraInfo string
 }
 
 type ContainerInfo struct {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
As part of making AppArmor a first class citizen within SPO, the log enrichment features needs to be improved, so that user can have a better view of AppArmor operations across the cluster.

##### Show AppArmor profiles being reloaded
What pod loaded a new or replaced an existing AppArmor into the node:
```
I1112 09:12:13.236328   10696 enricher.go:514] log-enricher "msg"="audit" "apparmor"="STATUS" "container"="security-profiles-operator" "executable"="security-profil" "name"="flux-controllers" "namespace"="security-profiles-operator" "node"="kube-worker1" "operation"="profile_replace" "pid"=10591 "pod"="spod-hgxd7" "profile"="unconfined" "timestamp"="1668244333.228:485" "type"="apparmor"
```

##### Normal AppArmor Entries
Entries include `extra` to expand on additional information:
```
I1112 09:14:23.418753   14721 enricher.go:514] log-enricher "msg"="audit" "apparmor"="ALLOWED" "container"="manager" "executable"="ash" "extra"="requested_mask='r' denied_mask='r' fsuid=65534 ouid=0" "name"="/dev/tty" "namespace"="flux-system" "node"="kube-worker2" "operation"="open" "pid"=15860 "pod"="target-pod-7f69cdb69d-lw8bd" "profile"="complain-mmode-profile" "timestamp"="1668244463.390:2224" "type"="apparmor"
```

#### Which issue(s) this PR fixes:

Relates to https://github.com/kubernetes-sigs/security-profiles-operator/issues/718

#### Does this PR have test?

Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Log-enricher support for both short and long AppArmor log entries
```
