### PR TITLE
Fix: namespace resource should not be defined in the helm chart

### DIFF
--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -1,19 +1,4 @@
 apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    meta.helm.sh/release-name: security-profiles-operator
-    meta.helm.sh/release-namespace: '{{ .Release.Namespace }}'
-  labels:
-    app: security-profiles-operator
-    app.kubernetes.io/managed-by: Helm
-    helm.sh/chart: security-profiles-operator
-    pod-security.kubernetes.io/audit: privileged
-    pod-security.kubernetes.io/enforce: privileged
-    pod-security.kubernetes.io/warn: privileged
-  name: '{{ .Release.Namespace }}'
----
-apiVersion: v1
 kind: ServiceAccount
 metadata:
   annotations:

--- a/deploy/overlays/helm/delete-ns.yaml
+++ b/deploy/overlays/helm/delete-ns.yaml
@@ -1,0 +1,5 @@
+$patch: delete
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: security-profiles-operator

--- a/deploy/overlays/helm/kustomization.yaml
+++ b/deploy/overlays/helm/kustomization.yaml
@@ -25,18 +25,6 @@ patches:
   target:
     kind: (ClusterRoleBinding|RoleBinding)
 
-  # Replace the namespace name into the namespace resource.
-  # Remove unused openshift label
-- patch: |
-    - op: replace
-      path: /metadata/name
-      value: "{{ .Release.Namespace }}"
-    - op: remove
-      path:  "/metadata/labels/openshift.io~1cluster-monitoring"
-      value: "true"
-  target:
-    kind: Namespace
-
 # TODO: get webhook deployment replicas from values file
 - patch: |
     - op: replace
@@ -67,3 +55,6 @@ patches:
       value: "{{ .Release.Namespace }}"
   target:
     kind: (ClusterRole|ClusterRoleBinding|ConfigMap|MutatingWebhookConfiguration|Namespace|Role|RoleBinding|Secret|ServiceAccount)
+
+# Remove the namespace resource.
+- path: delete-ns.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:
Fixes #1567 

#### Does this PR have test?
N/A
You can test trying to install it to a cluster with an existing ns, like shown in the issue.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
NONE
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed a bug that prevents helm install to work when installing on a cluster where the namespace already exists.
```
