### PR TITLE
Cleanup enricher init

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -504,11 +504,7 @@ func runLogEnricher(_ *cli.Context, info *version.Info) error {
 	const component = "log-enricher"
 	printInfo(component, info)
 
-	e, err := enricher.New(ctrl.Log.WithName(component))
-	if err != nil {
-		return fmt.Errorf("building log enricher: %w", err)
-	}
-	return e.Run()
+	return enricher.New(ctrl.Log.WithName(component)).Run()
 }
 
 func runNonRootEnabler(ctx *cli.Context, info *version.Info) error {

--- a/internal/pkg/daemon/enricher/container.go
+++ b/internal/pkg/daemon/enricher/container.go
@@ -83,7 +83,7 @@ func (e *Enricher) populateContainerPodCache(
 	return util.RetryEx(
 		&containerRetryBackoff,
 		func() (retryErr error) {
-			pods, err := e.impl.ListPods(ctxwithTimeout, e.clientset, nodeName)
+			pods, err := e.ListPods(ctxwithTimeout, e.clientset, nodeName)
 			if err != nil {
 				return fmt.Errorf("list node %s's pods: %w", nodeName, err)
 			}

--- a/internal/pkg/daemon/enricher/enricher_test.go
+++ b/internal/pkg/daemon/enricher/enricher_test.go
@@ -323,8 +323,8 @@ func TestRun(t *testing.T) {
 		mock := &enricherfakes.FakeImpl{}
 		tc.prepare(mock, lineChan)
 
-		sut, ebuildErr := New(logr.Discard(), mock)
-		require.NoError(t, ebuildErr)
+		sut := New(logr.Discard())
+		sut.impl = mock
 
 		var err error
 		if tc.runAsync {


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
We can init the clientset directly on `Run`, making the initialization of the enricher more streamlined compared to other routines running within the daemon.

We now also use the `impl` of the Enricher directly when calling its methods.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
