### PR TITLE
Install the default log enricher profile only when log enricher is enabled

### DIFF
--- a/internal/pkg/manager/spod/bindata/default_profiles.go
+++ b/internal/pkg/manager/spod/bindata/default_profiles.go
@@ -24,21 +24,27 @@ import (
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 )
 
+// DefaultLogEnricherProfile returns the default seccomp profile for log enricher.
+func DefaultLogEnricherProfile() *seccompprofileapi.SeccompProfile {
+	namespace := config.GetOperatorNamespace()
+	labels := map[string]string{"app": config.OperatorName}
+	return &seccompprofileapi.SeccompProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      config.LogEnricherProfile,
+			Namespace: namespace,
+			Labels:    labels,
+		},
+		Spec: seccompprofileapi.SeccompProfileSpec{
+			DefaultAction: seccomp.ActLog,
+		},
+	}
+}
+
 // DefaultProfiles returns the default profiles deployed by the operator.
 func DefaultProfiles() []*seccompprofileapi.SeccompProfile {
 	namespace := config.GetOperatorNamespace()
 	labels := map[string]string{"app": config.OperatorName}
 	return []*seccompprofileapi.SeccompProfile{
-		{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      config.LogEnricherProfile,
-				Namespace: namespace,
-				Labels:    labels,
-			},
-			Spec: seccompprofileapi.SeccompProfileSpec{
-				DefaultAction: seccomp.ActLog,
-			},
-		},
 		{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "nginx-1.19.1",

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -272,7 +272,8 @@ func (r *ReconcileSPOd) handleUpdatingStatus(
 	return reconcile.Result{}, nil
 }
 
-func (r *ReconcileSPOd) defaultProfiles(cfg *spodv1alpha1.SecurityProfilesOperatorDaemon) []*seccompprofileapi.SeccompProfile {
+func (r *ReconcileSPOd) defaultProfiles(
+	cfg *spodv1alpha1.SecurityProfilesOperatorDaemon) []*seccompprofileapi.SeccompProfile {
 	defaultProfiles := bindata.DefaultProfiles()
 	if cfg.Spec.EnableLogEnricher {
 		defaultProfiles = append(defaultProfiles, bindata.DefaultLogEnricherProfile())

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -272,6 +272,14 @@ func (r *ReconcileSPOd) handleUpdatingStatus(
 	return reconcile.Result{}, nil
 }
 
+func (r *ReconcileSPOd) defaultProfiles(cfg *spodv1alpha1.SecurityProfilesOperatorDaemon) []*seccompprofileapi.SeccompProfile {
+	defaultProfiles := bindata.DefaultProfiles()
+	if cfg.Spec.EnableLogEnricher {
+		defaultProfiles = append(defaultProfiles, bindata.DefaultLogEnricherProfile())
+	}
+	return defaultProfiles
+}
+
 func (r *ReconcileSPOd) handleRunningStatus(
 	ctx context.Context,
 	spod *spodv1alpha1.SecurityProfilesOperatorDaemon,
@@ -324,7 +332,7 @@ func (r *ReconcileSPOd) handleCreate(
 	}
 
 	r.log.Info("Deploying operator default profiles")
-	for _, profile := range bindata.DefaultProfiles() {
+	for _, profile := range r.defaultProfiles(cfg) {
 		// Adapt the namespace if we watch only a single one
 		if r.watchNamespace != "" {
 			profile.Namespace = r.watchNamespace
@@ -392,7 +400,7 @@ func (r *ReconcileSPOd) handleUpdate(
 	}
 
 	r.log.Info("Updating operator default profiles")
-	for _, profile := range bindata.DefaultProfiles() {
+	for _, profile := range r.defaultProfiles(cfg) {
 		// Adapt the namespace if we watch only a single one
 		if r.watchNamespace != "" {
 			profile.Namespace = r.watchNamespace

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -273,7 +273,8 @@ func (r *ReconcileSPOd) handleUpdatingStatus(
 }
 
 func (r *ReconcileSPOd) defaultProfiles(
-	cfg *spodv1alpha1.SecurityProfilesOperatorDaemon) []*seccompprofileapi.SeccompProfile {
+	cfg *spodv1alpha1.SecurityProfilesOperatorDaemon,
+) []*seccompprofileapi.SeccompProfile {
 	defaultProfiles := bindata.DefaultProfiles()
 	if cfg.Spec.EnableLogEnricher {
 		defaultProfiles = append(defaultProfiles, bindata.DefaultLogEnricherProfile())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Install the default log enricher seccomp profile only when log enricher is enabled in the spod configuration.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Install the default log enricher sccomp profile only when log enricher is enabled in the spod configuration.

```
