### PR TITLE
ci: switch back to flatcar stable

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -248,7 +248,7 @@ dependencies:
       match: BTFHUB_COMMIT
 
   - name: flatcar
-    version: 3446.1.0
+    version: 3510.2.0
     refPaths:
     - path: hack/ci/Vagrantfile-flatcar
       match: flatcar_production_vagrant

--- a/hack/ci/Vagrantfile-flatcar
+++ b/hack/ci/Vagrantfile-flatcar
@@ -2,9 +2,9 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "flatcar-main"
+  config.vm.box = "flatcar-stable"
   config.vm.box_check_update = true
-  config.vm.box_url = "https://beta.release.flatcar-linux.net/amd64-usr/3446.1.0/flatcar_production_vagrant.box"
+  config.vm.box_url = "https://stable.release.flatcar-linux.net/amd64-usr/3510.2.0/flatcar_production_vagrant.box"
   memory = 8192
   cpus = 4
 
@@ -92,7 +92,7 @@ Vagrant.configure("2") do |config|
       # Install tools
       curl -sSL -o $DOWNLOAD_DIR/jq "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64"
       chmod +x $DOWNLOAD_DIR/jq
-      curl -sSL -o $DOWNLOAD_DIR/flatcar_developer_container.bin.bz2 "https://beta.release.flatcar-linux.net/amd64-usr/3446.1.0/flatcar_developer_container.bin.bz2"
+      curl -sSL -o $DOWNLOAD_DIR/flatcar_developer_container.bin.bz2 "https://stable.release.flatcar-linux.net/amd64-usr/3510.2.0/flatcar_developer_container.bin.bz2"
       bzcat $DOWNLOAD_DIR/flatcar_developer_container.bin.bz2 > $DOWNLOAD_DIR/flatcar_developer_container.bin
 
       curl -sSL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz


### PR DESCRIPTION
beta was used for Vagrant support - this one is now available on stable since the release 3510.2.0 (https://www.flatcar.org/releases#release-3510.2.0)

#### What this PR does / why we need it:
This PR updates the Flatcar version to latest stable (instead of beta)

#### Which issue(s) this PR fixes:
Related to https://github.com/kubernetes-sigs/security-profiles-operator/pull/1417 and https://github.com/flatcar/Flatcar/issues/916

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

This is a follow-up of https://github.com/kubernetes-sigs/security-profiles-operator/pull/1417

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

/kind cleanup