### PR TITLE
Remove `OutputProfile` type

### DIFF
--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -158,6 +158,10 @@ const (
 	// DefaultSpoProfilePath default path from where the security profiles are copied
 	// by non-root enabler.
 	DefaultSpoProfilePath = "/opt/spo-profiles"
+
+	// OCIProfilePrefix is the prefix used for specifying security profiles
+	// from OCI artifacts.
+	OCIProfilePrefix = "oci://"
 )
 
 // ProfileRecordingOutputPath is the path where the recorded profiles will be

--- a/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
@@ -278,25 +278,27 @@ func TestAllowProfile(t *testing.T) {
 		name                  string
 		allowedSyscalls       []string
 		allowedSeccompActions []seccomp.Action
-		profile               *OutputProfile
+		profile               *seccompprofileapi.SeccompProfile
 		want                  error
 	}{
 		{
 			name:                  "EmptyProfile",
 			allowedSyscalls:       []string{"a", "b", "c"},
 			allowedSeccompActions: []seccomp.Action{seccomp.ActAllow, seccomp.ActLog, seccomp.ActTrace},
-			profile:               &OutputProfile{},
+			profile:               &seccompprofileapi.SeccompProfile{},
 			want:                  nil,
 		},
 		{
 			name:                  "EmptyAllowedList",
 			allowedSyscalls:       []string{},
 			allowedSeccompActions: []seccomp.Action{},
-			profile: &OutputProfile{
-				Syscalls: []*seccompprofileapi.Syscall{
-					{
-						Action: seccomp.ActAllow,
-						Names:  []string{"a"},
+			profile: &seccompprofileapi.SeccompProfile{
+				Spec: seccompprofileapi.SeccompProfileSpec{
+					Syscalls: []*seccompprofileapi.Syscall{
+						{
+							Action: seccomp.ActAllow,
+							Names:  []string{"a"},
+						},
 					},
 				},
 			},
@@ -306,11 +308,13 @@ func TestAllowProfile(t *testing.T) {
 			name:                  "ProfileWithEmptySyscalls",
 			allowedSyscalls:       []string{"a", "b", "c"},
 			allowedSeccompActions: []seccomp.Action{seccomp.ActAllow, seccomp.ActLog, seccomp.ActTrace},
-			profile: &OutputProfile{
-				Syscalls: []*seccompprofileapi.Syscall{
-					{
-						Action: seccomp.ActAllow,
-						Names:  []string{},
+			profile: &seccompprofileapi.SeccompProfile{
+				Spec: seccompprofileapi.SeccompProfileSpec{
+					Syscalls: []*seccompprofileapi.Syscall{
+						{
+							Action: seccomp.ActAllow,
+							Names:  []string{},
+						},
 					},
 				},
 			},
@@ -320,11 +324,13 @@ func TestAllowProfile(t *testing.T) {
 			name:                  "AllowProfile",
 			allowedSyscalls:       []string{"a", "b", "c"},
 			allowedSeccompActions: []seccomp.Action{seccomp.ActAllow, seccomp.ActLog, seccomp.ActTrace},
-			profile: &OutputProfile{
-				Syscalls: []*seccompprofileapi.Syscall{
-					{
-						Action: seccomp.ActAllow,
-						Names:  []string{"b"},
+			profile: &seccompprofileapi.SeccompProfile{
+				Spec: seccompprofileapi.SeccompProfileSpec{
+					Syscalls: []*seccompprofileapi.Syscall{
+						{
+							Action: seccomp.ActAllow,
+							Names:  []string{"b"},
+						},
 					},
 				},
 			},
@@ -334,11 +340,13 @@ func TestAllowProfile(t *testing.T) {
 			name:                  "RejectProfile",
 			allowedSyscalls:       []string{"a", "b", "c"},
 			allowedSeccompActions: []seccomp.Action{seccomp.ActAllow, seccomp.ActLog, seccomp.ActTrace},
-			profile: &OutputProfile{
-				Syscalls: []*seccompprofileapi.Syscall{
-					{
-						Action: seccomp.ActAllow,
-						Names:  []string{"d"},
+			profile: &seccompprofileapi.SeccompProfile{
+				Spec: seccompprofileapi.SeccompProfileSpec{
+					Syscalls: []*seccompprofileapi.Syscall{
+						{
+							Action: seccomp.ActAllow,
+							Names:  []string{"d"},
+						},
 					},
 				},
 			},
@@ -348,19 +356,21 @@ func TestAllowProfile(t *testing.T) {
 			name:                  "AllAllowedActions",
 			allowedSyscalls:       []string{"a", "b", "c"},
 			allowedSeccompActions: []seccomp.Action{seccomp.ActAllow, seccomp.ActLog, seccomp.ActTrace},
-			profile: &OutputProfile{
-				Syscalls: []*seccompprofileapi.Syscall{
-					{
-						Action: seccomp.ActAllow,
-						Names:  []string{"a"},
-					},
-					{
-						Action: seccomp.ActLog,
-						Names:  []string{"b"},
-					},
-					{
-						Action: seccomp.ActTrace,
-						Names:  []string{"c"},
+			profile: &seccompprofileapi.SeccompProfile{
+				Spec: seccompprofileapi.SeccompProfileSpec{
+					Syscalls: []*seccompprofileapi.Syscall{
+						{
+							Action: seccomp.ActAllow,
+							Names:  []string{"a"},
+						},
+						{
+							Action: seccomp.ActLog,
+							Names:  []string{"b"},
+						},
+						{
+							Action: seccomp.ActTrace,
+							Names:  []string{"c"},
+						},
 					},
 				},
 			},
@@ -370,31 +380,33 @@ func TestAllowProfile(t *testing.T) {
 			name:                  "AllForbiddenActions",
 			allowedSyscalls:       []string{"a", "b", "c"},
 			allowedSeccompActions: []seccomp.Action{seccomp.ActAllow, seccomp.ActLog, seccomp.ActTrace},
-			profile: &OutputProfile{
-				Syscalls: []*seccompprofileapi.Syscall{
-					{
-						Action: seccomp.ActErrno,
-						Names:  []string{"a"},
-					},
-					{
-						Action: seccomp.ActTrap,
-						Names:  []string{"d"},
-					},
-					{
-						Action: seccomp.ActKillThread,
-						Names:  []string{"e"},
-					},
-					{
-						Action: seccomp.ActKillThread,
-						Names:  []string{"f"},
-					},
-					{
-						Action: seccomp.ActKillProcess,
-						Names:  []string{"g"},
-					},
-					{
-						Action: seccomp.ActKill,
-						Names:  []string{"b"},
+			profile: &seccompprofileapi.SeccompProfile{
+				Spec: seccompprofileapi.SeccompProfileSpec{
+					Syscalls: []*seccompprofileapi.Syscall{
+						{
+							Action: seccomp.ActErrno,
+							Names:  []string{"a"},
+						},
+						{
+							Action: seccomp.ActTrap,
+							Names:  []string{"d"},
+						},
+						{
+							Action: seccomp.ActKillThread,
+							Names:  []string{"e"},
+						},
+						{
+							Action: seccomp.ActKillThread,
+							Names:  []string{"f"},
+						},
+						{
+							Action: seccomp.ActKillProcess,
+							Names:  []string{"g"},
+						},
+						{
+							Action: seccomp.ActKill,
+							Names:  []string{"b"},
+						},
 					},
 				},
 			},
@@ -404,8 +416,10 @@ func TestAllowProfile(t *testing.T) {
 			name:                  "AllowedAll",
 			allowedSyscalls:       []string{"a"},
 			allowedSeccompActions: []seccomp.Action{seccomp.ActAllow, seccomp.ActLog, seccomp.ActTrace},
-			profile: &OutputProfile{
-				DefaultAction: seccomp.ActAllow,
+			profile: &seccompprofileapi.SeccompProfile{
+				Spec: seccompprofileapi.SeccompProfileSpec{
+					DefaultAction: seccomp.ActAllow,
+				},
 			},
 			want: fmt.Errorf(errForbiddenProfile),
 		},
@@ -413,8 +427,10 @@ func TestAllowProfile(t *testing.T) {
 			name:                  "DeniedAll",
 			allowedSyscalls:       []string{"a"},
 			allowedSeccompActions: []seccomp.Action{seccomp.ActAllow, seccomp.ActLog, seccomp.ActTrace},
-			profile: &OutputProfile{
-				DefaultAction: seccomp.ActErrno,
+			profile: &seccompprofileapi.SeccompProfile{
+				Spec: seccompprofileapi.SeccompProfileSpec{
+					DefaultAction: seccomp.ActErrno,
+				},
 			},
 			want: nil,
 		},
@@ -422,15 +438,17 @@ func TestAllowProfile(t *testing.T) {
 			name:                  "DeniedAction",
 			allowedSyscalls:       []string{"a", "b", "c"},
 			allowedSeccompActions: []seccomp.Action{seccomp.ActErrno},
-			profile: &OutputProfile{
-				Syscalls: []*seccompprofileapi.Syscall{
-					{
-						Action: seccomp.ActAllow,
-						Names:  []string{"a"},
-					},
-					{
-						Action: seccomp.ActTrace,
-						Names:  []string{"b"},
+			profile: &seccompprofileapi.SeccompProfile{
+				Spec: seccompprofileapi.SeccompProfileSpec{
+					Syscalls: []*seccompprofileapi.Syscall{
+						{
+							Action: seccomp.ActAllow,
+							Names:  []string{"a"},
+						},
+						{
+							Action: seccomp.ActTrace,
+							Names:  []string{"b"},
+						},
 					},
 				},
 			},

--- a/test/tc_default_profiles_test.go
+++ b/test/tc_default_profiles_test.go
@@ -25,7 +25,6 @@ import (
 	seccompprofileapi "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"
 	secprofnodestatusv1alpha1 "sigs.k8s.io/security-profiles-operator/api/secprofnodestatus/v1alpha1"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
-	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/seccompprofile"
 )
 
 func (e *e2e) testCaseDefaultAndExampleProfiles(nodes []string) {
@@ -96,10 +95,10 @@ func (e *e2e) verifyCRDProfileContent(node string, sp *seccompprofileapi.Seccomp
 	e.logf("Verifying %s profile on node %s", sp.Name, node)
 	profilePath := path.Join(e.nodeRootfsPrefix, sp.GetProfileOperatorPath())
 	catOutput := e.execNode(node, "cat", profilePath)
-	output := seccompprofile.OutputProfile{}
+	output := seccompprofileapi.SeccompProfileSpec{}
 	err := json.Unmarshal([]byte(catOutput), &output)
 	e.Nil(err)
-	expected := seccompprofile.OutputProfile{}
+	expected := seccompprofileapi.SeccompProfileSpec{}
 	spec, err := json.Marshal(sp.Spec)
 	e.Nil(err)
 	err = json.Unmarshal(spec, &expected)


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Remove the `OutputProfile` type and directly use `seccompprofileapi.SeccompProfileSpec`.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
