### PR TITLE
Update CRI-O and runc/crun base profiles

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -164,13 +164,13 @@ dependencies:
       match: VERSION
 
   - name: CRI-O
-    version: v1.26.2
+    version: v1.26.3
     refPaths:
     - path: hack/ci/install-cri-o.sh
       match: TAG
 
   - name: crun
-    version: v1.8.1
+    version: v1.8.3
     refPaths:
     - path: examples/baseprofile-crun.yaml
       match: name
@@ -178,7 +178,7 @@ dependencies:
       match: baseProfileNameCrun
 
   - name: runc
-    version: v1.1.4
+    version: v1.1.5
     refPaths:
     - path: examples/baseprofile-runc.yaml
       match: name

--- a/examples/baseprofile-crun.yaml
+++ b/examples/baseprofile-crun.yaml
@@ -2,7 +2,7 @@
 apiVersion: security-profiles-operator.x-k8s.io/v1beta1
 kind: SeccompProfile
 metadata:
-  name: crun-v1.8.1
+  name: crun-v1.8.3
 spec:
   defaultAction: SCMP_ACT_ERRNO
   architectures:
@@ -54,6 +54,7 @@ spec:
         - setresgid
         - setresuid
         - setsid
+        - statfs
         - statx
         - symlinkat
         - umask

--- a/examples/baseprofile-runc.yaml
+++ b/examples/baseprofile-runc.yaml
@@ -2,7 +2,7 @@
 apiVersion: security-profiles-operator.x-k8s.io/v1beta1
 kind: SeccompProfile
 metadata:
-  name: runc-v1.1.4
+  name: runc-v1.1.5
 spec:
   defaultAction: SCMP_ACT_ERRNO
   architectures:

--- a/hack/ci/install-cri-o.sh
+++ b/hack/ci/install-cri-o.sh
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-TAG=v1.26.2
+TAG=v1.26.3
 
 curl_retry() {
     curl -sSfL --retry 5 --retry-delay 3 "$@"

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -1,6 +1,7 @@
 # Installation and Usage
 
 <!-- toc -->
+
 - [Features](#features)
 - [Architecture](#architecture)
 - [Tutorials and Demos](#tutorials-and-demos)
@@ -514,7 +515,7 @@ metadata:
   name: profile1
 spec:
   defaultAction: SCMP_ACT_ERRNO
-  baseProfileName: runc-v1.1.4
+  baseProfileName: runc-v1.1.5
   syscalls:
     - action: SCMP_ACT_ALLOW
       names:
@@ -550,7 +551,7 @@ metadata:
   name: profile1
 spec:
   defaultAction: SCMP_ACT_ERRNO
-  baseProfileName: oci://ghcr.io/security-profiles/runc:v1.1.4
+  baseProfileName: oci://ghcr.io/security-profiles/runc:v1.1.5
 ```
 
 The resulting profile `profile1` will then contain all base syscalls from the

--- a/test/tc_base_profiles_test.go
+++ b/test/tc_base_profiles_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	baseProfileNameRunc = "runc-v1.1.4"
-	baseProfileNameCrun = "crun-v1.8.1"
+	baseProfileNameRunc = "runc-v1.1.5"
+	baseProfileNameCrun = "crun-v1.8.3"
 )
 
 func (e *e2e) testCaseBaseProfile([]string) {


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Updated CRI-O as well as crun and runc.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated crun v1.8.3 and runc v1.1.5 base profiles.
```
