### PR TITLE
merging: Fix the mergeStrategy=containers option

### DIFF
--- a/test/tc_profilerecordings_test.go
+++ b/test/tc_profilerecordings_test.go
@@ -408,11 +408,6 @@ func (e *e2e) profileRecordingSelinuxDeployment(
 }
 
 func (e *e2e) createRecordingTestDeployment() (since time.Time, deployName string) {
-	e.logf("Creating test deployment")
-	deployName = "my-deployment"
-
-	e.setupRecordingSa(e.getCurrentContextNamespace(defaultNamespace))
-
 	const testDeployment = `
 apiVersion: apps/v1
 kind: Deployment
@@ -440,10 +435,18 @@ spec:
           initialDelaySeconds: 5
           periodSeconds: 5
 `
+	return e.createRecordingTestDeploymentFromManifest(testDeployment)
+}
+
+func (e *e2e) createRecordingTestDeploymentFromManifest(manifest string) (since time.Time, deployName string) {
+	e.logf("Creating test deployment")
+	deployName = "my-deployment"
+
+	e.setupRecordingSa(e.getCurrentContextNamespace(defaultNamespace))
 
 	testFile, err := os.CreateTemp("", "recording-deployment*.yaml")
 	e.Nil(err)
-	_, err = testFile.WriteString(testDeployment)
+	_, err = testFile.WriteString(manifest)
 	e.Nil(err)
 	err = testFile.Close()
 	e.Nil(err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The mergeStrategy=containers option was implemented wrong. Instead of
merging per-container policies, it was merging policies per workload.


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
Yes

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The ProfileRecording setting mergeStrategy=containers did not work
as expected, it was merging all containers from a single recording
into a single policy. This PR fixes the bug and now a single policy
is generated for each container.
```
