### PR TITLE
Allow a custom kubelet directory for each node or pool of nodes

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -530,7 +530,20 @@ func runNonRootEnabler(ctx *cli.Context, info *version.Info) error {
 	const component = "non-root-enabler"
 	printInfo(component, info)
 	runtime := ctx.String("runtime")
-	return nonrootenabler.New().Run(ctrl.Log.WithName(component), runtime)
+
+	cfg, err := ctrl.GetConfig()
+	if err != nil {
+		return fmt.Errorf("getting config: %w", err)
+	}
+	mgr, err := ctrl.NewManager(cfg, ctrl.Options{})
+	if err != nil {
+		return fmt.Errorf("creating manager: %w", err)
+	}
+	kubeletDir, err := util.GetKubeletDirFromNodeLabel(ctx.Context, mgr.GetAPIReader())
+	if err != nil {
+		kubeletDir = config.KubeletDir()
+	}
+	return nonrootenabler.New().Run(ctrl.Log.WithName(component), runtime, kubeletDir)
 }
 
 func runWebhook(ctx *cli.Context, info *version.Info) error {

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -196,6 +196,16 @@ You can configure a custom kubelet root directory in case your cluster is not us
 You can achieve this by setting the environment variable `KUBELET_DIR` in the operator deployment. This environment variable will
 be then set in the manager container as well as it will be propagated into the containers part of spod daemonset.
 
+Furthermore, you can configure a custom kubelet root directory for each node or a pool of worker nodes inside the cluster. This
+can be achieved by applying the following label on each node object which has a custom path:
+
+```
+kubelet.kubernetes.io/directory-location: mnt-resource-kubelet
+```
+
+Where the value of the label is the kubelet root directory path, by replacing `/` with `-`. For example the value above is translated
+by the operator from `mnt-resource-kubelet` into path `/mnt/resource/kubelet`.
+
 ## Set logging verbosity
 
 The operator supports the default logging verbosity of `0` and an enhanced `1`.

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -39,6 +39,9 @@ const (
 	// from within the daemon.
 	SPOdNameEnvKey = "SPOD_NAME"
 
+	// HostRoot define the host files root mount path
+	HostRoot = "/host"
+
 	// OperatorRoot is the root directory of the operator.
 	OperatorRoot = "/var/lib/security-profiles-operator"
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -126,6 +126,10 @@ const (
 
 	// GRPCServerSocketBpfRecorder is the socket path for the GRPC bpf recorder server.
 	GRPCServerSocketBpfRecorder = "/var/run/grpc/bpf-recorder.sock"
+
+	// DefaultSpoProfilePath default path from where the security profiles are copied
+	// by non-root enabler.
+	DefaultSpoProfilePath = "/opt/spo-profiles"
 )
 
 // ProfileRecordingOutputPath is the path where the recorded profiles will be

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -42,7 +41,7 @@ const (
 	// from within the daemon.
 	SPOdNameEnvKey = "SPOD_NAME"
 
-	// HostRoot define the host files root mount path
+	// HostRoot define the host files root mount path.
 	HostRoot = "/host"
 
 	// SeccompProfilesFolder defines the folder name where the seccomp
@@ -165,7 +164,7 @@ var ProfileRecordingOutputPath = filepath.Join(os.TempDir(), "security-profiles-
 
 var ErrPodNamespaceEnvNotFound = errors.New("the env variable OPERATOR_NAMESPACE hasn't been set")
 
-// KubeletConfig stores various configuration parameters of the kubelet
+// KubeletConfig stores various configuration parameters of the kubelet.
 type KubeletConfig struct {
 	// KubeletDir kubelet root directory path
 	KubeletDir string `json:"kubeletDir,omitempty"`
@@ -217,14 +216,14 @@ func ProfilesRootPath() string {
 	return path.Join(KubeletSeccompRootPath(), OperatorProfilesFolder)
 }
 
-// KubeletConfigFilePath returns the kubelet config file path
+// KubeletConfigFilePath returns the kubelet config file path.
 func KubeletConfigFilePath() string {
 	return path.Join(OperatorRoot, KubeletConfigFile)
 }
 
-// GetKubeletConfigFromFile reads the kubelet config from file
+// GetKubeletConfigFromFile reads the kubelet config from file.
 func GetKubeletConfigFromFile() (*KubeletConfig, error) {
-	cfg, err := ioutil.ReadFile(KubeletConfigFilePath())
+	cfg, err := os.ReadFile(KubeletConfigFilePath())
 	if err != nil {
 		return nil, fmt.Errorf("reading kubelet config: %w", err)
 	}

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -196,6 +196,14 @@ var Manifest = &appsv1.DaemonSet{
 						},
 						Env: []corev1.EnvVar{
 							{
+								Name: config.NodeNameEnvKey,
+								ValueFrom: &corev1.EnvVarSource{
+									FieldRef: &corev1.ObjectFieldSelector{
+										FieldPath: "spec.nodeName",
+									},
+								},
+							},
+							{
 								Name:  config.KubeletDirEnvKey,
 								Value: config.KubeletDir(),
 							},

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -162,6 +162,10 @@ var Manifest = &appsv1.DaemonSet{
 								ReadOnly:  true,
 							},
 							{
+								Name:      "host-root-volume",
+								MountPath: config.HostRoot,
+							},
+							{
 								Name:      "metrics-cert-volume",
 								MountPath: metricsCertPath,
 							},
@@ -744,6 +748,15 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 						Name: "grpc-server-volume",
 						VolumeSource: corev1.VolumeSource{
 							EmptyDir: &corev1.EmptyDirVolumeSource{},
+						},
+					},
+					{
+						Name: "host-root-volume",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: "/",
+								Type: &hostPathDirectory,
+							},
 						},
 					},
 				},

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -520,16 +520,6 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 			"--with-selinux=true")
 	}
 
-	// Mount the kubelet custom directory into non-root-enabler container if is different
-	// than Kubernetes default kubelet directory. This is required in order to set it up for daemon.
-	if config.KubeletDir() != config.DefaultKubeletPath {
-		volume, mount := bindata.CustomHostKubeletVolume(config.KubeletDir())
-		templateSpec.Volumes = append(templateSpec.Volumes, volume)
-
-		templateSpec.InitContainers[bindata.InitContainerIDNonRootenabler].VolumeMounts = append(
-			templateSpec.InitContainers[bindata.InitContainerIDNonRootenabler].VolumeMounts, mount)
-	}
-
 	// Custom host proc volume
 	useCustomHostProc := cfg.Spec.HostProcVolumePath != bindata.DefaultHostProcPath
 	volume, mount := bindata.CustomHostProcVolume(cfg.Spec.HostProcVolumePath)

--- a/internal/pkg/nonrootenabler/nonrootenabler.go
+++ b/internal/pkg/nonrootenabler/nonrootenabler.go
@@ -64,11 +64,10 @@ func (n *NonRootEnabler) Run(logger logr.Logger, runtime string) error {
 	); err != nil {
 		return fmt.Errorf(
 			"create operator root path %s: %w",
-			config.KubeletSeccompRootPath(), err,
+			config.OperatorRoot, err,
 		)
 	}
 
-	// In case the directory already existed
 	logger.Info("Setting operator root permissions")
 	if err := n.impl.Chmod(config.OperatorRoot, dirPermissions); err != nil {
 		return fmt.Errorf("change operator root path permissions: %w", err)
@@ -93,7 +92,7 @@ func (n *NonRootEnabler) Run(logger logr.Logger, runtime string) error {
 	kubeletSeccompRootPath := config.KubeletSeccompRootPath
 	logger.Info("Copying profiles into root path: " + kubeletSeccompRootPath())
 	if err := n.impl.CopyDirContentsLocal(
-		"/opt/spo-profiles", kubeletSeccompRootPath(),
+		config.DefaultSpoProfilePath, kubeletSeccompRootPath(),
 	); err != nil {
 		return fmt.Errorf("copy local security profiles: %w", err)
 	}

--- a/internal/pkg/nonrootenabler/nonrootenabler.go
+++ b/internal/pkg/nonrootenabler/nonrootenabler.go
@@ -77,7 +77,12 @@ func (n *NonRootEnabler) Run(logger logr.Logger, runtime, kubeletDir string) err
 		return fmt.Errorf("change operator root path permissions: %w", err)
 	}
 
-	kubeletOperatorDir := path.Join(config.HostRoot, kubeletDir, config.OperatorProfilesFolder)
+	kubeletOperatorDir := path.Join(
+		config.HostRoot,
+		kubeletDir,
+		config.SeccompProfilesFolder,
+		config.OperatorProfilesFolder,
+	)
 	if _, err := n.impl.Stat(kubeletOperatorDir); os.IsNotExist(err) {
 		logger.Info("Linking profiles root path")
 		if err := n.impl.Symlink(

--- a/internal/pkg/nonrootenabler/nonrootenabler.go
+++ b/internal/pkg/nonrootenabler/nonrootenabler.go
@@ -19,7 +19,6 @@ package nonrootenabler
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 
@@ -46,7 +45,7 @@ func (n *NonRootEnabler) SetImpl(i impl) {
 }
 
 // Run executes the NonRootEnabler and returns an error if anything fails.
-func (n *NonRootEnabler) Run(logger logr.Logger, runtime string, kubeletDir string) error {
+func (n *NonRootEnabler) Run(logger logr.Logger, runtime, kubeletDir string) error {
 	const dirPermissions os.FileMode = 0o744
 	const filePermissions os.FileMode = 0o644
 
@@ -124,19 +123,19 @@ func (n *NonRootEnabler) Run(logger logr.Logger, runtime string, kubeletDir stri
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate -header ../../../hack/boilerplate/boilerplate.generatego.txt
 //counterfeiter:generate . impl
 type impl interface {
-	MkdirAll(path string, perm os.FileMode) error
+	MkdirAll(dirpath string, perm os.FileMode) error
 	Chmod(name string, mode os.FileMode) error
 	Stat(name string) (os.FileInfo, error)
 	Symlink(oldname, newname string) error
 	Chown(name string, uid, gid int) error
 	CopyDirContentsLocal(src, dst string) error
-	SaveKubeletConfig(filename string, config []byte, perm os.FileMode) error
+	SaveKubeletConfig(filename string, kubeletConfig []byte, perm os.FileMode) error
 }
 
 type defaultImpl struct{}
 
-func (*defaultImpl) MkdirAll(path string, perm os.FileMode) error {
-	return os.MkdirAll(path, perm)
+func (*defaultImpl) MkdirAll(dirpath string, perm os.FileMode) error {
+	return os.MkdirAll(dirpath, perm)
 }
 
 func (*defaultImpl) Chmod(name string, perm os.FileMode) error {
@@ -159,6 +158,6 @@ func (*defaultImpl) CopyDirContentsLocal(src, dst string) error {
 	return util.CopyDirContentsLocal(src, dst)
 }
 
-func (*defaultImpl) SaveKubeletConfig(filename string, config []byte, perm os.FileMode) error {
-	return ioutil.WriteFile(filename, config, perm)
+func (*defaultImpl) SaveKubeletConfig(filename string, kubeletConfig []byte, perm os.FileMode) error {
+	return os.WriteFile(filename, kubeletConfig, perm)
 }

--- a/internal/pkg/nonrootenabler/nonrootenabler_test.go
+++ b/internal/pkg/nonrootenabler/nonrootenabler_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
 
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/nonrootenabler"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/nonrootenabler/nonrootenablerfakes"
 )
@@ -83,13 +84,25 @@ func TestRun(t *testing.T) {
 			},
 			shouldError: true,
 		},
+		{ // failure on SaveKubeletConfig failure
+			prepare: func(mock *nonrootenablerfakes.FakeImpl) {
+				mock.SaveKubeletConfigReturns(errTest)
+			},
+			shouldError: true,
+		},
+		{ // success on SaveKubeletDir success
+			prepare: func(mock *nonrootenablerfakes.FakeImpl) {
+				mock.SaveKubeletConfigReturns(nil)
+			},
+			shouldError: false,
+		},
 	} {
 		sut := nonrootenabler.New()
 		mock := &nonrootenablerfakes.FakeImpl{}
 		tc.prepare(mock)
 		sut.SetImpl(mock)
 
-		err := sut.Run(logr.Discard(), "")
+		err := sut.Run(logr.Discard(), "", config.KubeletDir())
 		if tc.shouldError {
 			require.NotNil(t, err)
 		} else {

--- a/internal/pkg/nonrootenabler/nonrootenablerfakes/fake_impl.go
+++ b/internal/pkg/nonrootenabler/nonrootenablerfakes/fake_impl.go
@@ -72,6 +72,19 @@ type FakeImpl struct {
 	mkdirAllReturnsOnCall map[int]struct {
 		result1 error
 	}
+	SaveKubeletConfigStub        func(string, []byte, fs.FileMode) error
+	saveKubeletConfigMutex       sync.RWMutex
+	saveKubeletConfigArgsForCall []struct {
+		arg1 string
+		arg2 []byte
+		arg3 fs.FileMode
+	}
+	saveKubeletConfigReturns struct {
+		result1 error
+	}
+	saveKubeletConfigReturnsOnCall map[int]struct {
+		result1 error
+	}
 	StatStub        func(string) (fs.FileInfo, error)
 	statMutex       sync.RWMutex
 	statArgsForCall []struct {
@@ -350,6 +363,74 @@ func (fake *FakeImpl) MkdirAllReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeImpl) SaveKubeletConfig(arg1 string, arg2 []byte, arg3 fs.FileMode) error {
+	var arg2Copy []byte
+	if arg2 != nil {
+		arg2Copy = make([]byte, len(arg2))
+		copy(arg2Copy, arg2)
+	}
+	fake.saveKubeletConfigMutex.Lock()
+	ret, specificReturn := fake.saveKubeletConfigReturnsOnCall[len(fake.saveKubeletConfigArgsForCall)]
+	fake.saveKubeletConfigArgsForCall = append(fake.saveKubeletConfigArgsForCall, struct {
+		arg1 string
+		arg2 []byte
+		arg3 fs.FileMode
+	}{arg1, arg2Copy, arg3})
+	stub := fake.SaveKubeletConfigStub
+	fakeReturns := fake.saveKubeletConfigReturns
+	fake.recordInvocation("SaveKubeletConfig", []interface{}{arg1, arg2Copy, arg3})
+	fake.saveKubeletConfigMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) SaveKubeletConfigCallCount() int {
+	fake.saveKubeletConfigMutex.RLock()
+	defer fake.saveKubeletConfigMutex.RUnlock()
+	return len(fake.saveKubeletConfigArgsForCall)
+}
+
+func (fake *FakeImpl) SaveKubeletConfigCalls(stub func(string, []byte, fs.FileMode) error) {
+	fake.saveKubeletConfigMutex.Lock()
+	defer fake.saveKubeletConfigMutex.Unlock()
+	fake.SaveKubeletConfigStub = stub
+}
+
+func (fake *FakeImpl) SaveKubeletConfigArgsForCall(i int) (string, []byte, fs.FileMode) {
+	fake.saveKubeletConfigMutex.RLock()
+	defer fake.saveKubeletConfigMutex.RUnlock()
+	argsForCall := fake.saveKubeletConfigArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeImpl) SaveKubeletConfigReturns(result1 error) {
+	fake.saveKubeletConfigMutex.Lock()
+	defer fake.saveKubeletConfigMutex.Unlock()
+	fake.SaveKubeletConfigStub = nil
+	fake.saveKubeletConfigReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) SaveKubeletConfigReturnsOnCall(i int, result1 error) {
+	fake.saveKubeletConfigMutex.Lock()
+	defer fake.saveKubeletConfigMutex.Unlock()
+	fake.SaveKubeletConfigStub = nil
+	if fake.saveKubeletConfigReturnsOnCall == nil {
+		fake.saveKubeletConfigReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.saveKubeletConfigReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeImpl) Stat(arg1 string) (fs.FileInfo, error) {
 	fake.statMutex.Lock()
 	ret, specificReturn := fake.statReturnsOnCall[len(fake.statArgsForCall)]
@@ -487,6 +568,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.copyDirContentsLocalMutex.RUnlock()
 	fake.mkdirAllMutex.RLock()
 	defer fake.mkdirAllMutex.RUnlock()
+	fake.saveKubeletConfigMutex.RLock()
+	defer fake.saveKubeletConfigMutex.RUnlock()
 	fake.statMutex.RLock()
 	defer fake.statMutex.RUnlock()
 	fake.symlinkMutex.RLock()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

This PR allows to configure a custom kubelet root directory for each node or pool of nodes. This is done 
by applying the `kubelet.kubernetes.io/directory-location` label on the node objects that have a custom path. 
The value of the label is the custom kubelet root directory path, where the `/` is replaced by `-`.

The non-root enabler init container running inside the daemon pod, it will read the labels on the node is running
on. If the custom kubelet directory label is available, it will parse the value, and it will persist it into the operator 
configuration folder `/var/lib/security-profiles-operator`, such that it can be later read by the other containers. 

The `security-profiles-operator` daemon container will get now the kubelet root directory path from different 
locations in the following order:
* `/var/lib/security-profiles-operator/kubelet-config.json` file if exists
* `KUBELET_DIR` environment variable if exists
* use default Kubernetes value `/var/lib/kubelet`


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Fixes #1446

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Allow to configure a custom kubelet root directory for each node or a pool of nodes.

```
