### PR TITLE
Always use filepath.Base for command filter

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strconv"
@@ -121,7 +122,7 @@ func (b *BpfRecorder) Syscalls() *bpf.BPFMap {
 
 // FilterProgramName can be used to filter on a specific program name.
 func (b *BpfRecorder) FilterProgramName(filter string) {
-	b.programNameFilter = filter
+	b.programNameFilter = filepath.Base(filter)
 }
 
 // Run the BpfRecorder.


### PR DESCRIPTION

#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We can only filter the base name in ebpf, so it makes sense to apply `filepath.Base()` to every filtered command. This fixes an issue with providing relative or absolute binary paths in spoc record.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
PTAL @kubernetes-sigs/security-profiles-operator-maintainers 
Part of #1482 
#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
