### PR TITLE
Fix flatcar vagrant for Kubernetes 1.26

### DIFF
--- a/hack/ci/Vagrantfile-flatcar
+++ b/hack/ci/Vagrantfile-flatcar
@@ -2,9 +2,10 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "flatcar-lts"
+  config.vm.box = "flatcar-main"
   config.vm.box_check_update = true
-  config.vm.box_url = "https://lts.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vagrant.box"
+  #config.vm.box_url = "https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vagrant.box"
+  config.vm.box_url = "http://bincache.flatcar-linux.net/images/amd64/9999.0.0+tormath1-ignition-vagrant/flatcar_production_vagrant.box"
   memory = 8192
   cpus = 4
 
@@ -24,12 +25,14 @@ Vagrant.configure("2") do |config|
     v.cpus = cpus
   end
 
+  config.ssh.connect_timeout = 30
   config.ssh.username = 'core'
   config.ssh.forward_agent = true
   config.ssh.insert_key = true
   config.ssh.keep_alive = true
 
   config.vm.synced_folder ".", "/vagrant", type: "rsync"
+  config.vm.boot_timeout = 600
 
   config.vm.provision "install-dependencies", type: "shell", run: "once" do |sh|
     sh.inline = <<~SHELL
@@ -90,7 +93,7 @@ Vagrant.configure("2") do |config|
       # Install tools
       curl -sSL -o $DOWNLOAD_DIR/jq "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64"
       chmod +x $DOWNLOAD_DIR/jq
-      curl -sSL -o $DOWNLOAD_DIR/flatcar_developer_container.bin.bz2 "https://lts.release.flatcar-linux.net/amd64-usr/current/flatcar_developer_container.bin.bz2"
+      curl -sSL -o $DOWNLOAD_DIR/flatcar_developer_container.bin.bz2 "https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_developer_container.bin.bz2"
       bzcat $DOWNLOAD_DIR/flatcar_developer_container.bin.bz2 > $DOWNLOAD_DIR/flatcar_developer_container.bin
 
       curl -sSL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
@@ -125,7 +128,7 @@ Vagrant.configure("2") do |config|
       kubectl taint nodes --all node-role.kubernetes.io/control-plane-
 
       # Install CNI
-      kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.24.0/manifests/tigera-operator.yaml
+      kubectl create -f https://raw.githubusercontent.com/projectcalico/calico/v3.24.5/manifests/tigera-operator.yaml
       kubectl apply -f /vagrant/hack/ci/flatcar-cni-plugin.yaml
     SHELL
   end

--- a/hack/ci/e2e-flatcar.sh
+++ b/hack/ci/e2e-flatcar.sh
@@ -38,6 +38,9 @@ export PATH="$HOSTFS_DEV_MOUNT_PATH/opt/bin:$PATH"
 export KUBECONFIG=$HOSTFS_DEV_MOUNT_PATH/etc/kubernetes/admin.conf
 alias k=kubectl
 
+# Configure git to consider the mounted host filesystem as safe
+git config --global --add safe.directory "/hostfs/vagrant"
+
 if "${E2E_TEST_FLAKY_TESTS_ONLY}"; then
     make test-flaky-e2e
 else


### PR DESCRIPTION
Fix flatcar vagrant for Kubernetes 1.26

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Fixes the vagrant for Flatcar Linux to work with Kubernetes 1.26 which requires containerd 1.6.x which is only available in Flatcar sable stream. 

Also we have to use a temporary vagrant box because there was still an issue with ssh which was fixed by Flatcar but not yet released.

See for details: https://github.com/flatcar/Flatcar/issues/916

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Fixes #1377

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix vagrant for Flatcar Linux to work with Kubernetes 1.26.

```
