### PR TITLE
Allow empty `HostProcVolumePath`

### DIFF
--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -524,7 +524,7 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 	}
 
 	// Custom host proc volume
-	useCustomHostProc := cfg.Spec.HostProcVolumePath != bindata.DefaultHostProcPath
+	useCustomHostProc := cfg.Spec.HostProcVolumePath != bindata.DefaultHostProcPath && cfg.Spec.HostProcVolumePath != ""
 	volume, mount := bindata.CustomHostProcVolume(cfg.Spec.HostProcVolumePath)
 
 	// Disable profile recording controller by default


### PR DESCRIPTION


#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:
If the option is unset then we treat the host proc volume path now as default one (`/proc`).

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes https://github.com/kubernetes-sigs/security-profiles-operator/issues/1645
#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
None
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed bug on daemon rollout when SPOD config `HostProcVolumePath` is unset.
```
