### PR TITLE
Add `replaces` and `containerImage` to operator manifest

### DIFF
--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -98,6 +98,7 @@ metadata:
       ]
     capabilities: Basic Install
     categories: Security
+    containerImage: registry.k8s.io/security-profiles-operator/security-profiles-operator:v0.6.0
     olm.skipRange: '>=0.4.1 <0.6.1-dev'
     operatorframework.io/suggested-namespace: security-profiles-operator
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift
@@ -514,4 +515,5 @@ spec:
     name: rbac-proxy
   - image: quay.io/security-profiles-operator/selinuxd
     name: selinuxd
+  replaces: security-profiles-operator.v0.5.0
   version: 0.6.1-dev

--- a/deploy/base/clusterserviceversion.yaml
+++ b/deploy/base/clusterserviceversion.yaml
@@ -6,6 +6,7 @@ metadata:
     alm-examples: '[]'
     capabilities: Basic Install
     categories: Security
+    containerImage: registry.k8s.io/security-profiles-operator/security-profiles-operator:v0.6.0
     olm.skipRange: '>=0.4.1 <0.4.2-dev'
     operatorframework.io/suggested-namespace: security-profiles-operator
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
@@ -87,4 +88,5 @@ spec:
   provider:
     name: Kubernetes SIGs
     url: https://github.com/kubernetes-sigs
+  replaces: security-profiles-operator.v0.5.0
   version: 0.0.0

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -56,4 +56,14 @@ for FILE in "${FILES[@]}"; do
     sed -i "s;$PREVIOUS_VERSION;$VERSION;g" "$FILE"
 done
 
+# Update operatorhub replacement
+FILE=deploy/base/clusterserviceversion.yaml
+OPERATOR_VERSION=$(curl -sSfL --retry 5 --retry-delay 3 "https://operatorhub.io/api/operator?packageName=security-profiles-operator" |
+    jq -r .operator.name)
+sed -i 's;replaces:.*;replaces: '"$OPERATOR_VERSION"';g' $FILE
+sed -i 's;containerImage:.*;containerImage: registry.k8s.io/security-profiles-operator/security-profiles-operator:v'"$VERSION"';g' $FILE
+
+# Build bundle
 make bundle
+
+echo "Done. Commit the changes to a new branch and create a PR from it"

--- a/release.md
+++ b/release.md
@@ -17,7 +17,7 @@ The script basically:
   [./deploy/kustomize-deployment/kustomization.yaml](deploy/kustomize-deployment/kustomization.yaml)
   from `gcr.io/k8s-staging-sp-operator/security-profiles-operator` to
   `registry.k8s.io/security-profiles-operator/security-profiles-operator` (`newName`) and the
-  corresponding tag (`newTag`). After that the make target `make bundle`
+  corresponding tag (`newTag`).
   has to be run and the changes have to be committed.
 - changes the `image` in the `CatalogSource` in the same way at
   [./examples/olm/install-resources.yaml](/examples/olm/install-resources.yaml)
@@ -29,6 +29,10 @@ The script basically:
 - updates [./dependencies.yaml](./dependencies.yaml) `spo-current` version as
   well as its linked files. Run `make verify-dependencies` to verify the
   results.
+- updates [./deploy/base/clusterserviceversion.yaml](./deploy/base/clusterserviceversion.yaml)
+  to change `replaces` to the latest available version on OperatorHub as well as
+  update the `containerImage`.
+- runs `make bundle`
 
 Create a new PR from the proposed changes and wait for the CI to succeed.
 


### PR DESCRIPTION

#### What type of PR is this?

/kind documentation


#### What this PR does / why we need it:
We now also update the release process to automatically adjust those versions.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Automatically adding `replaces` and `containerImage` to OperatorHub manifest bundle.
```
