### PR TITLE
e2e: Wait for profile that is supposed to be used

### DIFF
--- a/test/tc_seccomp_profilebindings_test.go
+++ b/test/tc_seccomp_profilebindings_test.go
@@ -63,6 +63,7 @@ spec:
 
 	e.kubectl("create", "-f", exampleProfilePath)
 	defer e.kubectl("delete", "-f", exampleProfilePath)
+	e.waitFor("condition=ready", "seccompprofile", "profile-allow-unsafe")
 
 	e.logf("Creating test profile binding")
 	testBindingFile, err := os.CreateTemp("", "hello-binding*.yaml")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind flake

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind regression
-->

#### What this PR does / why we need it:
In the flaky tests, I've sometimes seen failures like:
```
  Warning  Failed          1s               kubelet            Error: setup seccomp: from field: unable to load local profile "/var/lib/kubelet/seccomp/operator/spo-binding-enabled/profile-allow-unsafe.json": open /var/lib/kubelet/seccomp/operator/spo-binding-enabled/profile-allow-unsafe.json: no such file or directory
```

I think they are caused by us creating the profiles and not checking if
they actually exist before using them.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

-->

#### Does this PR have test?
Yes

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
