### PR TITLE
Exposing values to enable users to manage the SecurityProfilesOperatorDaemon config

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -1,0 +1,14 @@
+apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+kind: SecurityProfilesOperatorDaemon
+metadata:
+  labels:
+    app: security-profiles-operator
+  name: spod
+  namespace: security-profiles-operator
+spec:
+  enableSelinux: {{ .Values.enableSelinux }}
+  enableLogEnricher: {{ .Values.enableLogEnricher }}
+  enableAppArmor: {{ .Values.enableAppArmor }}
+  enableBpfRecorder: {{ .Values.enableBpfRecorder }}
+  enableProfiling: {{ .Values.enableProfiling }}
+  verbosity: {{ .Values.verbosity }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -6,6 +6,14 @@ spoImage:
   repository: k8s-staging-sp-operator/security-profiles-operator
   tag: latest
 
+enableSelinux: false
+enableLogEnricher: false
+enableAppArmor: false
+enableBpfRecorder: false
+enableProfiling: false
+verbosity: 0
+
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
#### What type of PR is this?

kind feature

#### What this PR does / why we need it:
Expanding helm chart to expose values to enable users to manage the SecurityProfilesOperatorDaemon config, so that users can toggle what's deployed more easily via three new values: enableSelinux, enableLogEnricher and enableAppArmor.
Added config.yaml file in the templates directory of helm chart which takes configurable input from users via values.yaml.

#### Which issue(s) this PR fixes:

Fixes #1320 

#### Does this PR have test?
NA

#### Special notes for your reviewer:
Tested the above changes with only enableAppArmor: true and enableSelinux, enableLogEnricher as false.  Verified in the spod logs after deployment:
I1213 04:41:53.620891 2231997 apparmorprofile.go:277] apparmor-spod "msg"="detecting apparmor support..."
I1213 04:41:53.642182 2231997 apparmorprofile.go:284] apparmor-spod "msg"="apparmor enabled: OK"
I1213 04:41:53.642412 2231997 apparmorprofile.go:287] apparmor-spod "msg"="apparmor enforceable: OK"


#### Does this PR introduce a user-facing change?
```release-note
Exposed `enableSelinux`, `enableLogEnricher` and `enableAppArmor` values in the helm chart values.yaml to make it configurable by the user during the deployment.
```

