### PR TITLE
 Configure the Selinux type tag when the AppArmor is disabled regardless of EnableSelinux flag

### DIFF
--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -592,8 +592,12 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 		// Set the logging verbosity
 		templateSpec.InitContainers[i].Env = append(templateSpec.InitContainers[i].Env, verbosityEnv(cfg.Spec.Verbosity))
 
-		// Update the SELinux type tag when is defined in the configuration
-		if cfg.Spec.EnableSelinux != nil && *cfg.Spec.EnableSelinux {
+		// Update the SELinux type tag only when AppArmor is not enabled this is to prevent a crash.
+		// The SELinux type tag needs to be configured independent of EnableSelinux flag, because the
+		// SELinux can be active on the node regardless if the SELinux feature is enabled or not in the operator.
+		// For instance, on Flatcar Linux SELinux type tag needs to be set to 'unconfined_t' instead of 'spc_t'
+		// even though SELinux is disabled in order to get the containers to start.
+		if !cfg.Spec.EnableAppArmor {
 			configureSeLinuxTag(templateSpec.InitContainers[i].SecurityContext, cfg.Spec.SelinuxTypeTag)
 		}
 	}
@@ -613,8 +617,12 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 		if cfg.Spec.EnableProfiling {
 			enableContainerProfiling(templateSpec, i)
 		}
-		// Update the SELinux type tag when is defined in the configuration
-		if cfg.Spec.EnableSelinux != nil && *cfg.Spec.EnableSelinux {
+		// Update the SELinux type tag only when AppArmor is not enabled this is to prevent a crash.
+		// The SELinux type tag needs to be configured independent of EnableSelinux flag, because the
+		// SELinux can be active on the node regardless if the SELinux feature is enabled or not in the operator.
+		// For instance, on Flatcar Linux SELinux type tag needs to be set to 'unconfined_t' instead of 'spc_t'
+		// even though SELinux is disabled in order to get the containers to start.
+		if !cfg.Spec.EnableAppArmor {
 			configureSeLinuxTag(templateSpec.Containers[i].SecurityContext, cfg.Spec.SelinuxTypeTag)
 		}
 	}

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -491,7 +491,7 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 	if enableSelinux {
 		templateSpec.InitContainers = append(
 			templateSpec.InitContainers,
-			r.baseSPOd.Spec.Template.Spec.InitContainers[bindata.ContainerIDSelinuxd])
+			r.baseSPOd.Spec.Template.Spec.InitContainers[bindata.InitContainerIDSelinuxSharedPoliciesCopier])
 		templateSpec.Containers = append(
 			templateSpec.Containers,
 			r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDSelinuxd])


### PR DESCRIPTION
- Configure the Selinux type tag when the AppArmor is disabled regardless of EnableSelinux flag
- Use the proper init container ID to avoid confusion

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug 

#### What this PR does / why we need it:

This introduced a regression on Flatcar Linux. The SELinux type tag needs to be configured independent of EnableSelinux flag, because the SELinux can be active on the node regardless if the SELinux feature is enabled or not in the operator.
For instance, on Flatcar Linux SELinux type tag needs to be set to 'unconfined_t' instead of 'spc_t'
even though SELinux is disabled in order to get the containers to start.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Configure the Selinux type tag when the AppArmor is disabled regardless of EnableSelinux flag.
```
