### PR TITLE
Exposing spo image repo & tag in helm charts to make it configurable

### DIFF
--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -34,7 +34,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
+        image: {{ .Values.spoImage.registry }}/{{ .Values.spoImage.repository }}:{{ .Values.spoImage.tag }}
         imagePullPolicy: Always
         name: {{ .Chart.Name }}
         resources:

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -1,6 +1,11 @@
 # Default values for security-profiles-operator.
 replicaCount: 3
 
+spoImage:
+  registry: gcr.io
+  repository: k8s-staging-sp-operator/security-profiles-operator
+  tag: latest
+
 nameOverride: ""
 fullnameOverride: ""
 


### PR DESCRIPTION
#### What type of PR is this?
kind feature

#### What this PR does / why we need it:
This enables users to have better control over what images/tags they deploy when using the official SPO helm chart, instead of having to create their own.

#### Which issue(s) this PR fixes:
Fixes #1334 

#### Does this PR have test?
Tested the above changes with spoimage repository set to gcr.io/k8s-staging-sp-operator/security-profiles-operator and spoimage tag set to latest.
Image pulled successfully.

#### Does this PR introduce a user-facing change?
```release-note
Added registry, repository & tag in values.yaml to make SPO repo & image values configurable in helm charts.
```
