### PR TITLE
Fix profiling

### DIFF
--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -64,6 +64,11 @@ const (
 	ContainerIDMetrics                         = 4
 	DefaultHostProcPath                        = "/proc"
 	MetricsContainerName                       = "metrics"
+	SelinuxContainerNmae                       = "selinuxd"
+	LogEnricherContainerName                   = "log-enricher"
+	BpfRecorderContainerName                   = "bpf-recorder"
+	NonRootEnablerContainerName                = "non-root-enabler"
+	SelinuxPoliciesCopierContainerName         = "selinux-shared-policies-copier"
 	LocalSeccompProfilePath                    = "security-profiles-operator.json"
 )
 
@@ -143,7 +148,7 @@ var Manifest = &appsv1.DaemonSet{
 				},
 				InitContainers: []corev1.Container{
 					{
-						Name:            "non-root-enabler",
+						Name:            NonRootEnablerContainerName,
 						Args:            []string{"non-root-enabler"},
 						ImagePullPolicy: corev1.PullAlways,
 						VolumeMounts: []corev1.VolumeMount{
@@ -187,7 +192,7 @@ var Manifest = &appsv1.DaemonSet{
 						},
 					},
 					{
-						Name:  "selinux-shared-policies-copier",
+						Name:  SelinuxPoliciesCopierContainerName,
 						Image: "quay.io/security-profiles-operator/selinuxd",
 						// Primes the volume mount under /etc/selinux.d with the
 						// shared policies shipped by selinuxd and makes sure the volume mount
@@ -372,7 +377,7 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 						},
 					},
 					{
-						Name:  "selinuxd",
+						Name:  SelinuxContainerNmae,
 						Image: "quay.io/security-profiles-operator/selinuxd",
 						Args: []string{
 							"daemon",
@@ -429,7 +434,7 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 						},
 					},
 					{
-						Name:            "log-enricher",
+						Name:            LogEnricherContainerName,
 						Args:            []string{"log-enricher"},
 						ImagePullPolicy: corev1.PullAlways,
 						VolumeMounts: []corev1.VolumeMount{
@@ -481,7 +486,7 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 						},
 					},
 					{
-						Name:            "bpf-recorder",
+						Name:            BpfRecorderContainerName,
 						Args:            []string{"bpf-recorder"},
 						ImagePullPolicy: corev1.PullAlways,
 						VolumeMounts: []corev1.VolumeMount{

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -666,8 +666,9 @@ func verbosityEnv(value uint) corev1.EnvVar {
 }
 
 func enableContainerProfiling(templateSpec *corev1.PodSpec, cID int) {
-	switch cID {
-	case bindata.ContainerIDSelinuxd:
+	containerName := templateSpec.Containers[cID].Name
+	switch containerName {
+	case bindata.SelinuxContainerNmae:
 		templateSpec.Containers[cID].Args = append(
 			templateSpec.Containers[cID].Args,
 			profilingArgsSelinuxd()...,

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -109,6 +109,10 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			e.testCaseVerbosityChange,
 		},
 		{
+			"SPOD: Change profiling",
+			e.testCaseProfilingChange,
+		},
+		{
 			"SPOD: Change resource requirements",
 			e.testCaseResourceRequirementsChange,
 		},

--- a/test/tc_profiling_test.go
+++ b/test/tc_profiling_test.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"time"
+)
+
+func (e *e2e) testCaseProfilingChange([]string) {
+	e.logf("Change profiling in spod")
+	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableProfiling": true}}`, "--type=merge")
+	time.Sleep(defaultWaitTime)
+
+	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultBpfRecorderOpTimeout)
+
+	logs := e.kubectlOperatorNS(
+		"logs",
+		"ds/spod",
+		"security-profiles-operator",
+	)
+
+	e.Contains(logs, "Profiling support enabled: true")
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Use the container name instead of ID when enabling the profile to avoid a situation when the id is reorderd and the wrong argument is passed to another container. 

For instance, the bpf-recorder container fails when profiling is enabled and the SELinux is disabled with the following error:
```
 Incorrect Usage: flag provided but not defined: -enable-profiling 
```

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix profiling when bpf-recorder is enabled but SELinux is disabled.
```
