### PR TITLE
Add `spoc`, the Security Profiles Operator CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ LABEL name="Security Profiles Operator" \
 
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=make /work/result/security-profiles-operator /
+COPY --from=make /work/result/spoc /
 
 USER 65535:65535
 

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -49,6 +49,7 @@ LABEL name="Security Profiles Operator" \
       description="The Security Profiles Operator makes it easier for cluster admins to manage their seccomp, SELinux or AppArmor profiles and apply them to Kubernetes' workloads."
 
 COPY --from=build /work/build/security-profiles-operator /usr/bin/
+COPY --from=build /work/build/spoc /usr/bin/
 
 ENTRYPOINT ["/usr/bin/security-profiles-operator"]
 

--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ CI_IMAGE ?= golang:1.20
 CONTROLLER_GEN_CMD := CGO_LDFLAGS= $(GO) run -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen
 
 PROJECT := security-profiles-operator
+CLI_BINARY := spoc
 BUILD_DIR := build
 
 APPARMOR_ENABLED ?= 1
@@ -125,7 +126,7 @@ DOCKERFILE ?= Dockerfile
 
 # Utility targets
 
-all: $(BUILD_DIR)/$(PROJECT) ## Build the security-profiles-operator binary
+all: $(BUILD_DIR)/$(PROJECT) $(BUILD_DIR)/$(CLI_BINARY) ## Build the project binaries
 
 .PHONY: help
 help:  ## Display this help
@@ -147,8 +148,15 @@ help:  ## Display this help
 $(BUILD_DIR):
 	mkdir -p $(BUILD_DIR)
 
+define go-build-spo
+	$(GO) build -trimpath -ldflags '$(LDFLAGS)' -tags '$(BUILDTAGS)' -o $@ ./cmd/$(1)
+endef
+
 $(BUILD_DIR)/$(PROJECT): $(BUILD_DIR) $(BUILD_FILES)
-	$(GO) build -trimpath -ldflags '$(LDFLAGS)' -tags '$(BUILDTAGS)' -o $@ ./cmd/security-profiles-operator
+	$(call go-build-spo,$(PROJECT))
+
+$(BUILD_DIR)/$(CLI_BINARY): $(BUILD_DIR) $(BUILD_FILES)
+	$(call go-build-spo,$(CLI_BINARY))
 
 .PHONY: clean
 clean: ## Clean the build directory

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -1,0 +1,67 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cmd
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/urfave/cli/v2"
+
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/version"
+)
+
+const jsonFlag string = "json"
+
+func DefaultApp() (*cli.App, *version.Info) {
+	app := cli.NewApp()
+
+	info, err := version.Get()
+	if err != nil {
+		log.Fatal(err)
+	}
+	app.Version = info.Version
+
+	app.Commands = cli.Commands{
+		&cli.Command{
+			Name:    "version",
+			Aliases: []string{"v"},
+			Usage:   "display detailed version information",
+			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:    jsonFlag,
+					Aliases: []string{"j"},
+					Usage:   "print JSON instead of text",
+				},
+			},
+			Action: func(c *cli.Context) error {
+				res := info.String()
+				if c.Bool(jsonFlag) {
+					j, err := info.JSONString()
+					if err != nil {
+						return fmt.Errorf("unable to generate JSON from version info: %w", err)
+					}
+					res = j
+				}
+				print(res)
+				return nil
+			},
+		},
+	}
+
+	return app, info
+}

--- a/cmd/spoc/main.go
+++ b/cmd/spoc/main.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/urfave/cli/v2"
+
+	"sigs.k8s.io/security-profiles-operator/cmd"
+)
+
+func main() {
+	app, _ := cmd.DefaultApp()
+	app.Usage = "Security Profiles Operator CLI"
+
+	app.Commands = append(app.Commands,
+		&cli.Command{
+			Name:    "record",
+			Aliases: []string{"r"},
+			Usage:   "run the recorder",
+			Action:  record,
+		},
+	)
+
+	if err := app.Run(os.Args); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/cmd/spoc/record.go
+++ b/cmd/spoc/record.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import "github.com/urfave/cli/v2"
+
+// record runs the `spoc record` subcommand.
+func record(ctx *cli.Context) error {
+	return nil
+}

--- a/nix/derivation.nix
+++ b/nix/derivation.nix
@@ -24,6 +24,6 @@ with pkgs; buildGo119Module rec {
     make WITH_BPF=1
   '';
   installPhase = ''
-    install -Dm755 -t $out build/security-profiles-operator
+    install -Dm755 -t $out build/security-profiles-operator build/spoc
   '';
 }


### PR DESCRIPTION


#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:
We discussed in our last sync meeting that it would be helpful to have a slimmer SPO CLI for faster execution in edge scenarios. For that we would need a new binary, which can be used to directly interact with features like the ebpf recorder.


#### Which issue(s) this PR fixes:

Refers to https://github.com/kubernetes-sigs/security-profiles-operator/issues/1482

#### Does this PR have test?

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added `spoc` binary, the Security Profiles Operator CLI. This new binary is also part of the default container images.
```
