### PR TITLE
Make the kubelet root directory configurable

### DIFF
--- a/api/seccompprofile/v1beta1/seccompprofile_types.go
+++ b/api/seccompprofile/v1beta1/seccompprofile_types.go
@@ -149,7 +149,7 @@ func (sp *SeccompProfile) DeepCopyToStatusBaseIf() profilebase.StatusBaseUser {
 
 func (sp *SeccompProfile) SetImplementationStatus() {
 	profilePath := sp.GetProfilePath()
-	sp.Status.LocalhostProfile = strings.TrimPrefix(profilePath, config.KubeletSeccompRootPath+"/")
+	sp.Status.LocalhostProfile = strings.TrimPrefix(profilePath, config.KubeletSeccompRootPath()+"/")
 }
 
 func (sp *SeccompProfile) GetProfileFile() string {
@@ -163,7 +163,7 @@ func (sp *SeccompProfile) GetProfileFile() string {
 func (sp *SeccompProfile) GetProfilePath() string {
 	pfile := sp.GetProfileFile()
 	return path.Join(
-		config.ProfilesRootPath,
+		config.ProfilesRootPath(),
 		filepath.Base(sp.GetNamespace()),
 		filepath.Base(pfile),
 	)

--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -860,6 +860,8 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: spec.nodeName
+                - name: KUBELET_DIR
+                  value: /var/lib/kubelet
                 image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
                 imagePullPolicy: Always
                 name: security-profiles-operator

--- a/deploy/kustomize-deployment/manager_deployment.yaml
+++ b/deploy/kustomize-deployment/manager_deployment.yaml
@@ -51,6 +51,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: spec.nodeName
+            - name: KUBELET_DIR
+              value: "/var/lib/kubelet"
       tolerations:
         - key: "node-role.kubernetes.io/master"
           operator: "Exists"

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2983,6 +2983,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBELET_DIR
+          value: /var/lib/kubelet
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
         imagePullPolicy: Always
         name: security-profiles-operator

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -2981,6 +2981,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBELET_DIR
+          value: /var/lib/kubelet
         image: image-registry.openshift-image-registry.svc:5000/openshift/security-profiles-operator:latest
         imagePullPolicy: Always
         name: security-profiles-operator

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -2994,6 +2994,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBELET_DIR
+          value: /var/lib/kubelet
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
         imagePullPolicy: Always
         name: security-profiles-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2981,6 +2981,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBELET_DIR
+          value: /var/lib/kubelet
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
         imagePullPolicy: Always
         name: security-profiles-operator

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -2981,6 +2981,8 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
+        - name: KUBELET_DIR
+          value: /var/lib/kubelet
         image: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
         imagePullPolicy: Always
         name: security-profiles-operator

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -10,6 +10,7 @@
   - [Installation using OLM using upstream catalog and bundle](#installation-using-olm-using-upstream-catalog-and-bundle)
   - [Installation using helm](#installation-using-helm)
   - [Installation on AKS](#installation-on-aks)
+- [Configure a custom kubelet root directory](#configure-a-custom-kubelet-root-directory)
 - [Set logging verbosity](#set-logging-verbosity)
 - [Pull images from private registry](#pull-images-from-private-registry)
 - [Configure the SELinux type](#configure-the-selinux-type)
@@ -188,6 +189,12 @@ $ kubectl -nsecurity-profiles-operator get spod spod
 NAME   STATE
 spod   RUNNING
 ```
+
+## Configure a custom kubelet root directory
+
+You can configure a custom kubelet root directory in case your cluster is not using the default `/var/lib/kubelet` path.
+You can achieve this by setting the environment variable `KUBELET_DIR` in the operator deployment. This environment variable will
+be then set in the manager container as well as it will be propagated into the containers part of spod daemonset.
 
 ## Set logging verbosity
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -47,14 +47,6 @@ const (
 	// DefaultKubeletPath specifies the default kubelet path.
 	DefaultKubeletPath = "/var/lib/kubelet"
 
-	// KubeletSeccompRootPath specifies the path where all kubelet seccomp
-	// profiles are stored.
-	KubeletSeccompRootPath = "/var/lib/kubelet/seccomp"
-
-	// ProfilesRootPath specifies the path where the operator stores seccomp
-	// profiles.
-	ProfilesRootPath = KubeletSeccompRootPath + "/operator"
-
 	// NodeNameEnvKey is the default environment variable key for retrieving
 	// the name of the current node.
 	NodeNameEnvKey = "NODE_NAME"
@@ -170,4 +162,16 @@ func KubeletDir() string {
 		return DefaultKubeletPath
 	}
 	return kubeletDir
+}
+
+// KubeletSeccompRootPath specifies the path where all kubelet seccomp
+// profiles are stored.
+func KubeletSeccompRootPath() string {
+	return KubeletDir() + "/seccomp"
+}
+
+// ProfilesRootPath specifies the path where the operator stores seccomp
+// profiles.
+func ProfilesRootPath() string {
+	return KubeletSeccompRootPath() + "/operator"
 }

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -168,11 +168,11 @@ func KubeletDir() string {
 // KubeletSeccompRootPath specifies the path where all kubelet seccomp
 // profiles are stored.
 func KubeletSeccompRootPath() string {
-	return path.Join(KubeletDir() + "seccomp")
+	return path.Join(KubeletDir(), "seccomp")
 }
 
 // ProfilesRootPath specifies the path where the operator stores seccomp
 // profiles.
 func ProfilesRootPath() string {
-	return path.Join(KubeletSeccompRootPath() + "operator")
+	return path.Join(KubeletSeccompRootPath(), "operator")
 }

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -19,6 +19,7 @@ package config
 import (
 	"errors"
 	"os"
+	"path"
 	"path/filepath"
 
 	"sigs.k8s.io/release-utils/env"
@@ -167,11 +168,11 @@ func KubeletDir() string {
 // KubeletSeccompRootPath specifies the path where all kubelet seccomp
 // profiles are stored.
 func KubeletSeccompRootPath() string {
-	return KubeletDir() + "/seccomp"
+	return path.Join(KubeletDir() + "seccomp")
 }
 
 // ProfilesRootPath specifies the path where the operator stores seccomp
 // profiles.
 func ProfilesRootPath() string {
-	return KubeletSeccompRootPath() + "/operator"
+	return path.Join(KubeletSeccompRootPath() + "operator")
 }

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -44,6 +44,9 @@ const (
 	// UserRootless is the user which runs the operator.
 	UserRootless = 65535
 
+	// DefaultKubeletPath specifies the default kubelet path.
+	DefaultKubeletPath = "/var/lib/kubelet"
+
 	// KubeletSeccompRootPath specifies the path where all kubelet seccomp
 	// profiles are stored.
 	KubeletSeccompRootPath = "/var/lib/kubelet/seccomp"
@@ -83,6 +86,9 @@ const (
 	// ProfilingPortEnvKey is the environment variable key for choosing the
 	// profiling port.
 	ProfilingPortEnvKey = "SPO_PROFILING_PORT"
+
+	// KubeletDirEnvKey is the environment variable key for custom kubelet directory.
+	KubeletDirEnvKey = "KUBELET_DIR"
 
 	// DefaultProfilingPort is the start port where the profiling endpoint runs.
 	DefaultProfilingPort = 6060
@@ -154,4 +160,14 @@ func TryToGetOperatorNamespace() (string, error) {
 		return "", ErrPodNamespaceEnvNotFound
 	}
 	return operatorNS, nil
+}
+
+// KubeletDir returns the kubelet directory either form an environment variable
+// when is set or the default Kubernetes path.
+func KubeletDir() string {
+	kubeletDir := env.Default(KubeletDirEnvKey, "")
+	if kubeletDir == "" {
+		return DefaultKubeletPath
+	}
+	return kubeletDir
 }

--- a/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
@@ -210,7 +210,7 @@ func TestGetProfilePath(t *testing.T) {
 	}{
 		{
 			name: "AppendNamespaceAndProfile",
-			want: path.Join(config.ProfilesRootPath, "config-namespace", "file.json"),
+			want: path.Join(config.ProfilesRootPath(), "config-namespace", "file.json"),
 			sp: &seccompprofileapi.SeccompProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "file.json",
@@ -220,7 +220,7 @@ func TestGetProfilePath(t *testing.T) {
 		},
 		{
 			name: "BlockTraversalAtProfileName",
-			want: path.Join(config.ProfilesRootPath, "ns", "file.json"),
+			want: path.Join(config.ProfilesRootPath(), "ns", "file.json"),
 			sp: &seccompprofileapi.SeccompProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "../../../../../file.json",
@@ -230,7 +230,7 @@ func TestGetProfilePath(t *testing.T) {
 		},
 		{
 			name: "BlockTraversalAtTargetName",
-			want: path.Join(config.ProfilesRootPath, "ns", "file.json"),
+			want: path.Join(config.ProfilesRootPath(), "ns", "file.json"),
 			sp: &seccompprofileapi.SeccompProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "file.json",
@@ -240,7 +240,7 @@ func TestGetProfilePath(t *testing.T) {
 		},
 		{
 			name: "BlockTraversalAtSPNamespace",
-			want: path.Join(config.ProfilesRootPath, "ns", "file.json"),
+			want: path.Join(config.ProfilesRootPath(), "ns", "file.json"),
 			sp: &seccompprofileapi.SeccompProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "file.json",
@@ -250,7 +250,7 @@ func TestGetProfilePath(t *testing.T) {
 		},
 		{
 			name: "AppendExtension",
-			want: path.Join(config.ProfilesRootPath, "config-namespace", "file.json"),
+			want: path.Join(config.ProfilesRootPath(), "config-namespace", "file.json"),
 			sp: &seccompprofileapi.SeccompProfile{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "file",

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -276,7 +276,7 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 						VolumeMounts: []corev1.VolumeMount{
 							{
 								Name:      "host-operator-volume",
-								MountPath: config.ProfilesRootPath,
+								MountPath: config.ProfilesRootPath(),
 							},
 							{
 								Name:      "selinux-drop-dir",

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -190,6 +190,12 @@ var Manifest = &appsv1.DaemonSet{
 								corev1.ResourceEphemeralStorage: resource.MustParse("50Mi"),
 							},
 						},
+						Env: []corev1.EnvVar{
+							{
+								Name:  config.KubeletDirEnvKey,
+								Value: config.KubeletDir(),
+							},
+						},
 					},
 					{
 						Name:  SelinuxPoliciesCopierContainerName,
@@ -264,6 +270,12 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 								// libsemanage is very resource hungry...
 								corev1.ResourceMemory:           resource.MustParse("1024Mi"),
 								corev1.ResourceEphemeralStorage: resource.MustParse("50Mi"),
+							},
+						},
+						Env: []corev1.EnvVar{
+							{
+								Name:  config.KubeletDirEnvKey,
+								Value: config.KubeletDir(),
 							},
 						},
 					},
@@ -344,6 +356,10 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 								// Note that this will be set per SPOD instance
 								Name:  config.SPOdNameEnvKey,
 								Value: config.SPOdName,
+							},
+							{
+								Name:  config.KubeletDirEnvKey,
+								Value: config.KubeletDir(),
 							},
 						},
 						Ports: []corev1.ContainerPort{
@@ -432,6 +448,12 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 								corev1.ResourceEphemeralStorage: resource.MustParse("400Mi"),
 							},
 						},
+						Env: []corev1.EnvVar{
+							{
+								Name:  config.KubeletDirEnvKey,
+								Value: config.KubeletDir(),
+							},
+						},
 					},
 					{
 						Name:            LogEnricherContainerName,
@@ -482,6 +504,10 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 										FieldPath: "spec.nodeName",
 									},
 								},
+							},
+							{
+								Name:  config.KubeletDirEnvKey,
+								Value: config.KubeletDir(),
 							},
 						},
 					},
@@ -537,6 +563,10 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 										FieldPath: "spec.nodeName",
 									},
 								},
+							},
+							{
+								Name:  config.KubeletDirEnvKey,
+								Value: config.KubeletDir(),
 							},
 						},
 					},

--- a/internal/pkg/nonrootenabler/nonrootenabler.go
+++ b/internal/pkg/nonrootenabler/nonrootenabler.go
@@ -48,13 +48,13 @@ func (n *NonRootEnabler) Run(logger logr.Logger, runtime string) error {
 
 	logger.Info("Container runtime:" + runtime)
 
-	logger.Info("Ensuring seccomp root path: " + config.KubeletSeccompRootPath)
+	logger.Info("Ensuring seccomp root path: " + config.KubeletSeccompRootPath())
 	if err := n.impl.MkdirAll(
-		config.KubeletSeccompRootPath, dirPermissions,
+		config.KubeletSeccompRootPath(), dirPermissions,
 	); err != nil {
 		return fmt.Errorf(
 			"create seccomp root path %s: %w",
-			config.KubeletSeccompRootPath, err,
+			config.KubeletSeccompRootPath(), err,
 		)
 	}
 
@@ -64,7 +64,7 @@ func (n *NonRootEnabler) Run(logger logr.Logger, runtime string) error {
 	); err != nil {
 		return fmt.Errorf(
 			"create operator root path %s: %w",
-			config.KubeletSeccompRootPath, err,
+			config.KubeletSeccompRootPath(), err,
 		)
 	}
 
@@ -74,10 +74,10 @@ func (n *NonRootEnabler) Run(logger logr.Logger, runtime string) error {
 		return fmt.Errorf("change operator root path permissions: %w", err)
 	}
 
-	if _, err := n.impl.Stat(config.ProfilesRootPath); os.IsNotExist(err) {
+	if _, err := n.impl.Stat(config.ProfilesRootPath()); os.IsNotExist(err) {
 		logger.Info("Linking profiles root path")
 		if err := n.impl.Symlink(
-			config.OperatorRoot, config.ProfilesRootPath,
+			config.OperatorRoot, config.ProfilesRootPath(),
 		); err != nil {
 			return fmt.Errorf("link profiles root path: %w", err)
 		}
@@ -91,9 +91,9 @@ func (n *NonRootEnabler) Run(logger logr.Logger, runtime string) error {
 	}
 
 	kubeletSeccompRootPath := config.KubeletSeccompRootPath
-	logger.Info("Copying profiles into root path: " + kubeletSeccompRootPath)
+	logger.Info("Copying profiles into root path: " + kubeletSeccompRootPath())
 	if err := n.impl.CopyDirContentsLocal(
-		"/opt/spo-profiles", kubeletSeccompRootPath,
+		"/opt/spo-profiles", kubeletSeccompRootPath(),
 	); err != nil {
 		return fmt.Errorf("copy local security profiles: %w", err)
 	}

--- a/test/tc_allowed_syscalls_test.go
+++ b/test/tc_allowed_syscalls_test.go
@@ -57,7 +57,7 @@ func (e *e2e) testCaseAllowedSyscallsValidation(nodes []string) {
 		// the dev container where the tests are executed. This check needs to be skipped.
 		if e.nodeRootfsPrefix == "" {
 			statOutput := e.execNode(
-				node, "stat", "-L", "-c", `%a,%u,%g`, config.ProfilesRootPath,
+				node, "stat", "-L", "-c", `%a,%u,%g`, config.ProfilesRootPath(),
 			)
 			e.Contains(statOutput, "744,65535,65535")
 

--- a/test/tc_default_profiles_test.go
+++ b/test/tc_default_profiles_test.go
@@ -44,7 +44,7 @@ func (e *e2e) testCaseDefaultAndExampleProfiles(nodes []string) {
 		// the dev container where the tests are executed. This check needs to be skipped.
 		if e.nodeRootfsPrefix == "" {
 			statOutput := e.execNode(
-				node, "stat", "-L", "-c", `%a,%u,%g`, config.ProfilesRootPath,
+				node, "stat", "-L", "-c", `%a,%u,%g`, config.ProfilesRootPath(),
 			)
 			e.Contains(statOutput, "744,65535,65535")
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This makes the kubelet root directory configurable. kubelet has a command option which allows to
configure its root directory. This is the place form where the configuration is loaded, including
the seccomp profiles. 

This is useful in a cluster which doesn't use the default `/var/lib/kubelet` path. 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Make the kubelet root directory configurable via KUBELET_DIR environment variable.
```
