### PR TITLE
selinux: Allow using other container-selinux policy templates than container

### DIFF
--- a/internal/pkg/translator/obj2cil.go
+++ b/internal/pkg/translator/obj2cil.go
@@ -27,7 +27,8 @@ import (
 )
 
 const (
-	typePermissive = "(typepermissive process)"
+	typePermissive         = "(typepermissive process)"
+	systemContainerInherit = "container"
 )
 
 func Object2CIL(
@@ -37,7 +38,17 @@ func Object2CIL(
 ) string {
 	cilbuilder := strings.Builder{}
 	cilbuilder.WriteString(getCILStart(sp))
+
+	// all templates must inherit from the system container. Without explicitly
+	// inheriting from the system container, the policy will not be loaded
+	// if it uses e.g. net_container or any other template because only the
+	// container template includes a "process" definition
+	cilbuilder.WriteString(getCILInheritline(systemContainerInherit))
 	for _, inherit := range systemInherits {
+		if inherit == systemContainerInherit {
+			// already appended above
+			continue
+		}
 		cilbuilder.WriteString(getCILInheritline(inherit))
 	}
 	for _, inherit := range objInherits {

--- a/internal/pkg/translator/obj2cil_test.go
+++ b/internal/pkg/translator/obj2cil_test.go
@@ -259,6 +259,48 @@ func TestObject2CIL(t *testing.T) {
 				"container",
 			},
 		},
+		{
+			name: "Test translation with another template than container",
+			profile: &selxv1alpha2.SelinuxProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "foo",
+					Namespace: "bar",
+				},
+				Spec: selxv1alpha2.SelinuxProfileSpec{
+					Inherit: []selxv1alpha2.PolicyRef{
+						{
+							Name: "net_container",
+						},
+					},
+					Allow: selxv1alpha2.Allow{
+						"var_log_t": {
+							"dir": []string{
+								"open",
+							},
+							"file": []string{
+								"getattr",
+							},
+							"sock_file": []string{
+								"getattr",
+							},
+						},
+					},
+				},
+			},
+			wantMatches: []string{
+				"\\(block foo_bar",
+				"\\(blockinherit container\\)",
+				"\\(blockinherit net_container\\)",
+				// We match on several lines since we don't care about the order
+				"\\(allow process var_log_t \\( dir \\(.*open.*\\)\\)\\)\n",
+				"\\(allow process var_log_t \\( file \\(.*getattr.*\\)\\)\\)\n",
+				"\\(allow process var_log_t \\( sock_file \\(.*getattr.*\\)\\)\\)\n",
+			},
+			inheritsys: []string{
+				"container",
+				"net_container",
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -97,6 +97,10 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			e.testCaseSelinuxBaseUsage,
 		},
 		{
+			"SELinux: non-default template",
+			e.testCaseSelinuxNonDefaultTemplate,
+		},
+		{
 			"SELinux: Metrics (update, delete)",
 			e.testCaseSelinuxMetrics,
 		},

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -665,6 +665,9 @@ func (e *e2e) enableSelinuxInSpod() {
 	if !strings.Contains(selinuxEnabledInSPODDS, "--with-selinux=true") {
 		e.logf("Enable selinux in SPOD")
 		e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableSelinux": true}}`, "--type=merge")
+		e.kubectlOperatorNS("patch", "spod", "spod", "-p",
+			`{"spec":{"selinuxOptions":{"allowedSystemProfiles":["container","net_container"]}}}`,
+			"--type=merge")
 
 		time.Sleep(defaultWaitTime)
 		e.waitInOperatorNSFor("condition=ready", "spod", "spod")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The container-selinux package (at least on RHEL/Fedora) ships a number
of policy templates. One of them is called simply `container` is special
in the sense that using it also creates a `type process`, the
others do not.

The effect is that if the other templates such as `net_container` should
be used, the CIL policy must also include the raw container type.

This patch amends the generation of the CIL policy from the SPO-specific
format so that the `container` type is always used.


#### Which issue(s) this PR fixes:
None

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

-->

#### Does this PR have test?
Yes

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
N/A

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug where SELinux policies inheriting from another template than container
would not load correctly.
```
