### PR TITLE
Add base syscalls for spoc recording

### DIFF
--- a/cmd/spoc/main.go
+++ b/cmd/spoc/main.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/urfave/cli/v2"
 
@@ -55,6 +56,18 @@ func main() {
 						recorder.TypeSeccomp,
 						recorder.TypeRawSeccomp,
 					),
+				},
+				&cli.StringSliceFlag{
+					Name:    recorder.FlagBaseSyscalls,
+					Aliases: []string{"b"},
+					Usage: "base syscalls to be included in every profile " +
+						"to ensure compatibility with OCI runtimes like runc and crun",
+					DefaultText: strings.Join(recorder.DefaultBaseSyscalls, ", "),
+				},
+				&cli.BoolFlag{
+					Name:    recorder.FlagNoBaseSyscalls,
+					Aliases: []string{"n"},
+					Usage:   "do not add any base syscalls at all",
 				},
 			},
 		},

--- a/internal/pkg/cli/recorder/consts.go
+++ b/internal/pkg/cli/recorder/consts.go
@@ -27,6 +27,14 @@ const (
 
 	// FlagType is the flag for defining the recorder type.
 	FlagType string = "type"
+
+	// FlagBaseSyscalls are the syscalls included in every seccomp profile to
+	// ensure compatibility with OCI runtimes like runc and crun.
+	FlagBaseSyscalls string = "base-syscalls"
+
+	// FlagNoBaseSyscalls can be used to indicate that no base syscalls should
+	// be added at all.
+	FlagNoBaseSyscalls string = "no-base-syscalls"
 )
 
 // Type is the enum for all available recorder types.
@@ -42,5 +50,82 @@ const (
 	TypeRawSeccomp Type = "raw-seccomp"
 )
 
-// DefaultOutputFile defines the default output location for the recorder.
-var DefaultOutputFile = filepath.Join(os.TempDir(), "profile.yaml")
+var (
+	// DefaultOutputFile defines the default output location for the recorder.
+	DefaultOutputFile = filepath.Join(os.TempDir(), "profile.yaml")
+
+	// DefaultBaseSyscalls are the syscalls included in every seccomp profile
+	// to ensure compatibility with OCI runtimes like runc and crun.
+	//
+	// Please note that the syscalls may vary depending on which container
+	// runtime we choose.
+	DefaultBaseSyscalls = []string{
+		"access",
+		"arch_prctl",
+		"brk",
+		"capget",
+		"capset",
+		"chdir",
+		"close",
+		"close_range",
+		"dup2",
+		"dup3",
+		"epoll_ctl",
+		"epoll_pwait",
+		"execve",
+		"exit_group",
+		"faccessat2",
+		"fchdir",
+		"fchown",
+		"fcntl",
+		"fstat",
+		"fstatfs",
+		"futex",
+		"getcwd",
+		"getdents64",
+		"getegid",
+		"geteuid",
+		"getgid",
+		"getpid",
+		"getppid",
+		"getrandom",
+		"getuid",
+		"ioctl",
+		"lseek",
+		"mmap",
+		"mount",
+		"mprotect",
+		"nanosleep",
+		"newfstatat",
+		"openat",
+		"openat2",
+		"pivot_root",
+		"prctl",
+		"prlimit64",
+		"pselect6",
+		"read",
+		"readlink",
+		"rseq",
+		"rt_sigaction",
+		"rt_sigprocmask",
+		"rt_sigreturn",
+		"select",
+		"set_robust_list",
+		"set_tid_address",
+		"setgid",
+		"setgroups",
+		"sethostname",
+		"setresgid",
+		"setresuid",
+		"setsid",
+		"setuid",
+		"stat",
+		"statfs",
+		"statx",
+		"tgkill",
+		"umask",
+		"umount2",
+		"uname",
+		"write",
+	}
+)

--- a/internal/pkg/cli/recorder/options.go
+++ b/internal/pkg/cli/recorder/options.go
@@ -25,17 +25,19 @@ import (
 
 // Options define all possible options for the recorder.
 type Options struct {
-	typ        Type
-	outputFile string
-	command    string
-	args       []string
+	typ          Type
+	outputFile   string
+	baseSyscalls []string
+	command      string
+	args         []string
 }
 
 // Default returns a default options instance.
 func Default() *Options {
 	return &Options{
-		typ:        TypeSeccomp,
-		outputFile: DefaultOutputFile,
+		typ:          TypeSeccomp,
+		outputFile:   DefaultOutputFile,
+		baseSyscalls: DefaultBaseSyscalls,
 	}
 }
 
@@ -55,6 +57,13 @@ func FromContext(ctx *cli.Context) (*Options, error) {
 	}
 	if options.typ != TypeSeccomp && options.typ != TypeRawSeccomp {
 		return nil, fmt.Errorf("unsupported %s: %s", FlagType, options.typ)
+	}
+
+	if ctx.IsSet(FlagBaseSyscalls) {
+		options.baseSyscalls = ctx.StringSlice(FlagBaseSyscalls)
+	}
+	if ctx.IsSet(FlagNoBaseSyscalls) {
+		options.baseSyscalls = nil
 	}
 
 	args := ctx.Args().Slice()


### PR DESCRIPTION


#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This allows to have a preset of defined syscalls required as a minimum to run containers with runc and crun.

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes-sigs/security-profiles-operator/issues/1482

#### Does this PR have test?

Yes

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Added `--base-syscalls` to `spoc record` to ensure compatibility with OCI runtimes like runc and crun.
```
