### PR TITLE
Dockerfile.ubi: Work around krb5-libs CVE until the UBI image is refreshed

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -37,9 +37,12 @@ ARG STATIC_LINK=no
 RUN make
 
 # hash below referred to latest
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:33931dce809712888d1a8061bfa676963f517daca993984afed3251bc1fb5987
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:4ed971a5564d2cfedf750793da53ef6f1fdf295263f1cc31d703aa8acf6d02cf
 ARG version
 USER root
+
+# Temporary until UBI is upgraded to make Trivy happy
+RUN microdnf upgrade -y krb5-libs
 
 RUN microdnf install -y \
         libseccomp

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -105,6 +105,18 @@ dependencies:
     - path: Dockerfile.build-image
       match: registry.k8s.io/build-image/debian-base
 
+  - name: ubi8-minimal
+    version: sha256:4ed971a5564d2cfedf750793da53ef6f1fdf295263f1cc31d703aa8acf6d02cf
+    refPaths:
+    - path: Dockerfile.ubi
+      match: registry.access.redhat.com/ubi8/ubi-minimal
+
+  - name: ubi8-go-toolset
+    version: sha256:5c33798716db98ce485d606451bef1dd7a6eb3b1422a67cbd10eacc870eb2de5
+    refPaths:
+    - path: Dockerfile.ubi
+      match: registry.access.redhat.com/ubi8/go-toolset
+
   - name: nix
     version: 2.9.2
     refPaths:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The current version of Dockerfile.ubi is vulnerable against
CVE-2022-42898, according to
https://catalog.redhat.com/software/containers/ubi8-minimal/
and also a quick local test.

Until an updated image is released, let's upgrade the version directly in
the Dockerfile to make security scanners happy.

#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
Implicit through GH actions

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
I haven't linked issue #1340 explicitly because we still want the image
to be bumped.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
