### PR TITLE
Add an option which enables the memory optimization inside of spod daemon

### DIFF
--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -258,6 +258,11 @@ type SPODSpec struct {
 	// EnableProfiling tells the operator whether or not to enable profiling
 	// support for this SPOD instance.
 	EnableProfiling bool `json:"enableProfiling,omitempty"`
+	// EnableMemoryOptimization enables memory optimization in the controller
+	// running inside of SPOD instance and watching for pods in the cluster.
+	// This will make the controller loading in the cache memory only the pods
+	// labled explicitly for profile recording with 'spo.x-k8s.io/enable-recording=true'.
+	EnableMemoryOptimization bool `json:"enableMemoryOptimization,omitempty"`
 	// tells the operator whether or not to enable SELinux support for this
 	// SPOD instance.
 	EnableSelinux *bool `json:"enableSelinux,omitempty"`

--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -261,7 +261,7 @@ type SPODSpec struct {
 	// EnableMemoryOptimization enables memory optimization in the controller
 	// running inside of SPOD instance and watching for pods in the cluster.
 	// This will make the controller loading in the cache memory only the pods
-	// labled explicitly for profile recording with 'spo.x-k8s.io/enable-recording=true'.
+	// labelled explicitly for profile recording with 'spo.x-k8s.io/enable-recording=true'.
 	EnableMemoryOptimization bool `json:"enableMemoryOptimization,omitempty"`
 	// tells the operator whether or not to enable SELinux support for this
 	// SPOD instance.

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_securityprofilesoperatordaemons.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_securityprofilesoperatordaemons.yaml
@@ -923,6 +923,13 @@ spec:
                 description: tells the operator whether or not to enable log enrichment
                   support for this SPOD instance.
                 type: boolean
+              enableMemoryOptimization:
+                description: EnableMemoryOptimization enables memory optimization
+                  in the controller running inside of SPOD instance and watching for
+                  pods in the cluster. This will make the controller loading in the
+                  cache memory only the pods labelled explicitly for profile recording
+                  with 'spo.x-k8s.io/enable-recording=true'.
+                type: boolean
               enableProfiling:
                 description: EnableProfiling tells the operator whether or not to
                   enable profiling support for this SPOD instance.

--- a/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
@@ -921,6 +921,13 @@ spec:
                 description: tells the operator whether or not to enable log enrichment
                   support for this SPOD instance.
                 type: boolean
+              enableMemoryOptimization:
+                description: EnableMemoryOptimization enables memory optimization
+                  in the controller running inside of SPOD instance and watching for
+                  pods in the cluster. This will make the controller loading in the
+                  cache memory only the pods labelled explicitly for profile recording
+                  with 'spo.x-k8s.io/enable-recording=true'.
+                type: boolean
               enableProfiling:
                 description: EnableProfiling tells the operator whether or not to
                   enable profiling support for this SPOD instance.

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -1448,6 +1448,13 @@ spec:
                 description: tells the operator whether or not to enable log enrichment
                   support for this SPOD instance.
                 type: boolean
+              enableMemoryOptimization:
+                description: EnableMemoryOptimization enables memory optimization
+                  in the controller running inside of SPOD instance and watching for
+                  pods in the cluster. This will make the controller loading in the
+                  cache memory only the pods labelled explicitly for profile recording
+                  with 'spo.x-k8s.io/enable-recording=true'.
+                type: boolean
               enableProfiling:
                 description: EnableProfiling tells the operator whether or not to
                   enable profiling support for this SPOD instance.

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1448,6 +1448,13 @@ spec:
                 description: tells the operator whether or not to enable log enrichment
                   support for this SPOD instance.
                 type: boolean
+              enableMemoryOptimization:
+                description: EnableMemoryOptimization enables memory optimization
+                  in the controller running inside of SPOD instance and watching for
+                  pods in the cluster. This will make the controller loading in the
+                  cache memory only the pods labelled explicitly for profile recording
+                  with 'spo.x-k8s.io/enable-recording=true'.
+                type: boolean
               enableProfiling:
                 description: EnableProfiling tells the operator whether or not to
                   enable profiling support for this SPOD instance.

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -1448,6 +1448,13 @@ spec:
                 description: tells the operator whether or not to enable log enrichment
                   support for this SPOD instance.
                 type: boolean
+              enableMemoryOptimization:
+                description: EnableMemoryOptimization enables memory optimization
+                  in the controller running inside of SPOD instance and watching for
+                  pods in the cluster. This will make the controller loading in the
+                  cache memory only the pods labelled explicitly for profile recording
+                  with 'spo.x-k8s.io/enable-recording=true'.
+                type: boolean
               enableProfiling:
                 description: EnableProfiling tells the operator whether or not to
                   enable profiling support for this SPOD instance.

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -1448,6 +1448,13 @@ spec:
                 description: tells the operator whether or not to enable log enrichment
                   support for this SPOD instance.
                 type: boolean
+              enableMemoryOptimization:
+                description: EnableMemoryOptimization enables memory optimization
+                  in the controller running inside of SPOD instance and watching for
+                  pods in the cluster. This will make the controller loading in the
+                  cache memory only the pods labelled explicitly for profile recording
+                  with 'spo.x-k8s.io/enable-recording=true'.
+                type: boolean
               enableProfiling:
                 description: EnableProfiling tells the operator whether or not to
                   enable profiling support for this SPOD instance.

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1448,6 +1448,13 @@ spec:
                 description: tells the operator whether or not to enable log enrichment
                   support for this SPOD instance.
                 type: boolean
+              enableMemoryOptimization:
+                description: EnableMemoryOptimization enables memory optimization
+                  in the controller running inside of SPOD instance and watching for
+                  pods in the cluster. This will make the controller loading in the
+                  cache memory only the pods labelled explicitly for profile recording
+                  with 'spo.x-k8s.io/enable-recording=true'.
+                type: boolean
               enableProfiling:
                 description: EnableProfiling tells the operator whether or not to
                   enable profiling support for this SPOD instance.

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -1624,6 +1624,13 @@ spec:
                 description: tells the operator whether or not to enable log enrichment
                   support for this SPOD instance.
                 type: boolean
+              enableMemoryOptimization:
+                description: EnableMemoryOptimization enables memory optimization
+                  in the controller running inside of SPOD instance and watching for
+                  pods in the cluster. This will make the controller loading in the
+                  cache memory only the pods labelled explicitly for profile recording
+                  with 'spo.x-k8s.io/enable-recording=true'.
+                type: boolean
               enableProfiling:
                 description: EnableProfiling tells the operator whether or not to
                   enable profiling support for this SPOD instance.

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -16,6 +16,7 @@
 - [Customise the daemon resource requirements](#customise-the-daemon-resource-requirements)
 - [Restrict the allowed syscalls in seccomp profiles](#restrict-the-allowed-syscalls-in-seccomp-profiles)
 - [Constrain spod scheduling](#constrain-spod-scheduling)
+- [Enable memory optimization in spod](#enable-memory-optimization-in-spod)
 - [Create a seccomp profile](#create-a-seccomp-profile)
   - [Apply a seccomp profile to a pod](#apply-a-seccomp-profile-to-a-pod)
   - [Base syscalls for a container runtime](#base-syscalls-for-a-container-runtime)

--- a/internal/pkg/manager/spod/bindata/webhook.go
+++ b/internal/pkg/manager/spod/bindata/webhook.go
@@ -69,15 +69,22 @@ var (
 )
 
 const (
-	webhookName                 = config.OperatorName + "-webhook"
-	webhookConfigName           = "spo-mutating-webhook-configuration"
-	serviceAccountName          = "spo-webhook"
-	certsMountPath              = "/tmp/k8s-webhook-server/serving-certs"
-	containerPort               = 9443
-	serviceName                 = "webhook-service"
-	webhookServerCert           = "webhook-server-cert"
-	webhookEnableBindingLabel   = "spo.x-k8s.io/enable-binding"
-	webhookEnableRecordingLabel = "spo.x-k8s.io/enable-recording"
+	// EnableRecordingLabel this label can be applied to a namespace or a pod
+	// in order to enable profile recording.
+	EnableRecordingLabel = "spo.x-k8s.io/enable-recording"
+	// EnableBindingLabel this label can be applied to a namespace in order to
+	// enable profile binding.
+	EnableBindingLabel = "spo.x-k8s.io/enable-binding"
+)
+
+const (
+	webhookName        = config.OperatorName + "-webhook"
+	webhookConfigName  = "spo-mutating-webhook-configuration"
+	serviceAccountName = "spo-webhook"
+	certsMountPath     = "/tmp/k8s-webhook-server/serving-certs"
+	containerPort      = 9443
+	serviceName        = "webhook-service"
+	webhookServerCert  = "webhook-server-cert"
 )
 
 type Webhook struct {
@@ -397,7 +404,7 @@ var webhookConfig = &admissionregv1.MutatingWebhookConfiguration{
 			NamespaceSelector: &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{
-						Key:      webhookEnableBindingLabel,
+						Key:      EnableBindingLabel,
 						Operator: metav1.LabelSelectorOpExists,
 					},
 				},
@@ -420,7 +427,7 @@ var webhookConfig = &admissionregv1.MutatingWebhookConfiguration{
 			NamespaceSelector: &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
 					{
-						Key:      webhookEnableRecordingLabel,
+						Key:      EnableRecordingLabel,
 						Operator: metav1.LabelSelectorOpExists,
 					},
 				},

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -592,6 +592,13 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 		templateSpec.HostPID = true
 	}
 
+	// Enable memory optimization for spod controller
+	if cfg.Spec.EnableMemoryOptimization {
+		templateSpec.Containers[bindata.ContainerIDDaemon].Args = append(
+			templateSpec.Containers[bindata.ContainerIDDaemon].Args,
+			"--with-mem-optim=true")
+	}
+
 	// Metrics parameters
 	templateSpec.Containers = append(
 		templateSpec.Containers,

--- a/test/e2e_flaky_test.go
+++ b/test/e2e_flaky_test.go
@@ -68,6 +68,7 @@ func (e *e2e) TestSecurityProfilesOperator_Flaky() {
 		e.testCaseProfileRecordingDeploymentLogs()
 		e.testCaseRecordingFinalizers()
 		e.testCaseProfileRecordingDeploymentScaleUpDownLogs()
+		e.testCaseProfileRecordingWithMemoryOptimization()
 	})
 
 	e.Run("cluster-wide: Seccomp: Verify profile recording bpf", func() {
@@ -77,6 +78,7 @@ func (e *e2e) TestSecurityProfilesOperator_Flaky() {
 		e.testCaseBpfRecorderDeployment()
 		e.testCaseBpfRecorderParallel()
 		e.testCaseBpfRecorderSelectContainer()
+		e.testCaseBpfRecorderWithMemoryOptimization()
 	})
 
 	// Clean up cluster-wide deployment to prepare for namespace deployment

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -113,6 +113,10 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			e.testCaseProfilingChange,
 		},
 		{
+			"SPOD: Enable memory optimiztaion",
+			e.testCaseMemOptmEnable,
+		},
+		{
 			"SPOD: Change resource requirements",
 			e.testCaseResourceRequirementsChange,
 		},

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -721,6 +721,24 @@ func (e *e2e) enableBpfRecorderInSpod() {
 	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultBpfRecorderOpTimeout)
 }
 
+func (e *e2e) enableMemoryOptimization() {
+	e.logf("Enable memory optimization in SPOD")
+	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableMemoryOptimization": true}}`, "--type=merge")
+	time.Sleep(defaultWaitTime)
+
+	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultBpfRecorderOpTimeout)
+}
+
+func (e *e2e) disableMemoryOptimization() {
+	e.logf("Enable memory optimization in SPOD")
+	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableMemoryOptimization": false}}`, "--type=merge")
+	time.Sleep(defaultWaitTime)
+
+	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultBpfRecorderOpTimeout)
+}
+
 func (e *e2e) deployRecordingSa(namespace string) {
 	saTemplate := `
     apiVersion: v1

--- a/test/tc_bpf_recorder_test.go
+++ b/test/tc_bpf_recorder_test.go
@@ -297,3 +297,40 @@ func (e *e2e) testCaseBpfRecorderSelectContainer() {
 	e.kubectl("delete", "-f", exampleRecordingBpfSpecificContainerPath)
 	e.kubectl("delete", "sp", profileNameNginx)
 }
+
+func (e *e2e) testCaseBpfRecorderWithMemoryOptimization() {
+	e.bpfRecorderOnlyTestCase()
+
+	e.enableMemoryOptimization()
+	defer e.disableMemoryOptimization()
+
+	restoreNs := e.switchToRecordingNs(nsRecordingEnabled)
+	defer restoreNs()
+
+	e.logf("Creating bpf recording for static pod test")
+	e.kubectl("create", "-f", exampleRecordingBpfPath)
+
+	since, podName := e.createRecordingTestPod()
+
+	resourceName := recordingName + "-nginx"
+	e.waitForBpfRecorderLogs(since, resourceName)
+
+	e.kubectl("delete", "pod", podName)
+
+	profile := e.retryGetSeccompProfile(resourceName)
+	e.Contains(profile, "listen")
+
+	e.kubectl("delete", "-f", exampleRecordingBpfPath)
+	e.kubectl("delete", "sp", resourceName)
+
+	metrics := e.getSpodMetrics()
+	// we don't use resource name here, because the metrics are tracked by the annotation name which contains
+	// underscores instead of dashes
+	metricName := recordingName + "_nginx"
+	e.Regexp(fmt.Sprintf(`(?m)security_profiles_operator_seccomp_profile_bpf_total{`+
+		`mount_namespace=".*",`+
+		`node=".*",`+
+		`profile="%s_.*"} \d+`,
+		metricName,
+	), metrics)
+}

--- a/test/tc_memoptm_test.go
+++ b/test/tc_memoptm_test.go
@@ -16,17 +16,11 @@ limitations under the License.
 
 package e2e_test
 
-import (
-	"time"
-)
-
 func (e *e2e) testCaseMemOptmEnable([]string) {
 	e.logf("Change memory optimization in spod")
-	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableMemoryOptimization": true}}`, "--type=merge")
-	time.Sleep(defaultWaitTime)
 
-	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
-	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultBpfRecorderOpTimeout)
+	e.enableMemoryOptimization()
+	defer e.disableMemoryOptimization()
 
 	e.waitForSpod()
 	e.waitInOperatorNSFor("condition=initialized", "pod", "-l", "name=spod")

--- a/test/tc_memoptm_test.go
+++ b/test/tc_memoptm_test.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"time"
+)
+
+func (e *e2e) testCaseMemOptmEnable([]string) {
+	e.logf("Change memory optimization in spod")
+	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableMemoryOptimization": true}}`, "--type=merge")
+	time.Sleep(defaultWaitTime)
+
+	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultBpfRecorderOpTimeout)
+
+	e.waitForSpod()
+	e.waitInOperatorNSFor("condition=initialized", "pod", "-l", "name=spod")
+	e.waitInOperatorNSFor("condition=ready", "pod", "-l", "name=spod")
+}

--- a/test/tc_profilerecordings_test.go
+++ b/test/tc_profilerecordings_test.go
@@ -332,6 +332,18 @@ func (e *e2e) testCaseRecordingFinalizers() {
 	e.kubectl("delete", "sp", resourceName)
 }
 
+func (e *e2e) testCaseProfileRecordingWithMemoryOptimization() {
+	e.logEnricherOnlyTestCase()
+	e.testCaseMemOptmEnable([]string{})
+	restoreNs := e.switchToRecordingNs(nsRecordingEnabled)
+	defer restoreNs()
+
+	e.profileRecordingStaticPod(
+		exampleRecordingSeccompLogsPath,
+		regexp.MustCompile(`(?m)"syscallName"="listen"`),
+	)
+}
+
 func (e *e2e) profileRecordingDeployment(
 	recording string, waitConditions ...*regexp.Regexp,
 ) {
@@ -462,6 +474,7 @@ metadata:
   name: recording
   labels:
     app: alpine
+    spo.x-k8s.io/enable-recording: "true"
 spec:
   containers:
   - image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Adds an option to enable memory optimization inside of spod daemon.

The controller running inside of spod daemon process is watching all pods available in the cluster when profile recording
is enabled. It will perform some pre-filtering before the reconciliation to select only the pods running on local
node as well as pods annotated for recording, but this operation takes place after all pods objects are loaded
into the cache memory of the informer. This can lead to very high memory usage in large clusters with 1000s of pods, resulting in spod daemon running out of memory or crashing.

In order to prevent this situation, the spod daemon can be configured to only load into the cache memory the pods explicitly
labeled for profile recording.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Fixes #1385
Fixes #1386

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add an option to enable memory optimization inside of spod daemon.
```
