### PR TITLE
Add `verify-format` target to reformat proto and c files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,159 @@
+---
+Language:        Cpp
+AccessModifierOffset: -3
+AlignAfterOpenBracket: Align
+AlignArrayOfStructures: None
+AlignConsecutiveMacros: None
+AlignConsecutiveAssignments: None
+AlignConsecutiveBitFields: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments: true
+AllowAllArgumentsOnNextLine: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortEnumsOnASingleLine: true
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: None
+AllowShortLambdasOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterCaseLabel:  false
+  AfterClass:      false
+  AfterControlStatement: Never
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  true
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  AfterExternBlock: false
+  BeforeCatch:     false
+  BeforeElse:      false
+  BeforeLambdaBody: false
+  BeforeWhile:     false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: true
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: true
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeColon
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeColon
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+QualifierAlignment: Leave
+CompactNamespaces: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DeriveLineEnding: true
+DerivePointerAlignment: false
+DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
+ExperimentalAutoDetectBinPacking: false
+PackConstructorInitializers: NextLine
+BasedOnStyle:    LLVM
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+AllowAllConstructorInitializersOnNextLine: true
+FixNamespaceComments: true
+IncludeBlocks:   Preserve
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseLabels: true
+IndentCaseBlocks: false
+IndentGotoLabels: true
+IndentPPDirectives: None
+IndentExternBlock: AfterExternBlock
+IndentRequires:  false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+InsertTrailingCommas: None
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: Signature
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PenaltyIndentedWhitespace: 0
+PointerAlignment: Middle
+PPIndentWidth:   -1
+ReferenceAlignment: Pointer
+ReflowComments:  true
+RemoveBracesLLVM: false
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SortIncludes:    CaseSensitive
+SortJavaStaticImport: Before
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  BeforeNonEmptyParentheses: false
+SpaceAroundPointerQualifiers: Default
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyBlock: false
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  Never
+SpacesInConditionalStatement: false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+SpaceBeforeSquareBrackets: false
+BitFieldColonSpacing: Both
+Standard:        Auto
+TabWidth:        4
+UseCRLF:         false
+UseTab:          Never
+---
+Language: Proto

--- a/Makefile
+++ b/Makefile
@@ -299,7 +299,7 @@ update-bpf: $(BUILD_DIR) ## Build and update all generated BPF code with nix
 # Verification targets
 
 .PHONY: verify
-verify: verify-boilerplate verify-go-mod verify-go-lint verify-deployments verify-dependencies verify-toc verify-mocks ## Run all verification targets
+verify: verify-boilerplate verify-go-mod verify-go-lint verify-deployments verify-dependencies verify-toc verify-mocks verify-format ## Run all verification targets
 
 .PHONY: verify-in-a-container
 verify-in-a-container: ## Run all verification targets in a container
@@ -389,6 +389,11 @@ verify-bpf: update-bpf ## Verify the generated bpf code
 .PHONY: verify-btf
 verify-btf: update-btf ## Verify the generated btf code
 	git diff
+
+.PHONY: verify-format
+verify-format: ## Verify the code format
+	clang-format -i $(shell find . -type f -name '*.c' -or -name '*.proto' | grep -v ./vendor)
+	hack/tree-status
 
 # Test targets
 

--- a/api/grpc/bpfrecorder/api.proto
+++ b/api/grpc/bpfrecorder/api.proto
@@ -20,19 +20,17 @@ package api_bpfrecorder;
 option go_package = "/api_bpfrecorder";
 
 service BpfRecorder {
-    rpc Start(EmptyRequest) returns (EmptyResponse) {}
-    rpc Stop(EmptyRequest) returns (EmptyResponse) {}
-    rpc SyscallsForProfile(ProfileRequest) returns (SyscallsResponse) {}
+  rpc Start(EmptyRequest) returns (EmptyResponse) {}
+  rpc Stop(EmptyRequest) returns (EmptyResponse) {}
+  rpc SyscallsForProfile(ProfileRequest) returns (SyscallsResponse) {}
 }
 
 message EmptyRequest {}
 message EmptyResponse {}
 
-message ProfileRequest {
-    string name = 1;
-}
+message ProfileRequest { string name = 1; }
 
 message SyscallsResponse {
-    repeated string syscalls = 1;
-    string go_arch = 2;
+  repeated string syscalls = 1;
+  string go_arch = 2;
 }

--- a/api/grpc/enricher/api.proto
+++ b/api/grpc/enricher/api.proto
@@ -20,33 +20,29 @@ package api_enricher;
 option go_package = "/api_enricher";
 
 service Enricher {
-    rpc Syscalls(SyscallsRequest) returns (SyscallsResponse) {}
-    rpc ResetSyscalls(SyscallsRequest) returns (EmptyResponse) {}
-    rpc Avcs(AvcRequest) returns (AvcResponse) {}
-    rpc ResetAvcs(AvcRequest) returns (EmptyResponse) {}
+  rpc Syscalls(SyscallsRequest) returns (SyscallsResponse) {}
+  rpc ResetSyscalls(SyscallsRequest) returns (EmptyResponse) {}
+  rpc Avcs(AvcRequest) returns (AvcResponse) {}
+  rpc ResetAvcs(AvcRequest) returns (EmptyResponse) {}
 }
 
-message SyscallsRequest {
-    string profile = 1;
-}
+message SyscallsRequest { string profile = 1; }
 
 message SyscallsResponse {
-    repeated string syscalls = 1;
-    string go_arch = 2;
+  repeated string syscalls = 1;
+  string go_arch = 2;
 }
 
-message AvcRequest {
-    string profile = 1;
-}
+message AvcRequest { string profile = 1; }
 
 message AvcResponse {
-    message SelinuxAvc {
-        string perm = 1;
-        string scontext = 2;
-        string tcontext = 3;
-        string tclass = 4;
-    }
-    repeated SelinuxAvc avc = 1;
+  message SelinuxAvc {
+    string perm = 1;
+    string scontext = 2;
+    string tcontext = 3;
+    string tclass = 4;
+  }
+  repeated SelinuxAvc avc = 1;
 }
 
 message EmptyResponse {}

--- a/api/grpc/metrics/api.proto
+++ b/api/grpc/metrics/api.proto
@@ -20,31 +20,29 @@ package api_metrics;
 option go_package = "/api_metrics";
 
 service Metrics {
-    rpc AuditInc(stream AuditRequest) returns (EmptyResponse) {}
-    rpc BpfInc(stream BpfRequest) returns (EmptyResponse) {}
+  rpc AuditInc(stream AuditRequest) returns (EmptyResponse) {}
+  rpc BpfInc(stream BpfRequest) returns (EmptyResponse) {}
 }
 
 message AuditRequest {
-    message SeccompAuditReq {
-        string syscall = 1;
-    }
-    message SelinuxAuditReq {
-        string scontext = 1;
-        string tcontext = 2;
-    }
-    string node = 1;
-    string namespace = 2;
-    string pod = 3;
-    string container = 4;
-    string executable = 5;
-    SeccompAuditReq seccompReq = 6;
-    SelinuxAuditReq selinuxReq = 7;
+  message SeccompAuditReq { string syscall = 1; }
+  message SelinuxAuditReq {
+    string scontext = 1;
+    string tcontext = 2;
+  }
+  string node = 1;
+  string namespace = 2;
+  string pod = 3;
+  string container = 4;
+  string executable = 5;
+  SeccompAuditReq seccompReq = 6;
+  SelinuxAuditReq selinuxReq = 7;
 }
 
 message BpfRequest {
-    string node = 1;
-    uint64 mount_namespace = 2;
-    string profile = 3;
+  string node = 1;
+  uint64 mount_namespace = 2;
+  string profile = 3;
 }
 
 message EmptyResponse {}

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -192,6 +192,8 @@ dependencies:
       match: llvmPackages_\d+.clang-unwrapped
     - path: nix/derivation-bpf.nix
       match: llvm_\d+
+    - path: hack/pull-security-profiles-operator-verify
+      match: CLANG_VERSION
 
   - name: btfhub
     version: 12d2b6bb4664b6b1d15076f8090dcb0e55696d34

--- a/hack/pull-security-profiles-operator-verify
+++ b/hack/pull-security-profiles-operator-verify
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# assume a Debian based golang image, like: golang:1.16
+# assume a Debian based golang image, like: golang:1.19
 apt-get update
-apt-get install -y libseccomp-dev libelf-dev python3 libapparmor-dev
+apt-get install -y \
+    libapparmor-dev \
+    libelf-dev \
+    libseccomp-dev \
+    python3 \
+    software-properties-common
+
 ./hack/install-libbpf.sh
+
+CLANG_VERSION=14
+curl -sSfL --retry 5 --retry-delay 3 https://apt.llvm.org/llvm.sh | bash -s -- $CLANG_VERSION all
+ln -sf /usr/bin/clang-format-$CLANG_VERSION /usr/bin/clang-format
 
 make verify

--- a/internal/pkg/daemon/bpfrecorder/bpf/recorder.bpf.c
+++ b/internal/pkg/daemon/bpfrecorder/bpf/recorder.bpf.c
@@ -28,8 +28,8 @@ struct {
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(max_entries, MAX_MNTNS_LEN);
-    __type(key, u32);                   // PID
-    __type(value, u64);                 // mntns ID
+    __type(key, u32);    // PID
+    __type(value, u64);  // mntns ID
 } system_mntns SEC(".maps");
 
 struct {


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We now format c and proto files via `clang-format` within the CI.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
