### PR TITLE
Switch to `gcr.io/kubebuilder/kube-rbac-proxy`

### DIFF
--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -845,7 +845,7 @@ spec:
                 - manager
                 env:
                 - name: RELATED_IMAGE_RBAC_PROXY
-                  value: quay.io/brancz/kube-rbac-proxy:v0.13.1
+                  value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
                 - name: RELATED_IMAGE_SELINUXD
                   value: quay.io/security-profiles-operator/selinuxd
                 - name: OPERATOR_NAMESPACE
@@ -962,7 +962,7 @@ spec:
     name: Kubernetes SIGs
     url: https://github.com/kubernetes-sigs
   relatedImages:
-  - image: quay.io/brancz/kube-rbac-proxy:v0.13.1
+  - image: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
     name: rbac-proxy
   - image: quay.io/security-profiles-operator/selinuxd
     name: selinuxd

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -127,7 +127,11 @@ dependencies:
     version: 0.13.1
     refPaths:
     - path: internal/pkg/manager/spod/bindata/spod.go
-      match: quay.io/brancz/kube-rbac-proxy
+      match: gcr.io/kubebuilder/kube-rbac-proxy
+    - path: deploy/kustomize-deployment/manager_deployment.yaml
+      match: gcr.io/kubebuilder/kube-rbac-proxy
+    - path: deploy/helm/templates/deployment.yaml
+      match: gcr.io/kubebuilder/kube-rbac-proxy
 
   - name: gcb-docker-gcloud
     version: v20220617-174ad91c3a

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -27,7 +27,7 @@ spec:
         - manager
         env:
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: quay.io/brancz/kube-rbac-proxy:v0.13.1
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE

--- a/deploy/kustomize-deployment/manager_deployment.yaml
+++ b/deploy/kustomize-deployment/manager_deployment.yaml
@@ -35,7 +35,7 @@ spec:
               memory: 128Mi
           env:
             - name: RELATED_IMAGE_RBAC_PROXY
-              value: quay.io/brancz/kube-rbac-proxy:v0.13.1
+              value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
             - name: RELATED_IMAGE_SELINUXD
               value: quay.io/security-profiles-operator/selinuxd
             - name: OPERATOR_NAMESPACE

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2963,7 +2963,7 @@ spec:
         - name: RESTRICT_TO_NAMESPACE
           value: NS_REPLACE
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: quay.io/brancz/kube-rbac-proxy:v0.13.1
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -2961,7 +2961,7 @@ spec:
         - manager
         env:
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: quay.io/brancz/kube-rbac-proxy:v0.13.1
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -2974,7 +2974,7 @@ spec:
         - manager
         env:
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: quay.io/brancz/kube-rbac-proxy:v0.13.1
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2961,7 +2961,7 @@ spec:
         - manager
         env:
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: quay.io/brancz/kube-rbac-proxy:v0.13.1
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -2961,7 +2961,7 @@ spec:
         - --webhook=false
         env:
         - name: RELATED_IMAGE_RBAC_PROXY
-          value: quay.io/brancz/kube-rbac-proxy:v0.13.1
+          value: gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1
         - name: RELATED_IMAGE_SELINUXD
           value: quay.io/security-profiles-operator/selinuxd
         - name: OPERATOR_NAMESPACE

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -44,7 +44,7 @@ sed -i 's;image: .*;image: registry.k8s.io/security-profiles-operator/security-p
 # Update e2e tests
 # shellcheck disable=SC2016
 sed -i 's;gcr.io/k8s-staging-sp-operator.*;registry.k8s.io/security-profiles-operator/security-profiles-operator-catalog:v'"$VERSION"'#${CATALOG_IMG}#g" examples/olm/install-resources.yaml;g' hack/ci/e2e-olm.sh
-sed -i 's;gcr.io/;registry.k8s.io/;g' test/e2e_test.go
+sed -i 's;gcr.io/k8s-staging-sp-operator/;registry.k8s.io/;g' test/e2e_test.go
 
 # Update dependencies.yaml
 FILES=(

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -53,7 +53,7 @@ const (
 	SelinuxdPrivateDir                         = "/var/run/selinuxd"
 	SelinuxdSocketPath                         = SelinuxdPrivateDir + "/selinuxd.sock"
 	SelinuxdDBPath                             = SelinuxdPrivateDir + "/selinuxd.db"
-	MetricsImage                               = "quay.io/brancz/kube-rbac-proxy:v0.13.1"
+	MetricsImage                               = "gcr.io/kubebuilder/kube-rbac-proxy:v0.13.1"
 	sysKernelDebugPath                         = "/sys/kernel/debug"
 	InitContainerIDNonRootenabler              = 0
 	InitContainerIDSelinuxSharedPoliciesCopier = 1

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -285,8 +285,8 @@ func (e *e2e) deployOperator(manifest string) {
 	// ones from the nodes
 	e.logf("Setting imagePullPolicy to '%s' in manifest: %s", e.pullPolicy, manifest)
 	e.updateManifest(manifest, "imagePullPolicy: Always", fmt.Sprintf("imagePullPolicy: %s", e.pullPolicy))
-	e.updateManifest(manifest, "image: .*gcr.io/.*", fmt.Sprintf("image: %s", e.testImage))
-	e.updateManifest(manifest, "value: .*gcr.io/.*", fmt.Sprintf("value: %s", e.testImage))
+	e.updateManifest(manifest, "image: .*gcr.io/k8s-staging-sp-operator/.*", fmt.Sprintf("image: %s", e.testImage))
+	e.updateManifest(manifest, "value: .*gcr.io/k8s-staging-sp-operator/.*", fmt.Sprintf("value: %s", e.testImage))
 	e.updateManifest(manifest, "value: .*quay.io/.*/selinuxd.*", fmt.Sprintf("value: %s", e.selinuxdImage))
 	if e.selinuxEnabled {
 		e.updateManifest(manifest, "enableSelinux: false", "enableSelinux: true")


### PR DESCRIPTION


#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:
The old location does not seem to be the official one, so we switch over to the new one as well as adapt the dependency verification.


#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes-sigs/security-profiles-operator/issues/1423

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
Yes
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Switched to `gcr.io/kubebuilder/kube-rbac-proxy` from `quay.io/brancz`.
```
