### PR TITLE
Remove bpftool dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,6 @@ BUILD_DIR := build
 APPARMOR_ENABLED ?= 1
 BPF_ENABLED ?= 1
 
-BPFTOOL ?= bpftool
 CLANG ?= clang
 LLVM_STRIP ?= llvm-strip
 BPF_PATH := internal/pkg/daemon/bpfrecorder/bpf

--- a/nix/derivation-bpf.nix
+++ b/nix/derivation-bpf.nix
@@ -7,7 +7,6 @@ with pkgs; buildGo120Module rec {
   doCheck = false;
   outputs = [ "out" ];
   nativeBuildInputs = with buildPackages; [
-    bpftools
     git
     llvmPackages_15.clang-unwrapped
     llvm_15


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
The bpftool(s) dependency is not required any more since libbpf-go 1.1.0.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
