### PR TITLE
Make the priority class name configurable in the SPOD configuration

### DIFF
--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -318,6 +318,11 @@ type SPODSpec struct {
 	// of SPOD daemon.
 	// +optional
 	DaemonResourceRequirements *corev1.ResourceRequirements `json:"daemonResourceRequirements,omitempty"`
+
+	// PriorityClassName if defined, indicates the spod pod priority class.
+	// +optional
+	// +kubebuilder:default="system-node-critical"
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 }
 
 // SPODState defines the state that the spod is in.

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_securityprofilesoperatordaemons.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_securityprofilesoperatordaemons.yaml
@@ -959,6 +959,11 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              priorityClassName:
+                default: system-node-critical
+                description: PriorityClassName if defined, indicates the spod pod
+                  priority class.
+                type: string
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator

--- a/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
@@ -957,6 +957,11 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              priorityClassName:
+                default: system-node-critical
+                description: PriorityClassName if defined, indicates the spod pod
+                  priority class.
+                type: string
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -1484,6 +1484,11 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              priorityClassName:
+                default: system-node-critical
+                description: PriorityClassName if defined, indicates the spod pod
+                  priority class.
+                type: string
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1484,6 +1484,11 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              priorityClassName:
+                default: system-node-critical
+                description: PriorityClassName if defined, indicates the spod pod
+                  priority class.
+                type: string
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -1484,6 +1484,11 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              priorityClassName:
+                default: system-node-critical
+                description: PriorityClassName if defined, indicates the spod pod
+                  priority class.
+                type: string
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -1484,6 +1484,11 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              priorityClassName:
+                default: system-node-critical
+                description: PriorityClassName if defined, indicates the spod pod
+                  priority class.
+                type: string
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1484,6 +1484,11 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              priorityClassName:
+                default: system-node-critical
+                description: PriorityClassName if defined, indicates the spod pod
+                  priority class.
+                type: string
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -1660,6 +1660,11 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                 type: array
+              priorityClassName:
+                default: system-node-critical
+                description: PriorityClassName if defined, indicates the spod pod
+                  priority class.
+                type: string
               selinuxOptions:
                 description: Defines options specific to the SELinux functionality
                   of the SecurityProfilesOperator

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -11,6 +11,7 @@
   - [Installation using helm](#installation-using-helm)
   - [Installation on AKS](#installation-on-aks)
 - [Configure a custom kubelet root directory](#configure-a-custom-kubelet-root-directory)
+- [Set a custom priority class name for spod daemon pod](#set-a-custom-priority-class-name-for-spod-daemon-pod)
 - [Set logging verbosity](#set-logging-verbosity)
 - [Pull images from private registry](#pull-images-from-private-registry)
 - [Configure the SELinux type](#configure-the-selinux-type)
@@ -205,6 +206,20 @@ kubelet.kubernetes.io/directory-location: mnt-resource-kubelet
 
 Where the value of the label is the kubelet root directory path, by replacing `/` with `-`. For example the value above is translated
 by the operator from `mnt-resource-kubelet` into path `/mnt/resource/kubelet`.
+
+## Set a custom priority class name for spod daemon pod
+
+The default priority class name of the spod daemon pod is set to `system-node-critical`. A custom priority class name can be configured
+in the SPOD configuration by setting a value in the `priorityClassName` filed.
+
+
+```
+> kubectl -n security-profiles-operator patch spod spod --type=merge -p '{"spec":{"priorityClassName":"my-priority-class"}}'
+securityprofilesoperatordaemon.security-profiles-operator.x-k8s.io/spod patched
+```
+
+This is useful in situations when the spod deamon pod remains in `Pending` state, because there isn't enough capacity on the related
+node to be scheduled.
 
 ## Set logging verbosity
 

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -70,6 +70,7 @@ const (
 	NonRootEnablerContainerName                = "non-root-enabler"
 	SelinuxPoliciesCopierContainerName         = "selinux-shared-policies-copier"
 	LocalSeccompProfilePath                    = "security-profiles-operator.json"
+	DefaultPriorityClassName                   = "system-node-critical"
 )
 
 var DefaultSPOD = &spodv1alpha1.SecurityProfilesOperatorDaemon{
@@ -85,6 +86,7 @@ var DefaultSPOD = &spodv1alpha1.SecurityProfilesOperatorDaemon{
 		EnableBpfRecorder:   false,
 		StaticWebhookConfig: false,
 		HostProcVolumePath:  DefaultHostProcPath,
+		PriorityClassName:   DefaultPriorityClassName,
 		SelinuxOpts: spodv1alpha1.SelinuxOptions{
 			AllowedSystemProfiles: []string{
 				"container",

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -656,6 +656,7 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 	templateSpec.Tolerations = cfg.Spec.Tolerations
 	templateSpec.Affinity = cfg.Spec.Affinity
 	templateSpec.ImagePullSecrets = cfg.Spec.ImagePullSecrets
+	templateSpec.PriorityClassName = cfg.Spec.PriorityClassName
 
 	return newSPOd
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

Make the priority class name configurable in the SPOD configuration, and it sets the default value to `system-node-critical`.

This is useful when the spod daemon pod remains in `Pending` state because there isn't enough capacity on the related not to be scheduled.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Make the priority class name configurable in th SPOD configuration.
```
