### PR TITLE
profilerecorder: Don't issue seccomp events for recording of any profile

### DIFF
--- a/internal/pkg/daemon/profilerecorder/profilerecorder.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder.go
@@ -65,10 +65,10 @@ const (
 
 	errInvalidAnnotation = "invalid Annotation"
 
-	reasonProfileRecording      string = "SeccompProfileRecording"
-	reasonProfileCreated        string = "SeccompProfileCreated"
-	reasonProfileCreationFailed string = "CannotCreateSeccompProfile"
-	reasonAnnotationParsing     string = "SeccompAnnotationParsing"
+	reasonProfileRecording      string = "ProfileRecording"
+	reasonProfileCreated        string = "ProfileCreated"
+	reasonProfileCreationFailed string = "CannotCreateProfile"
+	reasonAnnotationParsing     string = "AnnotationParsing"
 
 	seContextRequiredParts = 3
 )


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
We would issue an event with Seccomp in the event name even when
recording SELinux. Let's use profile-agnostic event names instead.

The alternative would be to have a different even for each profile type. I'm
not sure myself which is better.

#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

-->

#### Does this PR have test?
No

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
