### PR TITLE
WIP: Change GitHub actions ulimit to let image build pass

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,6 +48,9 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+      - name: Prepare system
+        run: |
+          ulimit -n
       - run: make image
       - run: podman save -o image.tar security-profiles-operator
       - uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
The ulimits seem to be too low causing the CI to fail: 
https://github.com/kubernetes-sigs/security-profiles-operator/actions/runs/4784000101/jobs/8505452290

```
vendor/k8s.io/kube-openapi/pkg/internal/third_party/go-json-experiment/json/arshal_default.go:8:2: open /nix/store/3wpbn0nv1yhb47njlb3z3vicj20cp2mj-go-1.20.2/share/go/src/encoding/base32: too many open files
vendor/github.com/aws/aws-sdk-go-v2/aws/signer/internal/v4/header_rules.go:4:2: cannot query module due to -mod=vendor
vendor/github.com/emicklei/go-restful/v3/container.go:17:2: cannot query module due to -mod=vendor
vendor/github.com/go-logr/stdr/stdr.go:26:2: cannot query module due to -mod=vendor
vendor/github.com/go-playground/locales/rules.go:7:2: cannot query module due to -mod=vendor
vendor/github.com/gobwas/glob/compiler/compiler.go:10:2: cannot query module due to -mod=vendor
vendor/github.com/gobwas/glob/compiler/compiler.go:11:2: cannot query module due to -mod=vendor
vendor/github.com/gobwas/glob/syntax/syntax.go:5:2: cannot query module due to -mod=vendor
vendor/github.com/gobwas/glob/compiler/compiler.go:12:2: cannot query module due to -mod=vendor
vendor/github.com/protocolbuffers/txtpbfmt/parser/parser.go:16:2: cannot query module due to -mod=vendor
vendor/github.com/google/go-cmp/cmp/compare.go:38:2: cannot query module due to -mod=vendor
vendor/github.com/google/go-cmp/cmp/report_references.go:12:2: cannot query module due to -mod=vendor
vendor/github.com/google/go-cmp/cmp/compare.go:39:2: cannot query module due to -mod=vendor
vendor/github.com/google/go-cmp/cmp/compare.go:40:2: cannot query module due to -mod=vendor
vendor/google.golang.org/api/internal/cert/enterprise_cert.go:19:2: open /tmp/nix-build-security-profiles-operator.drv-0/work/vendor/github.com/googleapis/enterprise-certificate-proxy/client: too many open files
vendor/github.com/googleapis/enterprise-certificate-proxy/client/client.go:32:2: cannot find package
vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/metrics/metrics.go:21:2: cannot query module due to -mod=vendor
vendor/github.com/spiffe/go-spiffe/v2/internal/jwtutil/util.go:6:2: cannot query module due to -mod=vendor
vendor/github.com/xeipuuv/gojsonreference/reference.go:35:2: cannot query module due to -mod=vendor
vendor/go.opencensus.io/plugin/ochttp/trace.go:22:2: cannot query module due to -mod=vendor
vendor/go.opencensus.io/plugin/ochttp/client_stats.go:25:2: cannot query module due to -mod=vendor
vendor/go.opencensus.io/plugin/ochttp/stats.go:19:2: cannot query module due to -mod=vendor
vendor/go.opencensus.io/plugin/ochttp/client_stats.go:26:2: cannot query module due to -mod=vendor
vendor/go.opencensus.io/plugin/ochttp/client.go:21:2: cannot query module due to -mod=vendor
vendor/go.opencensus.io/plugin/ochttp/client.go:22:2: cannot query module due to -mod=vendor
vendor/golang.org/x/text/internal/language/lookup.go:13:2: cannot query module due to -mod=vendor
vendor/k8s.io/kube-openapi/pkg/openapiconv/convert.go:23:2: cannot query module due to -mod=vendor
make: *** [Makefile:158: build/spoc] Error 1
```


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
