### PR TITLE
make: Add an option to produce a dynamic build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,11 +91,18 @@ GO_PROJECT := sigs.k8s.io/$(PROJECT)
 LDVARS := \
 	-X $(GO_PROJECT)/internal/pkg/version.buildDate=$(BUILD_DATE) \
 	-X $(GO_PROJECT)/internal/pkg/version.version=$(VERSION)
+STATIC_LINK ?= yes
+ifeq ($(STATIC_LINK), yes)
+  EXTLDFLAGS := -extldflags "-static"
+else
+  EXTLDFLAGS :=
+endif
+
 LINKMODE_EXTERNAL ?= yes
 ifeq ($(LINKMODE_EXTERNAL), yes)
-  LDFLAGS := -s -w -linkmode external -extldflags "-static" $(LDVARS)
+  LDFLAGS := -s -w -linkmode external $(EXTLDFLAGS) $(LDVARS)
 else
-  LDFLAGS := -s -w -extldflags "-static" $(LDVARS)
+  LDFLAGS := -s -w $(EXTLDFLAGS) $(LDVARS)
 endif
 
 export CONTAINER_RUNTIME ?= $(if $(shell which podman 2>/dev/null),podman,docker)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
(I guess?)

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
OCP does not compile the binaries it runs with upstream go, but rather a
fork of go that uses OpenSSL for cryptography:
    https://github.com/golang-fips

This fork uses `dlopen()` on startup to load symbols that correspond to
the crypto functions:
    https://github.com/golang-fips/openssl-fips/blob/b9297ed11fc8890f74822482c46f4c9cb5507251/openssl/openssl.go#L53
    https://github.com/golang-fips/openssl-fips/blob/eeda1baae76c92112220de78c5a498a6ba0abb6b/openssl/goopenssl.h#L66-L72

For some reason, this dlopen initialization does to work well for SPO on
OpenShift clusters running in FIPS mode where the dlopen call just
segfaults:
```
(gdb) frame 0
"libcrypto.so.1.1") at dlopen.c:78
78          return _dlfcn_hook->dlopen (file, mode, DL_CALLER);
(gdb) p _dlfcn_hook
$1 = (struct dlfcn_hook *) 0x0
(gdb) list
73      void *
74      __dlopen (const char *file, int mode DL_CALLER_DECL)
75      {
76      # ifdef SHARED
77        if (!rtld_active ())
78          return _dlfcn_hook->dlopen (file, mode, DL_CALLER);
79      # endif
80
81        struct dlopen_args args;
82        args.file = file;
```

To work around this issue, this patch adds the option to compile SPO as
a dynamically linked executable.

Please see https://issues.redhat.com/browse/OCPBUGS-3431 for more
details.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
No, but I did test this PR on an OCP 4.12 cluster with FIPS enabled.

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
