### PR TITLE
Dockerfile.ubi: bump images, remove workaround

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -18,7 +18,7 @@
 # for more details
 
 # hash below referred to latest
-FROM registry.access.redhat.com/ubi8/go-toolset@sha256:5c33798716db98ce485d606451bef1dd7a6eb3b1422a67cbd10eacc870eb2de5 as build
+FROM registry.access.redhat.com/ubi8/go-toolset@sha256:3527fd9db5fb0b01e9e155f8a3b6b50b660c04eb9aa082e3e7fd373bbb0f3fbf as build
 USER root
 WORKDIR /work
 
@@ -37,12 +37,9 @@ ARG STATIC_LINK=no
 RUN make
 
 # hash below referred to latest
-FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:4ed971a5564d2cfedf750793da53ef6f1fdf295263f1cc31d703aa8acf6d02cf
+FROM registry.access.redhat.com/ubi8/ubi-minimal@sha256:6910799b75ad41f00891978575a0d955be2f800c51b955af73926e7ab59a41c3
 ARG version
 USER root
-
-# Temporary until UBI is upgraded to make Trivy happy
-RUN microdnf upgrade -y krb5-libs
 
 RUN microdnf install -y \
         libseccomp

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -106,13 +106,13 @@ dependencies:
       match: registry.k8s.io/build-image/debian-base
 
   - name: ubi8-minimal
-    version: sha256:4ed971a5564d2cfedf750793da53ef6f1fdf295263f1cc31d703aa8acf6d02cf
+    version: sha256:6910799b75ad41f00891978575a0d955be2f800c51b955af73926e7ab59a41c3
     refPaths:
     - path: Dockerfile.ubi
       match: registry.access.redhat.com/ubi8/ubi-minimal
 
   - name: ubi8-go-toolset
-    version: sha256:5c33798716db98ce485d606451bef1dd7a6eb3b1422a67cbd10eacc870eb2de5
+    version: sha256:3527fd9db5fb0b01e9e155f8a3b6b50b660c04eb9aa082e3e7fd373bbb0f3fbf
     refPaths:
     - path: Dockerfile.ubi
       match: registry.access.redhat.com/ubi8/go-toolset


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Red Hat upgraded their UBI and go-toolset images so we can drop the
workaround where we installed krb5-libs to work around a CVE.

Only ubi-minimal was affected by that CVE, but let's also bump the
go-toolset image while we're touching the Dockerfiles and stay current.

#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

-->

#### Does this PR have test?
Implicit

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
