### PR TITLE
Verify that base profiles exist in GitHub container registry

### DIFF
--- a/hack/ci/baseprofiles.sh
+++ b/hack/ci/baseprofiles.sh
@@ -167,6 +167,10 @@ EOT
 
     echo "Diffing output, while ignoring flaky syscalls 'rt_sigreturn', 'sched_yield' and 'tgkill'"
     git diff --exit-code -U0 -I rt_sigreturn -I sched_yield -I tgkill examples
+
+    echo "Verifying that profile is available in the GitHub container registry"
+    cosign verify --certificate-identity-regexp '.*' --certificate-oidc-issuer-regexp '.*' \
+        "ghcr.io/security-profiles/$RUNTIME:v$VERSION"
 }
 
 install_yq


### PR DESCRIPTION
#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:
We now feature two package repositories for the baseprofiles in https://github.com/orgs/security-profiles/packages

Means that we can use `spoc push` to manually maintain them for now. At some later stage we can add automation to push them on the fly.

The repositories have to made public as well, otherwise `cosign verify` will fail.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Part of #1482 
#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
