### PR TITLE
Auto-select selinuxd image based on nodeInfo.OSImage

### DIFF
--- a/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
+++ b/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
@@ -98,6 +98,17 @@ data:
         }
       ]
     }
+  selinuxd-image-mapping.json: |
+    [
+        {
+            "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
+            "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+        },
+        {
+            "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
+            "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+        }
+    ]
   selinuxd.cil: |
     (block selinuxd
         (blockinherit container)

--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -308,6 +308,14 @@ spec:
       - rules:
         - apiGroups:
           - ""
+          resourceNames:
+          - security-profiles-operator-profile
+          resources:
+          - configmaps
+          verbs:
+          - get
+        - apiGroups:
+          - ""
           resources:
           - nodes
           verbs:

--- a/deploy/base/kustomization.yaml
+++ b/deploy/base/kustomization.yaml
@@ -15,6 +15,7 @@ configMapGenerator:
   - profiles/security-profiles-operator.json
   - profiles/selinuxd.cil
   - profiles/selinuxrecording.cil
+  - profiles/selinuxd-image-mapping.json
   name: security-profiles-operator-profile
 
 generatorOptions:

--- a/deploy/base/profiles/selinuxd-image-mapping.json
+++ b/deploy/base/profiles/selinuxd-image-mapping.json
@@ -1,0 +1,10 @@
+[
+    {
+        "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
+        "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+    },
+    {
+        "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
+        "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+    }
+]

--- a/deploy/base/role.yaml
+++ b/deploy/base/role.yaml
@@ -7,6 +7,14 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - security-profiles-operator-profile
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
   resources:
   - nodes
   verbs:

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -52,6 +52,14 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - security-profiles-operator-profile
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
   resources:
   - nodes
   verbs:
@@ -966,6 +974,17 @@ data:
         }
       ]
     }
+  selinuxd-image-mapping.json: |
+    [
+        {
+            "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
+            "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+        },
+        {
+            "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
+            "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+        }
+    ]
   selinuxd.cil: |
     (block selinuxd
         (blockinherit container)

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2084,6 +2084,14 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - security-profiles-operator-profile
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
   resources:
   - nodes
   verbs:
@@ -2922,6 +2930,17 @@ data:
         }
       ]
     }
+  selinuxd-image-mapping.json: |
+    [
+        {
+            "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
+            "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+        },
+        {
+            "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
+            "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+        }
+    ]
   selinuxd.cil: |
     (block selinuxd
         (blockinherit container)

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -2156,6 +2156,14 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - security-profiles-operator-profile
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
   resources:
   - nodes
   verbs:
@@ -2904,6 +2912,17 @@ data:
         }
       ]
     }
+  selinuxd-image-mapping.json: |
+    [
+        {
+            "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
+            "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+        },
+        {
+            "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
+            "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+        }
+    ]
   selinuxd.cil: |
     (block selinuxd
         (blockinherit container)

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -2084,6 +2084,14 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - security-profiles-operator-profile
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
   resources:
   - nodes
   verbs:
@@ -2935,6 +2943,17 @@ data:
         }
       ]
     }
+  selinuxd-image-mapping.json: |
+    [
+        {
+            "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
+            "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+        },
+        {
+            "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
+            "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+        }
+    ]
   selinuxd.cil: |
     (block selinuxd
         (blockinherit container)

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2084,6 +2084,14 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - security-profiles-operator-profile
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
   resources:
   - nodes
   verbs:
@@ -2922,6 +2930,17 @@ data:
         }
       ]
     }
+  selinuxd-image-mapping.json: |
+    [
+        {
+            "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
+            "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+        },
+        {
+            "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
+            "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+        }
+    ]
   selinuxd.cil: |
     (block selinuxd
         (blockinherit container)

--- a/deploy/overlays/webhook/role.yaml
+++ b/deploy/overlays/webhook/role.yaml
@@ -1,3 +1,3 @@
 ---
-- path: /rules/2
+- path: /rules/3
   op: remove

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -2156,6 +2156,14 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  resourceNames:
+  - security-profiles-operator-profile
+  resources:
+  - configmaps
+  verbs:
+  - get
+- apiGroups:
+  - ""
   resources:
   - nodes
   verbs:
@@ -2893,6 +2901,17 @@ data:
         }
       ]
     }
+  selinuxd-image-mapping.json: |
+    [
+        {
+            "regex":"(.*)(CoreOS).*([\\d+])\\.8[\\d+]\\.(.*)",
+            "image":"quay.io/security-profiles-operator/selinuxd-el8:latest"
+        },
+        {
+            "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
+            "image":"quay.io/security-profiles-operator/selinuxd-el9:latest"
+        }
+    ]
   selinuxd.cil: |
     (block selinuxd
         (blockinherit container)

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -127,6 +127,9 @@ func (r *ReconcileSPOd) Healthz(*http.Request) error {
 //
 // Needed to detect which runtime is active
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;get
+//
+// Needed to detect the proper selinux image
+// +kubebuilder:rbac:groups="",resources=configmaps,resourceNames=security-profiles-operator-profile,verbs=get
 
 // Reconcile reads that state of the cluster for a SPOD object and makes changes based on the state read
 // and what is in the `ConfigMap.Spec`.

--- a/internal/pkg/util/constants.go
+++ b/internal/pkg/util/constants.go
@@ -28,3 +28,11 @@ const (
 	EventTypeNormal  string = "Normal"
 	EventTypeWarning string = "Warning"
 )
+
+const (
+	// OperatorConfigMap corresponds to the configMap created from deploy/base/profiles.
+	OperatorConfigMap = "security-profiles-operator-profile"
+	// SelinuxdImageMappingKey is the key in the configMap that contains the mapping
+	// between the selinuxd image and the OS version.
+	SelinuxdImageMappingKey = "selinuxd-image-mapping.json"
+)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Cluster nodes might be upgraded between major OS releases where the
libselinux major version is incompatible. This means that the selinuxd
image must be based on images matching the OS release and the libselinux
major version.

But SPO must also be able to select the images based on what OS are the
cluster nodes running.

To implement that, this patch adds a new key to the
security-profiles-operator-profile configmap that maps regexes matching
nodeInfo.OSImage to selinuxd images. The operator then selects the right
selinuxd image, falling back to using the `RELATED_IMAGE_SELINUXD` environment
variable.


#### Which issue(s) this PR fixes:
Fixes #1576

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.


or

None
-->

#### Does this PR have test?
some unit tests

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
I'll hold this patch before I can install a RHEL-9 based cluster - I've
been having issues with that. But I wanted to get some early feedback.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
SPO now autoselects the appropriate selinuxd image based on mapping in the
security-profiles-operator-profile. If none of the entries match, SPO falls back
to the image provided by `RELATED_IMAGE_SELINUXD`.
```
