### PR TITLE
workloadannotator: Prevent crash with non-operator seccomp profiles set in annotation

### DIFF
--- a/internal/pkg/manager/workloadannotator/workloadannotator_test.go
+++ b/internal/pkg/manager/workloadannotator/workloadannotator_test.go
@@ -110,6 +110,47 @@ func TestGetSeccompProfilesFromPod(t *testing.T) {
 			want: []string{profilePath},
 		},
 		{
+			name: "SeccompProfileRuntimeDefaultForPod",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "container1", Image: "testimage"}},
+					SecurityContext: &corev1.PodSecurityContext{
+						SeccompProfile: &corev1.SeccompProfile{
+							Type: "RuntimeDefault",
+						},
+					},
+				},
+			},
+			want: []string{},
+		},
+		{
+			name: "SeccompProfileLocalhostNoSlash",
+			pod: corev1.Pod{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "container1", Image: "testimage"}},
+					SecurityContext: &corev1.PodSecurityContext{
+						SeccompProfile: &corev1.SeccompProfile{
+							Type:             "Localhost",
+							LocalhostProfile: &[]string{"mariadb-seccomp-profile.json"}[0],
+						},
+					},
+				},
+			},
+			want: []string{},
+		},
+		{
+			name: "SeccompProfileInAnnotationNoSlash",
+			pod: corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{corev1.SeccompPodAnnotationKey: "localhost/mariadb-seccomp-profile.json"},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "container1", Image: "testimage"}},
+				},
+			},
+			want: []string{},
+		},
+		{
 			name: "SeccompProfileInPodAndContainerAndAnnotation",
 			pod: corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We would check if the seccomp profile set in the pod or its containers
are owned by the operator, but we did not do the same check for profiles
coming through the annotation. If such annotation existed, the workload
annotator would have attempted to parse it, the returned slice would not
have the expected number of elements which would crash the workload
annotator.


#### Which issue(s) this PR fixes:
Fixes #990

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.


or

None
-->

#### Does this PR have test?
Yes

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
I'll point some inline

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
