### PR TITLE
profilerecorder: gracefully skip containers that did not record anything

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
@@ -704,8 +704,10 @@ func (b *BpfRecorder) findProfileForContainerID(id string) (string, error) {
 
 			for p := range pods.Items {
 				pod := &pods.Items[p]
-				for c := range pod.Status.ContainerStatuses {
-					containerStatus := pod.Status.ContainerStatuses[c]
+				//nolint:gocritic // We explicitly do not want to append to the same slice
+				statuses := append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...)
+				for c := range statuses {
+					containerStatus := statuses[c]
 					fullContainerID := containerStatus.ContainerID
 					containerName := containerStatus.Name
 

--- a/test/tc_bpf_recorder_test.go
+++ b/test/tc_bpf_recorder_test.go
@@ -119,6 +119,7 @@ func (e *e2e) testCaseBpfRecorderMultiContainer() {
 
 	const profileNameRedis = recordingName + "-redis"
 	const profileNameNginx = recordingName + "-nginx"
+	const profileNameInit = recordingName + "-init"
 	e.waitForBpfRecorderLogs(since, profileNameRedis, profileNameNginx)
 
 	e.kubectl("delete", "pod", podName)
@@ -129,8 +130,11 @@ func (e *e2e) testCaseBpfRecorderMultiContainer() {
 	profileNginx := e.retryGetSeccompProfile(profileNameNginx)
 	e.Contains(profileNginx, "close")
 
+	profileInit := e.retryGetSeccompProfile(profileNameInit)
+	e.Contains(profileInit, "write")
+
 	e.kubectl("delete", "-f", exampleRecordingBpfPath)
-	e.kubectl("delete", "sp", profileNameRedis, profileNameNginx)
+	e.kubectl("delete", "sp", profileNameRedis, profileNameNginx, profileNameInit)
 }
 
 func (e *e2e) testCaseBpfRecorderDeployment() {
@@ -292,6 +296,10 @@ func (e *e2e) testCaseBpfRecorderSelectContainer() {
 
 	const profileNameRedis = recordingName + "-redis"
 	exists := e.existsSeccompProfile(profileNameRedis)
+	e.False(exists)
+
+	const profileNameInit = recordingName + "-init"
+	exists = e.existsSeccompProfile(profileNameInit)
 	e.False(exists)
 
 	e.kubectl("delete", "-f", exampleRecordingBpfSpecificContainerPath)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This is mostly concerning SELinux because even containers that don't
seemingly do anything at least record some syscalls, e.g. exec.

But with SELinux, if a container only performs actions that are allowed
by the container policy in the first place, no AVCs would be generated.
In that case, the call to get AVCs would return with a rather generic
error, which would then be retried by the profilerecording reconciler.
As a consequence, if a pod had multiple containers and the one with no
AVCs was collected before others, the profilerecorder would never reach
the other containers.

Instead, let's return an error matching the situation and handle the
absence of AVCs gracefully, by emptying whatever there might be in the
grpc cache and moving on to the next container.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

-->

#### Does this PR have test?
Yes

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
