### PR TITLE
Update the kubelet volume mount of non-root enabler container on the real object not on a copy of it

### DIFF
--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -526,8 +526,8 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 		volume, mount := bindata.CustomHostKubeletVolume(config.KubeletDir())
 		templateSpec.Volumes = append(templateSpec.Volumes, volume)
 
-		nonRootEnabler := templateSpec.InitContainers[bindata.InitContainerIDNonRootenabler]
-		nonRootEnabler.VolumeMounts = append(nonRootEnabler.VolumeMounts, mount)
+		templateSpec.InitContainers[bindata.InitContainerIDNonRootenabler].VolumeMounts =
+			append(templateSpec.InitContainers[bindata.InitContainerIDNonRootenabler].VolumeMounts, mount)
 	}
 
 	// Custom host proc volume

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -526,8 +526,8 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 		volume, mount := bindata.CustomHostKubeletVolume(config.KubeletDir())
 		templateSpec.Volumes = append(templateSpec.Volumes, volume)
 
-		templateSpec.InitContainers[bindata.InitContainerIDNonRootenabler].VolumeMounts =
-			append(templateSpec.InitContainers[bindata.InitContainerIDNonRootenabler].VolumeMounts, mount)
+		templateSpec.InitContainers[bindata.InitContainerIDNonRootenabler].VolumeMounts = append(
+			templateSpec.InitContainers[bindata.InitContainerIDNonRootenabler].VolumeMounts, mount)
 	}
 
 	// Custom host proc volume


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Update the volume mount on the effective object of non-root-enabler container instead of a copy with no effect.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Update the volume mount on the effective object of non-root-enabler container instead of a copy with no effect.
```
