### PR TITLE
Switch from N1 to E2 machine for cloudbuild

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -3,7 +3,7 @@
 timeout: 1200s
 options:
   substitution_option: ALLOW_LOOSE
-  machineType: N1_HIGHCPU_8
+  machineType: E2_HIGHCPU_8
 steps:
   - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20220617-174ad91c3a
     entrypoint: bash


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
This changes machine type from N1 to E2 which are newer but almost same pricing. But with E2 being more efficient and overall taking less time. The cost can be reduced.

#### Which issue(s) this PR fixes:
Reference https://github.com/kubernetes/k8s.io/issues/5059

#### Does this PR have test?
No

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?
```release-note
None
```
