### PR TITLE
Patching container ID discovery to support DiD

### DIFF
--- a/internal/pkg/util/containers.go
+++ b/internal/pkg/util/containers.go
@@ -69,7 +69,9 @@ func ContainerIDForPID(cache *ttlcache.Cache[string, string], pid int) (string, 
 	for scanner.Scan() {
 		text := scanner.Text()
 
-		if containerID := ContainerIDRegex.FindString(text); containerID != "" {
+		if containerIDs := ContainerIDRegex.FindAllString(text, -1); 0 < len(containerIDs) {
+			// Using the last container ID in the cgroup path to support "docker in docker" use cases
+			containerID := containerIDs[len(containerIDs)-1]
 			// Update the cache
 			cache.Set(strconv.Itoa(pid), containerID, ttlcache.DefaultTTL)
 			return containerID, nil


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
eBPF recorder is failing on minikube with the docker driver, this fix enables support parsing docker in docker /proc/pid/cgroup strings

#### Which issue(s) this PR fixes:
Fixes #1249 

#### Does this PR have test?

I haven't found an existing test to extend


```release-note
Support docker-in-docker for looking up the container ID in the ebpf based recorder
```
