### PR TITLE
Mount the custom kubelet root directory into non-root-enabler container when is different from default

### DIFF
--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -827,3 +827,22 @@ func CustomHostProcVolume(path string) (corev1.Volume, corev1.VolumeMount) {
 			ReadOnly:  true,
 		}
 }
+
+// CustomHostKubeletVolume returns a new host path volume for custom kubelet path
+// as well as corresponding mount used for non-root-enabler.
+func CustomHostKubeletVolume(path string) (corev1.Volume, corev1.VolumeMount) {
+	const volumeName = "host-kubelet-volume"
+	return corev1.Volume{
+			Name: volumeName,
+			VolumeSource: corev1.VolumeSource{
+				HostPath: &corev1.HostPathVolumeSource{
+					Path: path,
+					Type: &hostPathDirectory,
+				},
+			},
+		}, corev1.VolumeMount{
+			Name:      volumeName,
+			MountPath: path,
+			ReadOnly:  false,
+		}
+}

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -520,6 +520,16 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 			"--with-selinux=true")
 	}
 
+	// Mount the kubelet custom directory into non-root-enabler container if is different
+	// than Kubernetes default kubelet directory. This is required in order to set it up for daemon.
+	if config.KubeletDir() != config.DefaultKubeletPath {
+		volume, mount := bindata.CustomHostKubeletVolume(config.KubeletDir())
+		templateSpec.Volumes = append(templateSpec.Volumes, volume)
+
+		nonRootEnabler := templateSpec.InitContainers[bindata.InitContainerIDNonRootenabler]
+		nonRootEnabler.VolumeMounts = append(nonRootEnabler.VolumeMounts, mount)
+	}
+
 	// Custom host proc volume
 	useCustomHostProc := cfg.Spec.HostProcVolumePath != bindata.DefaultHostProcPath
 	volume, mount := bindata.CustomHostProcVolume(cfg.Spec.HostProcVolumePath)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Mounts the custom kubelet root directory into non-root-enabler container when this is different from default kubelet 
root directory. For example, this is located outside `/var/lib` folder which is already mounted in non-root-enabler container.  

This required in order to allow non-root-enabler container to set up the security profiles configuration for daemon.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Mount the custom kubelet root directory inside non-root-enabler container when is different from default.
```
