### PR TITLE
Use mergo for syscall merge

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/containers/common v0.51.1
 	github.com/go-logr/logr v1.2.4
 	github.com/google/go-containerregistry v0.14.0
+	github.com/imdario/mergo v0.3.13
 	github.com/jellydator/ttlcache/v3 v3.0.1
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.6.1
 	github.com/mogensen/kubernetes-split-yaml v0.4.0
@@ -159,7 +160,6 @@ require (
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-retryablehttp v0.7.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/imdario/mergo v0.3.13 // indirect
 	github.com/in-toto/in-toto-golang v0.6.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jedisct1/go-minisign v0.0.0-20211028175153-1c139d1cc84b // indirect

--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -393,7 +393,11 @@ func (r *Reconciler) resolveSyscallsForProfile(
 		baseProfile = profile
 	}
 
-	newSyscalls := util.UnionSyscalls(baseProfile.Spec.Syscalls, inputSyscalls)
+	newSyscalls, err := util.UnionSyscalls(baseProfile.Spec.Syscalls, inputSyscalls)
+	if err != nil {
+		return nil, fmt.Errorf("union syscalls: %w", err)
+	}
+
 	return r.resolveSyscallsForProfile(ctx, baseProfile, newSyscalls, l, level+1)
 }
 

--- a/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
@@ -634,11 +634,13 @@ func TestResolveSyscallsForProfile(t *testing.T) {
 			},
 			assert: func(syscalls []*seccompprofileapi.Syscall, err error) {
 				require.NoError(t, err)
-				require.Len(t, syscalls, 1)
-				require.Len(t, syscalls[0].Names, 3)
-				require.Equal(t, "first", syscalls[0].Names[0])
-				require.Equal(t, "second", syscalls[0].Names[1])
-				require.Equal(t, "third", syscalls[0].Names[2])
+				require.Len(t, syscalls, 3)
+				require.Len(t, syscalls[0].Names, 1)
+				require.Len(t, syscalls[1].Names, 1)
+				require.Len(t, syscalls[2].Names, 1)
+				require.Equal(t, "third", syscalls[0].Names[0])
+				require.Equal(t, "second", syscalls[1].Names[0])
+				require.Equal(t, "first", syscalls[2].Names[0])
 			},
 		},
 		{
@@ -672,11 +674,13 @@ func TestResolveSyscallsForProfile(t *testing.T) {
 			},
 			assert: func(syscalls []*seccompprofileapi.Syscall, err error) {
 				require.NoError(t, err)
-				require.Len(t, syscalls, 1)
-				require.Len(t, syscalls[0].Names, 3)
-				require.Equal(t, "first", syscalls[0].Names[0])
-				require.Equal(t, "second", syscalls[0].Names[1])
-				require.Equal(t, "third", syscalls[0].Names[2])
+				require.Len(t, syscalls, 3)
+				require.Len(t, syscalls[0].Names, 1)
+				require.Len(t, syscalls[1].Names, 1)
+				require.Len(t, syscalls[2].Names, 1)
+				require.Equal(t, "third", syscalls[0].Names[0])
+				require.Equal(t, "second", syscalls[1].Names[0])
+				require.Equal(t, "first", syscalls[2].Names[0])
 			},
 		},
 		{

--- a/internal/pkg/manager/recordingmerger/merge_utils.go
+++ b/internal/pkg/manager/recordingmerger/merge_utils.go
@@ -167,7 +167,11 @@ func (sp *mergeableSeccompProfile) merge(other mergeableProfile) error {
 	if !ok {
 		return fmt.Errorf("cannot merge SeccompProfile with %T", other)
 	}
-	sp.Spec.Syscalls = util.UnionSyscalls(sp.Spec.Syscalls, otherSP.Spec.Syscalls)
+	syscalls, err := util.UnionSyscalls(sp.Spec.Syscalls, otherSP.Spec.Syscalls)
+	if err != nil {
+		return fmt.Errorf("union syscalls: %w", err)
+	}
+	sp.Spec.Syscalls = syscalls
 
 	return nil
 }

--- a/internal/pkg/manager/recordingmerger/merge_utils_test.go
+++ b/internal/pkg/manager/recordingmerger/merge_utils_test.go
@@ -115,7 +115,9 @@ func TestMergeProfiles(t *testing.T) {
 
 				mergedProf := ifaceAsSortedSeccompProfile(mergedProfIface)
 				require.Equal(t, mergedProf.Spec.Syscalls[0].Action, seccomp.Action("foo"))
-				require.Equal(t, mergedProf.Spec.Syscalls[0].Names, []string{"a", "b", "c", "d", "e"})
+				require.Equal(t, mergedProf.Spec.Syscalls[0].Names, []string{"a", "b", "c"})
+				require.Equal(t, mergedProf.Spec.Syscalls[1].Action, seccomp.Action("foo"))
+				require.Equal(t, mergedProf.Spec.Syscalls[1].Names, []string{"c", "d", "e"})
 				return nil
 			},
 		},

--- a/internal/pkg/util/union_syscalls.go
+++ b/internal/pkg/util/union_syscalls.go
@@ -17,44 +17,33 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
 	"sort"
 
-	"github.com/containers/common/pkg/seccomp"
+	"github.com/imdario/mergo"
 
 	seccompprofile "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"
 )
 
-func UnionSyscalls(baseSyscalls, appliedSyscalls []*seccompprofile.Syscall) []*seccompprofile.Syscall {
-	longestLen := len(baseSyscalls)
-	if len(appliedSyscalls) > longestLen {
-		longestLen = len(appliedSyscalls)
+func UnionSyscalls(syscalls, appliedSyscalls []*seccompprofile.Syscall) ([]*seccompprofile.Syscall, error) {
+	if err := mergo.Merge(
+		&syscalls,
+		appliedSyscalls,
+		mergo.WithAppendSlice,
+		mergo.WithSliceDeepCopy,
+		mergo.WithOverrideEmptySlice,
+		mergo.WithOverwriteWithEmptyValue,
+	); err != nil {
+		return nil, fmt.Errorf("merge syscalls: %w", err)
 	}
 
-	allSyscalls := make(map[seccomp.Action]map[string]bool, longestLen)
-	for _, b := range baseSyscalls {
-		allSyscalls[b.Action] = make(map[string]bool)
-		for _, n := range b.Names {
-			allSyscalls[b.Action][n] = true
-		}
-	}
-	for _, s := range appliedSyscalls {
-		if _, ok := allSyscalls[s.Action]; !ok {
-			allSyscalls[s.Action] = make(map[string]bool)
-		}
-		for _, n := range s.Names {
-			allSyscalls[s.Action][n] = true
-		}
-	}
-	finalSyscalls := make([]*seccompprofile.Syscall, 0, longestLen)
-	for action, names := range allSyscalls {
-		syscall := seccompprofile.Syscall{
-			Action: action,
-		}
-		for n := range names {
-			syscall.Names = append(syscall.Names, n)
-		}
+	for _, syscall := range syscalls {
 		sort.Strings(syscall.Names)
-		finalSyscalls = append(finalSyscalls, &syscall)
 	}
-	return finalSyscalls
+
+	sort.Slice(syscalls, func(i, j int) bool {
+		return syscalls[i].Action < syscalls[j].Action
+	})
+
+	return syscalls, nil
 }


### PR DESCRIPTION


#### What type of PR is this?


/kind bug


#### What this PR does / why we need it:
The merging itself is not that intelligent any more, but we preserve possible args and error return values. It also makes the merge more simple, while we still sort the syscall names and actions.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed overriding args and error return values when merging profiles.
```
