### PR TITLE
Bump CRI-O to v1.27.0 and update base profiles

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -176,13 +176,13 @@ dependencies:
       match: VERSION
 
   - name: CRI-O
-    version: v1.26.3
+    version: v1.27.0
     refPaths:
     - path: hack/ci/install-cri-o.sh
       match: TAG
 
   - name: crun
-    version: v1.8.3
+    version: v1.8.4
     refPaths:
     - path: examples/baseprofile-crun.yaml
       match: name
@@ -190,7 +190,7 @@ dependencies:
       match: baseProfileNameCrun
 
   - name: runc
-    version: v1.1.5
+    version: v1.1.6
     refPaths:
     - path: examples/baseprofile-runc.yaml
       match: name
@@ -206,7 +206,7 @@ dependencies:
       match: VERSION
 
   - name: cosign
-    version: v2.0.0
+    version: v2.0.2
     refPaths:
     - path: hack/ci/install-cri-o.sh
       match: COSIGN_VERSION
@@ -260,3 +260,9 @@ dependencies:
     refPaths:
       - path: Makefile
         match: ZEITGEIST_VERSION
+
+  - name: yq
+    version: 4.33.3
+    refPaths:
+      - path: hack/ci/baseprofiles.sh
+        match: YQ_VERSION

--- a/examples/baseprofile-crun.yaml
+++ b/examples/baseprofile-crun.yaml
@@ -2,7 +2,7 @@
 apiVersion: security-profiles-operator.x-k8s.io/v1beta1
 kind: SeccompProfile
 metadata:
-  name: crun-v1.8.3
+  name: crun-v1.8.4
 spec:
   defaultAction: SCMP_ACT_ERRNO
   architectures:

--- a/examples/baseprofile-runc.yaml
+++ b/examples/baseprofile-runc.yaml
@@ -2,7 +2,7 @@
 apiVersion: security-profiles-operator.x-k8s.io/v1beta1
 kind: SeccompProfile
 metadata:
-  name: runc-v1.1.5
+  name: runc-v1.1.6
 spec:
   defaultAction: SCMP_ACT_ERRNO
   architectures:
@@ -34,9 +34,11 @@ spec:
         - getdents64
         - getpid
         - getppid
+        - getrlimit
         - gettid
         - getuid
         - keyctl
+        - madvise
         - mkdirat
         - mknodat
         - mmap

--- a/hack/ci/install-cri-o.sh
+++ b/hack/ci/install-cri-o.sh
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-TAG=v1.26.3
+TAG=v1.27.0
 
 curl_retry() {
     curl -sSfL --retry 5 --retry-delay 3 "$@"
@@ -24,7 +24,7 @@ curl_retry() {
 # We need cosign as well as the bom tool here because the CRI-O installation
 # script will automatically verify the signatures based on their existence in
 # $PATH.
-COSIGN_VERSION=v2.0.0
+COSIGN_VERSION=v2.0.2
 curl_retry -o /usr/bin/cosign \
     https://github.com/sigstore/cosign/releases/download/$COSIGN_VERSION/cosign-linux-amd64
 chmod +x /usr/bin/cosign

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -515,7 +515,7 @@ metadata:
   name: profile1
 spec:
   defaultAction: SCMP_ACT_ERRNO
-  baseProfileName: runc-v1.1.5
+  baseProfileName: runc-v1.1.6
   syscalls:
     - action: SCMP_ACT_ALLOW
       names:
@@ -551,7 +551,7 @@ metadata:
   name: profile1
 spec:
   defaultAction: SCMP_ACT_ERRNO
-  baseProfileName: oci://ghcr.io/security-profiles/runc:v1.1.5
+  baseProfileName: oci://ghcr.io/security-profiles/runc:v1.1.6
 ```
 
 The resulting profile `profile1` will then contain all base syscalls from the
@@ -1921,18 +1921,18 @@ The `spoc` client is able to pull security profiles from OCI artifact compatible
 registries. To do that, just run `spoc pull`:
 
 ```console
-> spoc pull ghcr.io/security-profiles/runc:v1.1.4
-16:32:29.795597 Pulling profile from: ghcr.io/security-profiles/runc:v1.1.4
+> spoc pull ghcr.io/security-profiles/runc:v1.1.6
+16:32:29.795597 Pulling profile from: ghcr.io/security-profiles/runc:v1.1.6
 16:32:29.795610 Verifying signature
 
-Verification for ghcr.io/security-profiles/runc:v1.1.4 --
+Verification for ghcr.io/security-profiles/runc:v1.1.6 --
 The following checks were performed on each of these signatures:
   - Existence of the claims in the transparency log was verified offline
   - The code-signing certificate was verified using trusted certificate authority certificates
 
 [{"critical":{"identity":{"docker-reference":"ghcr.io/security-profiles/runc"},…}}]
 16:32:33.208695 Creating file store in: /tmp/pull-3199397214
-16:32:33.208713 Verifying reference: ghcr.io/security-profiles/runc:v1.1.4
+16:32:33.208713 Verifying reference: ghcr.io/security-profiles/runc:v1.1.6
 16:32:33.208718 Creating repository for ghcr.io/security-profiles/runc
 16:32:33.208742 Using tag: v1.1.4
 16:32:33.208743 Copying profile from repository

--- a/test/tc_base_profiles_test.go
+++ b/test/tc_base_profiles_test.go
@@ -24,8 +24,8 @@ import (
 )
 
 const (
-	baseProfileNameRunc = "runc-v1.1.5"
-	baseProfileNameCrun = "crun-v1.8.3"
+	baseProfileNameRunc = "runc-v1.1.6"
+	baseProfileNameCrun = "crun-v1.8.4"
 )
 
 func (e *e2e) testCaseBaseProfile([]string) {


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Update the dependencies to their latest release.
#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated runc and crun base profiles to their latest release.
```
