### PR TITLE
build: Bump kube-rbac-proxy to v0.13.1

### DIFF
--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -427,7 +427,7 @@ spec:
                 - manager
                 env:
                 - name: RELATED_IMAGE_RBAC_PROXY
-                  value: quay.io/brancz/kube-rbac-proxy:v0.11.0
+                  value: quay.io/brancz/kube-rbac-proxy:v0.13.1
                 - name: RELATED_IMAGE_SELINUXD
                   value: quay.io/security-profiles-operator/selinuxd
                 - name: OPERATOR_NAMESPACE
@@ -504,7 +504,7 @@ spec:
     name: Kubernetes SIGs
     url: https://github.com/kubernetes-sigs
   relatedImages:
-  - image: quay.io/brancz/kube-rbac-proxy:v0.11.0
+  - image: quay.io/brancz/kube-rbac-proxy:v0.13.1
     name: rbac-proxy
   - image: quay.io/security-profiles-operator/selinuxd
     name: selinuxd

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -110,7 +110,7 @@ dependencies:
       match: NIX_VERSION
 
   - name: kube-rbac-proxy
-    version: 0.13.0
+    version: 0.13.1
     refPaths:
     - path: internal/pkg/manager/spod/bindata/spod.go
       match: quay.io/brancz/kube-rbac-proxy

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - manager
         env:
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: quay.io/brancz/kube-rbac-proxy:v0.11.0
+          value: quay.io/brancz/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE

--- a/deploy/kustomize-deployment/manager_deployment.yaml
+++ b/deploy/kustomize-deployment/manager_deployment.yaml
@@ -35,7 +35,7 @@ spec:
               memory: 128Mi
           env:
             - name: RELATED_IMAGE_RBAC_PROXY
-              value: quay.io/brancz/kube-rbac-proxy:v0.11.0
+              value: quay.io/brancz/kube-rbac-proxy:v0.13.1
             - name: RELATED_IMAGE_SELINUXD
               value: quay.io/security-profiles-operator/selinuxd
             - name: OPERATOR_NAMESPACE

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2929,7 +2929,7 @@ spec:
         - name: RESTRICT_TO_NAMESPACE
           value: NS_REPLACE
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: quay.io/brancz/kube-rbac-proxy:v0.11.0
+          value: quay.io/brancz/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -2927,7 +2927,7 @@ spec:
         - manager
         env:
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: quay.io/brancz/kube-rbac-proxy:v0.11.0
+          value: quay.io/brancz/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2927,7 +2927,7 @@ spec:
         - manager
         env:
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: quay.io/brancz/kube-rbac-proxy:v0.11.0
+          value: quay.io/brancz/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -2927,7 +2927,7 @@ spec:
         - --webhook=false
         env:
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: quay.io/brancz/kube-rbac-proxy:v0.11.0
+          value: quay.io/brancz/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -53,7 +53,7 @@ const (
 	SelinuxdPrivateDir                         = "/var/run/selinuxd"
 	SelinuxdSocketPath                         = SelinuxdPrivateDir + "/selinuxd.sock"
 	SelinuxdDBPath                             = SelinuxdPrivateDir + "/selinuxd.db"
-	MetricsImage                               = "quay.io/brancz/kube-rbac-proxy:v0.13.0"
+	MetricsImage                               = "quay.io/brancz/kube-rbac-proxy:v0.13.1"
 	sysKernelDebugPath                         = "/sys/kernel/debug"
 	InitContainerIDNonRootenabler              = 0
 	InitContainerIDSelinuxSharedPoliciesCopier = 1


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Bump kube-rbac-proxy version to patch 18 of its 20 CVEs. Once applied, the CVEs left will be CVE-2022-32149 and GHSA-69ch-w2m2-3vjp.
![image](https://user-images.githubusercontent.com/5452977/201476229-29c8cd21-9a13-439f-b876-30321ba7566f.png)

https://artifacthub.io/packages/olm/community-operators/security-profiles-operator?modal=security-report

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
