### PR TITLE
Wait longer for cert manager in baseprofiles test

### DIFF
--- a/hack/ci/baseprofiles.sh
+++ b/hack/ci/baseprofiles.sh
@@ -65,7 +65,7 @@ wait_for() {
 
 install_operator() {
     kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.11.1/cert-manager.yaml
-    kubectl -n cert-manager wait --for condition=ready pod -l app.kubernetes.io/instance=cert-manager
+    k_wait -n cert-manager pod -l app.kubernetes.io/instance=cert-manager
 
     git apply hack/deploy-localhost.patch
     kubectl apply -f deploy/operator.yaml


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
We timeout waiting for cert manager which should be now more stable.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
