### PR TITLE
Wait a second before stopping `spoc run`

### DIFF
--- a/internal/pkg/cli/runner/runner.go
+++ b/internal/pkg/cli/runner/runner.go
@@ -25,6 +25,7 @@ import (
 	"log"
 	"path/filepath"
 	"sync/atomic"
+	"time"
 
 	"github.com/nxadm/tail"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -102,6 +103,9 @@ func (r *Runner) Run() error {
 	if err := r.CommandWait(cmd); err != nil {
 		return fmt.Errorf("wait for command: %w", err)
 	}
+
+	// Wait for the late syscalls from the audit logs.
+	time.Sleep(time.Second)
 
 	return nil
 }


### PR DESCRIPTION



#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
This makes it possible to retrieve late syscalls from applications which are already terminated, but the message did not appear in audit log yet.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #1482 
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
