### PR TITLE
Wrap the `spoc` CLI from the operator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,5 +34,6 @@ COPY --from=make /work/result/security-profiles-operator /
 COPY --from=make /work/result/spoc /
 
 USER 65535:65535
+ENV PATH=/
 
 ENTRYPOINT ["/security-profiles-operator"]


### PR DESCRIPTION


#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
This allows us using the container images without overwriting its entrypoint:

```
> podman run -it security-profiles-operator spoc help
NAME:
   spoc - Security Profiles Operator CLI

USAGE:
   spoc [global options] command [command options] [arguments...]

VERSION:
   0.6.1-dev

COMMANDS:
   version, v  display detailed version information
   record, r   run the recorder
   help, h     Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --help, -h     show help
   --version, -v  print the version
```
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #1482 
#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Allow to run the `spoc` CLI from an operator `spoc`/`s` subcommand.
```
