### PR TITLE
Pin nix version in GitHub actions to fix builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
 env:
   GO_VERSION: '1.20'
+  NIX_VERSION: '2.13.3'
 
 permissions: {}
 
@@ -25,6 +26,8 @@ jobs:
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: cachix/install-nix-action@5c11eae19dba042788936d4f1c9685fdd814ac49
+        with:
+          install_url: https://releases.nixos.org/nix/nix-${{ env.NIX_VERSION }}/install
       - uses: cachix/cachix-action@6a9a34cdd93d0ae4b4b59fd678660efb08109f2f
         with:
           name: security-profiles-operator
@@ -40,6 +43,8 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - uses: cachix/install-nix-action@5c11eae19dba042788936d4f1c9685fdd814ac49
+        with:
+          install_url: https://releases.nixos.org/nix/nix-${{ env.NIX_VERSION }}/install
       - uses: cachix/cachix-action@6a9a34cdd93d0ae4b4b59fd678660efb08109f2f
         with:
           name: security-profiles-operator

--- a/Dockerfile.build-image
+++ b/Dockerfile.build-image
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y wget xz-utils libapparmor-dev
 
 ENV USER=root
 
-ARG NIX_VERSION=2.13.2
+ARG NIX_VERSION=2.13.3
 RUN wget https://nixos.org/releases/nix/nix-${NIX_VERSION}/nix-${NIX_VERSION}-x86_64-linux.tar.xz && \
     tar xf nix-${NIX_VERSION}-x86_64-linux.tar.xz && \
     groupadd -r -g 30000 nixbld && \

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -126,9 +126,11 @@ dependencies:
       match: registry.access.redhat.com/ubi8/go-toolset
 
   - name: nix
-    version: 2.13.2
+    version: 2.13.3
     refPaths:
     - path: Dockerfile.build-image
+      match: NIX_VERSION
+    - path: .github/workflows/build.yml
       match: NIX_VERSION
 
   - name: kube-rbac-proxy


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
We have to pin the GitHub actions nix version to v2.13.3 to avoid having the regression mentioned in https://github.com/cachix/cachix-action/issues/138#issuecomment-1448952201.

This should fix the build CI.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
