### PR TITLE
Preserve ErrnoRet and Args for syscall union

### DIFF
--- a/internal/pkg/util/union_syscalls_test.go
+++ b/internal/pkg/util/union_syscalls_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"sort"
 	"testing"
 
 	"github.com/containers/common/pkg/seccomp"
@@ -152,6 +151,33 @@ func TestUnionSyscalls(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "ArgsErrnoRet",
+			baseSyscalls: []*v1beta1.Syscall{
+				{
+					Names:    []string{"a", "b", "c"},
+					Action:   seccomp.Action("foo"),
+					Args:     []*v1beta1.Arg{{Index: 1, Value: 2}},
+					ErrnoRet: "ret",
+				},
+			},
+			appliedSyscalls: []*v1beta1.Syscall{
+				{
+					Names:    []string{"a", "b", "c"},
+					Action:   seccomp.Action("foo"),
+					Args:     []*v1beta1.Arg{{Index: 1, Value: 2}},
+					ErrnoRet: "ret",
+				},
+			},
+			want: []*v1beta1.Syscall{
+				{
+					Names:    []string{"a", "b", "c"},
+					Action:   seccomp.Action("foo"),
+					Args:     []*v1beta1.Arg{{Index: 1, Value: 2}},
+					ErrnoRet: "ret",
+				},
+			},
+		},
 	}
 
 	for _, tc := range cases {
@@ -160,12 +186,6 @@ func TestUnionSyscalls(t *testing.T) {
 			t.Parallel()
 
 			got := UnionSyscalls(tc.baseSyscalls, tc.appliedSyscalls)
-			for i := range got {
-				sort.Strings(got[i].Names)
-			}
-			sort.Slice(got, func(i, j int) bool {
-				return got[i].Action < got[j].Action
-			})
 			require.Equal(t, tc.want, got)
 		})
 	}


### PR DESCRIPTION


#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:
We need to preserve the args as well as the errno ret for unionizing syscalls, which is now fixed.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug to preserve `ErrnoRet` and `Args` for merging seccomp profile syscalls.
```
