### PR TITLE
Add OCI artifact platform support

### DIFF
--- a/cmd/spoc/main.go
+++ b/cmd/spoc/main.go
@@ -105,10 +105,10 @@ func main() {
 			Action:    push,
 			ArgsUsage: "FILE",
 			Flags: []cli.Flag{
-				&cli.StringFlag{
-					Name:        pusher.FlagProfile,
+				&cli.StringSliceFlag{
+					Name:        pusher.FlagProfiles,
 					Aliases:     []string{"f"},
-					Usage:       "the profile to be used",
+					Usage:       "the profiles to be used",
 					DefaultText: pusher.DefaultInputFile,
 					TakesFile:   true,
 				},
@@ -125,6 +125,11 @@ func main() {
 						"the username for registry authentication, use $%s for defining a password",
 						spocli.EnvKeyPassword,
 					),
+				},
+				&cli.StringSliceFlag{
+					Name:    pusher.FlagPlatforms,
+					Aliases: []string{"p"},
+					Usage:   "the platforms to be used in format: os[/arch][/variant][:os_version]",
 				},
 			},
 		},
@@ -150,6 +155,11 @@ func main() {
 						"the username for registry authentication, use $%s for defining a password",
 						spocli.EnvKeyPassword,
 					),
+				},
+				&cli.StringFlag{
+					Name:    puller.FlagPlatform,
+					Aliases: []string{"p"},
+					Usage:   "the platform to be used in format: os[/arch][/variant][:os_version]",
 				},
 			},
 		},

--- a/internal/pkg/artifact/artifact.go
+++ b/internal/pkg/artifact/artifact.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/go-logr/logr"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
@@ -86,7 +87,11 @@ func New(logger logr.Logger) *Artifact {
 }
 
 // Push a profile to a remote location.
-func (a *Artifact) Push(file, to, username, password string, annotations map[string]string) error {
+func (a *Artifact) Push(
+	files map[*v1.Platform]string,
+	to, username, password string,
+	annotations map[string]string,
+) error {
 	dir, err := a.MkdirTemp("", "push-")
 	if err != nil {
 		return fmt.Errorf("create temp dir: %w", err)
@@ -111,21 +116,31 @@ func (a *Artifact) Push(file, to, username, password string, annotations map[str
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
-	a.logger.Info("Adding profile to store: " + file)
-	absPath, err := a.FilepathAbs(file)
-	if err != nil {
-		return fmt.Errorf("get absoluate file path: %w", err)
+	fileDescriptors := []v1.Descriptor{}
+	a.logger.Info("Adding " + fmt.Sprint(len(files)) + " profiles")
+	for platform, file := range files {
+		a.logger.Info(
+			"Adding profile " + file +
+				" for platform " +
+				platformToString(platform) +
+				" to store",
+		)
+		absPath, err := a.FilepathAbs(file)
+		if err != nil {
+			return fmt.Errorf("get absolute file path: %w", err)
+		}
+		fileDescriptor, err := a.StoreAdd(
+			ctx, store, profileName(platform), "", absPath,
+		)
+		if err != nil {
+			return fmt.Errorf("add profile to store: %w", err)
+		}
+		for k, v := range annotations {
+			fileDescriptor.Annotations[k] = v
+		}
+		fileDescriptor.Platform = platform
+		fileDescriptors = append(fileDescriptors, fileDescriptor)
 	}
-	fileDescriptor, err := a.StoreAdd(
-		ctx, store, defaultProfileYAML, "", absPath,
-	)
-	if err != nil {
-		return fmt.Errorf("add profile to store: %w", err)
-	}
-	for k, v := range annotations {
-		fileDescriptor.Annotations[k] = v
-	}
-	fileDescriptors := []v1.Descriptor{fileDescriptor}
 
 	a.logger.Info("Packing files")
 	manifestDescriptor, err := a.Pack(
@@ -176,7 +191,7 @@ func (a *Artifact) Push(file, to, username, password string, annotations map[str
 		return fmt.Errorf("copy to repository: %w", err)
 	}
 
-	a.logger.Info("Signing container image")
+	a.logger.Info("Signing OCI artifact")
 	o := &options.SignOptions{
 		Upload:           true,
 		TlogUpload:       true,
@@ -223,7 +238,11 @@ func (a *Artifact) Push(file, to, username, password string, annotations map[str
 }
 
 // Pull a profile from a remote location.
-func (a *Artifact) Pull(c context.Context, from, username, password string) (*PullResult, error) {
+func (a *Artifact) Pull(
+	c context.Context,
+	from, username, password string,
+	platform *v1.Platform,
+) (*PullResult, error) {
 	ctx, cancel := context.WithTimeout(c, defaultTimeout)
 	defer cancel()
 
@@ -296,8 +315,15 @@ func (a *Artifact) Pull(c context.Context, from, username, password string) (*Pu
 		return nil, fmt.Errorf("copy from repository: %w", err)
 	}
 
-	a.logger.Info("Reading profile")
-	content, err := a.ReadFile(filepath.Join(dir, defaultProfileYAML))
+	// Allow a fallback to defaultProfileYAML if no platform is available.
+	content := []byte{}
+	for _, name := range []string{profileName(platform), defaultProfileYAML} {
+		a.logger.Info("Trying to read profile: " + name)
+		content, err = a.ReadFile(filepath.Join(dir, name))
+		if err == nil {
+			break
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("read profile: %w", err)
 	}
@@ -337,4 +363,52 @@ func (a *Artifact) Pull(c context.Context, from, username, password string) (*Pu
 
 	a.logger.Info("No profile found")
 	return nil, fmt.Errorf("%w: last err: %w", ErrDecodeYAML, err)
+}
+
+// profileName returns the name for the profile based on the platform.
+func profileName(platform *v1.Platform) string {
+	name := strings.Builder{}
+	name.WriteString("profile")
+
+	if platform != nil {
+		for _, part := range []string{
+			platform.OS,
+			platform.Architecture,
+			platform.Variant,
+			platform.OSVersion,
+		} {
+			if part != "" {
+				name.WriteRune('-')
+				name.WriteString(part)
+			}
+		}
+	}
+
+	name.WriteString(".yaml")
+	return name.String()
+}
+
+// platformToString returns a string for the provided platform.
+func platformToString(platform *v1.Platform) string {
+	name := strings.Builder{}
+
+	for i, part := range []string{
+		platform.OS,
+		platform.Architecture,
+		platform.Variant,
+	} {
+		if part != "" {
+			if i > 0 {
+				name.WriteRune('/')
+			}
+			name.WriteString(part)
+		}
+	}
+
+	if platform.OSVersion != "" {
+		name.WriteRune(':')
+		name.WriteString(platform.OSVersion)
+	}
+
+	return name.String()
 }

--- a/internal/pkg/cli/consts.go
+++ b/internal/pkg/cli/consts.go
@@ -22,9 +22,6 @@ import (
 )
 
 const (
-	// FlagProfile is the flag for defining the input file location.
-	FlagProfile string = "profile"
-
 	// FlagOutputFile is the flag for defining the output file location.
 	FlagOutputFile string = "output-file"
 

--- a/internal/pkg/cli/platform.go
+++ b/internal/pkg/cli/platform.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// ParsePlatform parses an OCI image spec platform from the provided string.
+func ParsePlatform(input string) (*v1.Platform, error) {
+	res := &v1.Platform{}
+
+	if input == "" {
+		res.Architecture = runtime.GOARCH
+		res.OS = runtime.GOOS
+		return res, nil
+	}
+
+	platformStr, osVersion, _ := strings.Cut(input, ":")
+	res.OSVersion = osVersion
+	parts := strings.Split(platformStr, "/")
+
+	switch len(parts) {
+	case 3: //nolint:gomnd // intentional
+		res.Variant = parts[2]
+		fallthrough
+	case 2: //nolint:gomnd // intentional
+		res.Architecture = parts[1]
+	case 1:
+		res.Architecture = runtime.GOARCH
+	default:
+		return nil, fmt.Errorf("unable to parse platform from %s", input)
+	}
+
+	res.OS = parts[0]
+	if res.OS == "" {
+		return nil, fmt.Errorf("unable to parse OS from %s", input)
+	}
+
+	if res.Architecture == "" {
+		return nil, fmt.Errorf("unable to parse architecture from %s", input)
+	}
+
+	return res, nil
+}

--- a/internal/pkg/cli/platform_test.go
+++ b/internal/pkg/cli/platform_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package cli
+
+import (
+	"runtime"
+	"testing"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParsePlatform(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name, input string
+		assert      func(*v1.Platform, error)
+	}{
+		{
+			name:  "success no input",
+			input: "",
+			assert: func(platform *v1.Platform, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, runtime.GOOS, platform.OS)
+				assert.Equal(t, runtime.GOARCH, platform.Architecture)
+				assert.Empty(t, platform.OSFeatures)
+				assert.Empty(t, platform.OSVersion)
+				assert.Empty(t, platform.Variant)
+			},
+		},
+		{
+			name:  "success only OS",
+			input: "os",
+			assert: func(platform *v1.Platform, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "os", platform.OS)
+				assert.Equal(t, runtime.GOARCH, platform.Architecture)
+				assert.Empty(t, platform.OSFeatures)
+				assert.Empty(t, platform.OSVersion)
+				assert.Empty(t, platform.Variant)
+			},
+		},
+		{
+			name:  "success OS and architecture",
+			input: "os/arch",
+			assert: func(platform *v1.Platform, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "os", platform.OS)
+				assert.Equal(t, "arch", platform.Architecture)
+				assert.Empty(t, platform.OSFeatures)
+				assert.Empty(t, platform.OSVersion)
+				assert.Empty(t, platform.Variant)
+			},
+		},
+		{
+			name:  "success OS, architecture and variant",
+			input: "os/arch/var",
+			assert: func(platform *v1.Platform, err error) {
+				assert.NoError(t, err)
+				assert.Equal(t, "os", platform.OS)
+				assert.Equal(t, "arch", platform.Architecture)
+				assert.Equal(t, "var", platform.Variant)
+				assert.Empty(t, platform.OSFeatures)
+				assert.Empty(t, platform.OSVersion)
+			},
+		},
+		{
+			name:  "failure too many parts",
+			input: "os/arch/var/wrong",
+			assert: func(platform *v1.Platform, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, platform)
+			},
+		},
+		{
+			name:  "failure empty OS",
+			input: "/arch/var",
+			assert: func(platform *v1.Platform, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, platform)
+			},
+		},
+		{
+			name:  "failure empty architecture",
+			input: "os//var",
+			assert: func(platform *v1.Platform, err error) {
+				assert.Error(t, err)
+				assert.Nil(t, platform)
+			},
+		},
+	} {
+		input := tc.input
+		runAssert := tc.assert
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			runAssert(ParsePlatform(input))
+		})
+	}
+}

--- a/internal/pkg/cli/puller/consts.go
+++ b/internal/pkg/cli/puller/consts.go
@@ -28,4 +28,7 @@ const (
 	// FlagUsername is the flag for defining the username for registry
 	// authentication.
 	FlagUsername string = cli.FlagUsername
+
+	// FlagPlatform is the flag for defining the platform.
+	FlagPlatform string = "platform"
 )

--- a/internal/pkg/cli/puller/impl.go
+++ b/internal/pkg/cli/puller/impl.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/go-logr/logr"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/artifact"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/cli"
@@ -31,12 +32,12 @@ type defaultImpl struct{}
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate -header ../../../../hack/boilerplate/boilerplate.generatego.txt
 //counterfeiter:generate . impl
 type impl interface {
-	Pull(string, string, string) (*artifact.PullResult, error)
+	Pull(string, string, string, *v1.Platform) (*artifact.PullResult, error)
 	WriteFile(string, []byte, os.FileMode) error
 }
 
-func (*defaultImpl) Pull(from, username, password string) (*artifact.PullResult, error) {
-	return artifact.New(logr.New(&cli.LogSink{})).Pull(context.Background(), from, username, password)
+func (*defaultImpl) Pull(from, username, password string, platform *v1.Platform) (*artifact.PullResult, error) {
+	return artifact.New(logr.New(&cli.LogSink{})).Pull(context.Background(), from, username, password, platform)
 }
 
 func (*defaultImpl) WriteFile(name string, data []byte, perm os.FileMode) error {

--- a/internal/pkg/cli/puller/options.go
+++ b/internal/pkg/cli/puller/options.go
@@ -18,8 +18,10 @@ package puller
 
 import (
 	"errors"
+	"fmt"
 	"os"
 
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	ucli "github.com/urfave/cli/v2"
 
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/cli"
@@ -31,6 +33,7 @@ type Options struct {
 	outputFile string
 	username   string
 	password   string
+	platform   *v1.Platform
 }
 
 // Default returns a default options instance.
@@ -62,6 +65,12 @@ func FromContext(ctx *ucli.Context) (*Options, error) {
 	}
 
 	options.password = os.Getenv(cli.EnvKeyPassword)
+
+	platform, err := cli.ParsePlatform(ctx.String(FlagPlatform))
+	if err != nil {
+		return nil, fmt.Errorf("parse platform: %w", err)
+	}
+	options.platform = platform
 
 	return options, nil
 }

--- a/internal/pkg/cli/puller/puller.go
+++ b/internal/pkg/cli/puller/puller.go
@@ -46,6 +46,7 @@ func (p *Puller) Run() error {
 		p.options.pullFrom,
 		p.options.username,
 		p.options.password,
+		p.options.platform,
 	)
 	if err != nil {
 		return fmt.Errorf("pull profile: %w", err)

--- a/internal/pkg/cli/puller/pullerfakes/fake_impl.go
+++ b/internal/pkg/cli/puller/pullerfakes/fake_impl.go
@@ -21,16 +21,18 @@ import (
 	"io/fs"
 	"sync"
 
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/artifact"
 )
 
 type FakeImpl struct {
-	PullStub        func(string, string, string) (*artifact.PullResult, error)
+	PullStub        func(string, string, string, *v1.Platform) (*artifact.PullResult, error)
 	pullMutex       sync.RWMutex
 	pullArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
+		arg4 *v1.Platform
 	}
 	pullReturns struct {
 		result1 *artifact.PullResult
@@ -57,20 +59,21 @@ type FakeImpl struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeImpl) Pull(arg1 string, arg2 string, arg3 string) (*artifact.PullResult, error) {
+func (fake *FakeImpl) Pull(arg1 string, arg2 string, arg3 string, arg4 *v1.Platform) (*artifact.PullResult, error) {
 	fake.pullMutex.Lock()
 	ret, specificReturn := fake.pullReturnsOnCall[len(fake.pullArgsForCall)]
 	fake.pullArgsForCall = append(fake.pullArgsForCall, struct {
 		arg1 string
 		arg2 string
 		arg3 string
-	}{arg1, arg2, arg3})
+		arg4 *v1.Platform
+	}{arg1, arg2, arg3, arg4})
 	stub := fake.PullStub
 	fakeReturns := fake.pullReturns
-	fake.recordInvocation("Pull", []interface{}{arg1, arg2, arg3})
+	fake.recordInvocation("Pull", []interface{}{arg1, arg2, arg3, arg4})
 	fake.pullMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3)
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -84,17 +87,17 @@ func (fake *FakeImpl) PullCallCount() int {
 	return len(fake.pullArgsForCall)
 }
 
-func (fake *FakeImpl) PullCalls(stub func(string, string, string) (*artifact.PullResult, error)) {
+func (fake *FakeImpl) PullCalls(stub func(string, string, string, *v1.Platform) (*artifact.PullResult, error)) {
 	fake.pullMutex.Lock()
 	defer fake.pullMutex.Unlock()
 	fake.PullStub = stub
 }
 
-func (fake *FakeImpl) PullArgsForCall(i int) (string, string, string) {
+func (fake *FakeImpl) PullArgsForCall(i int) (string, string, string, *v1.Platform) {
 	fake.pullMutex.RLock()
 	defer fake.pullMutex.RUnlock()
 	argsForCall := fake.pullArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeImpl) PullReturns(result1 *artifact.PullResult, result2 error) {

--- a/internal/pkg/cli/pusher/consts.go
+++ b/internal/pkg/cli/pusher/consts.go
@@ -16,14 +16,28 @@ limitations under the License.
 
 package pusher
 
-import "sigs.k8s.io/security-profiles-operator/internal/pkg/cli"
+import (
+	"runtime"
 
-// DefaultInputFile defines the default input location for the pusher.
-var DefaultInputFile = cli.DefaultFile
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/cli"
+)
+
+var (
+	// DefaultInputFile defines the default input location for the pusher.
+	DefaultInputFile = cli.DefaultFile
+
+	// DefaultPlatform defines the default platform for the current system.
+	DefaultPlatform = &v1.Platform{
+		OS:           runtime.GOOS,
+		Architecture: runtime.GOARCH,
+	}
+)
 
 const (
-	// FlagProfile is the flag for defining the input file location.
-	FlagProfile string = cli.FlagProfile
+	// FlagProfiles is the flag for defining the input file locations.
+	FlagProfiles string = "profiles"
 
 	// FlagUsername is the flag for defining the username for registry
 	// authentication.
@@ -32,4 +46,7 @@ const (
 	// FlagAnnotations is the flag for setting custom annotations to the pushed
 	// artifact.
 	FlagAnnotations string = "annotations"
+
+	// FlagPlatforms is the flag for defining the platforms to push.
+	FlagPlatforms string = "platforms"
 )

--- a/internal/pkg/cli/pusher/impl.go
+++ b/internal/pkg/cli/pusher/impl.go
@@ -18,6 +18,7 @@ package pusher
 
 import (
 	"github.com/go-logr/logr"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/artifact"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/cli"
@@ -28,9 +29,13 @@ type defaultImpl struct{}
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate -header ../../../../hack/boilerplate/boilerplate.generatego.txt
 //counterfeiter:generate . impl
 type impl interface {
-	Push(string, string, string, string, map[string]string) error
+	Push(map[*v1.Platform]string, string, string, string, map[string]string) error
 }
 
-func (*defaultImpl) Push(file, to, username, password string, annotations map[string]string) error {
-	return artifact.New(logr.New(&cli.LogSink{})).Push(file, to, username, password, annotations)
+func (*defaultImpl) Push(
+	files map[*v1.Platform]string,
+	to, username, password string,
+	annotations map[string]string,
+) error {
+	return artifact.New(logr.New(&cli.LogSink{})).Push(files, to, username, password, annotations)
 }

--- a/internal/pkg/cli/pusher/pusher.go
+++ b/internal/pkg/cli/pusher/pusher.go
@@ -37,13 +37,10 @@ func New(options *Options) *Pusher {
 
 // Run the Pusher.
 func (p *Pusher) Run() error {
-	log.Printf(
-		"Pushing profile %s to: %s",
-		p.options.inputFile, p.options.pushTo,
-	)
+	log.Printf("Pushing profiles to: %s", p.options.pushTo)
 
 	if err := p.Push(
-		p.options.inputFile,
+		p.options.inputFiles,
 		p.options.pushTo,
 		p.options.username,
 		p.options.password,

--- a/internal/pkg/cli/pusher/pusherfakes/fake_impl.go
+++ b/internal/pkg/cli/pusher/pusherfakes/fake_impl.go
@@ -19,13 +19,15 @@ package pusherfakes
 
 import (
 	"sync"
+
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 )
 
 type FakeImpl struct {
-	PushStub        func(string, string, string, string, map[string]string) error
+	PushStub        func(map[*v1.Platform]string, string, string, string, map[string]string) error
 	pushMutex       sync.RWMutex
 	pushArgsForCall []struct {
-		arg1 string
+		arg1 map[*v1.Platform]string
 		arg2 string
 		arg3 string
 		arg4 string
@@ -41,11 +43,11 @@ type FakeImpl struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeImpl) Push(arg1 string, arg2 string, arg3 string, arg4 string, arg5 map[string]string) error {
+func (fake *FakeImpl) Push(arg1 map[*v1.Platform]string, arg2 string, arg3 string, arg4 string, arg5 map[string]string) error {
 	fake.pushMutex.Lock()
 	ret, specificReturn := fake.pushReturnsOnCall[len(fake.pushArgsForCall)]
 	fake.pushArgsForCall = append(fake.pushArgsForCall, struct {
-		arg1 string
+		arg1 map[*v1.Platform]string
 		arg2 string
 		arg3 string
 		arg4 string
@@ -70,13 +72,13 @@ func (fake *FakeImpl) PushCallCount() int {
 	return len(fake.pushArgsForCall)
 }
 
-func (fake *FakeImpl) PushCalls(stub func(string, string, string, string, map[string]string) error) {
+func (fake *FakeImpl) PushCalls(stub func(map[*v1.Platform]string, string, string, string, map[string]string) error) {
 	fake.pushMutex.Lock()
 	defer fake.pushMutex.Unlock()
 	fake.PushStub = stub
 }
 
-func (fake *FakeImpl) PushArgsForCall(i int) (string, string, string, string, map[string]string) {
+func (fake *FakeImpl) PushArgsForCall(i int) (map[*v1.Platform]string, string, string, string, map[string]string) {
 	fake.pushMutex.RLock()
 	defer fake.pushMutex.RUnlock()
 	argsForCall := fake.pushArgsForCall[i]

--- a/internal/pkg/cli/runner/consts.go
+++ b/internal/pkg/cli/runner/consts.go
@@ -26,7 +26,7 @@ const (
 	FlagType string = "type"
 
 	// FlagProfile is the flag for defining the input file location.
-	FlagProfile string = cli.FlagProfile
+	FlagProfile string = "profile"
 )
 
 // Type is the enum for all available profile types.

--- a/internal/pkg/daemon/seccompprofile/impl.go
+++ b/internal/pkg/daemon/seccompprofile/impl.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	"github.com/go-logr/logr"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -34,7 +35,7 @@ type defaultImpl struct{}
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate -header ../../../../hack/boilerplate/boilerplate.generatego.txt
 //counterfeiter:generate . impl
 type impl interface {
-	Pull(context.Context, logr.Logger, string, string, string) (*artifact.PullResult, error)
+	Pull(context.Context, logr.Logger, string, string, string, *v1.Platform) (*artifact.PullResult, error)
 	PullResultType(*artifact.PullResult) artifact.PullResultType
 	PullResultSeccompProfile(*artifact.PullResult) *seccompprofileapi.SeccompProfile
 	ClientGetProfile(
@@ -45,9 +46,9 @@ type impl interface {
 }
 
 func (*defaultImpl) Pull(
-	ctx context.Context, l logr.Logger, from, _, _ string,
+	ctx context.Context, l logr.Logger, from, _, _ string, platform *v1.Platform,
 ) (*artifact.PullResult, error) {
-	return artifact.New(l).Pull(ctx, from, "", "")
+	return artifact.New(l).Pull(ctx, from, "", "", platform)
 }
 
 func (*defaultImpl) PullResultType(res *artifact.PullResult) artifact.PullResultType {

--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -25,12 +25,14 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"runtime"
 	"strings"
 	"time"
 
 	"github.com/containers/common/pkg/seccomp"
 	"github.com/go-logr/logr"
 	"github.com/jellydator/ttlcache/v3"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -363,7 +365,10 @@ func (r *Reconciler) resolveSyscallsForProfile(
 			baseProfile = item.Value()
 		} else {
 			l.Info("Pulling base profile: " + from)
-			res, err := r.Pull(ctx, l, from, "", "")
+			res, err := r.Pull(ctx, l, from, "", "", &v1.Platform{
+				Architecture: runtime.GOARCH,
+				OS:           runtime.GOOS,
+			})
 			if err != nil {
 				l.Error(err, "cannot pull base profile "+baseProfileName)
 				r.IncSeccompProfileError(r.metrics, reasonCannotPullProfile)

--- a/internal/pkg/daemon/seccompprofile/seccompprofilefakes/fake_impl.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofilefakes/fake_impl.go
@@ -22,6 +22,7 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
+	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
@@ -54,7 +55,7 @@ type FakeImpl struct {
 		arg1 *metrics.Metrics
 		arg2 string
 	}
-	PullStub        func(context.Context, logr.Logger, string, string, string) (*artifact.PullResult, error)
+	PullStub        func(context.Context, logr.Logger, string, string, string, *v1.Platform) (*artifact.PullResult, error)
 	pullMutex       sync.RWMutex
 	pullArgsForCall []struct {
 		arg1 context.Context
@@ -62,6 +63,7 @@ type FakeImpl struct {
 		arg3 string
 		arg4 string
 		arg5 string
+		arg6 *v1.Platform
 	}
 	pullReturns struct {
 		result1 *artifact.PullResult
@@ -206,7 +208,7 @@ func (fake *FakeImpl) IncSeccompProfileErrorArgsForCall(i int) (*metrics.Metrics
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeImpl) Pull(arg1 context.Context, arg2 logr.Logger, arg3 string, arg4 string, arg5 string) (*artifact.PullResult, error) {
+func (fake *FakeImpl) Pull(arg1 context.Context, arg2 logr.Logger, arg3 string, arg4 string, arg5 string, arg6 *v1.Platform) (*artifact.PullResult, error) {
 	fake.pullMutex.Lock()
 	ret, specificReturn := fake.pullReturnsOnCall[len(fake.pullArgsForCall)]
 	fake.pullArgsForCall = append(fake.pullArgsForCall, struct {
@@ -215,13 +217,14 @@ func (fake *FakeImpl) Pull(arg1 context.Context, arg2 logr.Logger, arg3 string, 
 		arg3 string
 		arg4 string
 		arg5 string
-	}{arg1, arg2, arg3, arg4, arg5})
+		arg6 *v1.Platform
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
 	stub := fake.PullStub
 	fakeReturns := fake.pullReturns
-	fake.recordInvocation("Pull", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("Pull", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.pullMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
@@ -235,17 +238,17 @@ func (fake *FakeImpl) PullCallCount() int {
 	return len(fake.pullArgsForCall)
 }
 
-func (fake *FakeImpl) PullCalls(stub func(context.Context, logr.Logger, string, string, string) (*artifact.PullResult, error)) {
+func (fake *FakeImpl) PullCalls(stub func(context.Context, logr.Logger, string, string, string, *v1.Platform) (*artifact.PullResult, error)) {
 	fake.pullMutex.Lock()
 	defer fake.pullMutex.Unlock()
 	fake.PullStub = stub
 }
 
-func (fake *FakeImpl) PullArgsForCall(i int) (context.Context, logr.Logger, string, string, string) {
+func (fake *FakeImpl) PullArgsForCall(i int) (context.Context, logr.Logger, string, string, string, *v1.Platform) {
 	fake.pullMutex.RLock()
 	defer fake.pullMutex.RUnlock()
 	argsForCall := fake.pullArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *FakeImpl) PullReturns(result1 *artifact.PullResult, result2 error) {


### PR DESCRIPTION


#### What type of PR is this?


/kind feature

#### What this PR does / why we need it:
This allows pushing and pulling multiple platforms as OCI artifacts.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to #1482 
#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
Yes
#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Added support for platforms (`os[/arch][/variant][:os_version]`) when using seccomp OCI artifact profiles.
```
