### PR TITLE
Add a base e2e test for apparmor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ CLANG ?= clang
 LLVM_STRIP ?= llvm-strip
 BPF_PATH := internal/pkg/daemon/bpfrecorder/bpf
 ARCH ?= $(shell uname -m | \
-	sed 's/x86_64/x86/' | \
+	sed 's/x86_64/amd64/' | \
 	sed 's/aarch64/arm64/' | \
 	sed 's/ppc64le/powerpc/' | \
 	sed 's/mips.*/mips/')
@@ -423,7 +423,7 @@ verify-dependencies: $(BUILD_DIR)/zeitgeist ## Verify external dependencies
 
 $(BUILD_DIR)/zeitgeist: $(BUILD_DIR)
 	curl -sSfL -o $(BUILD_DIR)/zeitgeist \
-		https://github.com/kubernetes-sigs/zeitgeist/releases/download/$(ZEITGEIST_VERSION)/zeitgeist_$(ZEITGEIST_VERSION:v%=%)_linux_amd64
+		https://github.com/kubernetes-sigs/zeitgeist/releases/download/$(ZEITGEIST_VERSION)/zeitgeist_$(ZEITGEIST_VERSION:v%=%)_${OS}_${ARCH}
 	chmod +x $(BUILD_DIR)/zeitgeist
 
 .PHONY: verify-toc

--- a/hack/ci/Vagrantfile-ubuntu
+++ b/hack/ci/Vagrantfile-ubuntu
@@ -41,7 +41,9 @@ Vagrant.configure("2") do |config|
         kubectl=$KUBERNETES_VERSION \
         podman \
         jq \
-        moreutils
+        moreutils \
+        apparmor \
+        apparmor-utils
 
       # Disable kernel print rate limiting for syslog messaging
       sysctl -w kernel.printk_ratelimit=0

--- a/hack/ci/e2e-ubuntu.sh
+++ b/hack/ci/e2e-ubuntu.sh
@@ -18,10 +18,11 @@ set -euo pipefail
 export E2E_CLUSTER_TYPE=vanilla
 export E2E_TEST_LOG_ENRICHER=true
 export E2E_TEST_SECCOMP=false
+export E2E_TEST_APPARMOR=true
 export E2E_TEST_FLAKY_TESTS_ONLY=${E2E_TEST_FLAKY_TESTS_ONLY:-false}
 
 if "${E2E_TEST_FLAKY_TESTS_ONLY}"; then
-    make test-flaky-e2e
+	make test-flaky-e2e
 else
-    make test-e2e
+	make test-e2e
 fi

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -109,6 +109,10 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			e.testCaseSelinuxMetrics,
 		},
 		{
+			"AppArmor: base case (install policy, run pod and delete)",
+			e.testCaseAppArmorBaseUsage,
+		},
+		{
 			"SPOD: Update SELinux flag",
 			e.testCaseSPODUpdateSelinux,
 		},

--- a/test/tc_apparmor_base_usage_test.go
+++ b/test/tc_apparmor_base_usage_test.go
@@ -1,0 +1,162 @@
+/*
+Copyright 2023 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	defaultAppArmorOpTimeout = "60s"
+	errorloggerProfile       = `
+apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+kind: AppArmorProfile
+metadata:
+  name: aa-errorlogger-profile
+spec:
+  policy: |
+    #include <tunables/global>
+
+    profile aa-errorlogger-profile flags=(attach_disconnected) {
+      #include <abstractions/base>
+
+      file,
+
+      # Deny all file writes.
+      deny /** w,
+    }
+`
+
+	//nolint:lll // full yaml
+	aaPodWithPolicyFmt = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: aa-errorlogger
+  annotations:
+    container.apparmor.security.beta.kubernetes.io/errorlogger: localhost/%s
+spec:
+  containers:
+  - name: errorlogger
+    image: "registry.access.redhat.com/ubi8/ubi-minimal:latest"
+    command: ["/bin/bash"]
+    args: [ "-c","set -eux; echo 'Hello AppArmor!' && sleep 1h" ]
+  restartPolicy: Never
+`
+)
+
+func (e *e2e) testCaseAppArmorBaseUsage(nodes []string) {
+	e.apparmorOnlyTestCase()
+
+	e.logf("The 'errorlogger' workload should be able to use AppArmor profile")
+
+	e.logf("creating profile")
+	e.writeAndCreate(errorloggerProfile, "errorlogger-profile.yml")
+
+	profileName := "aa-errorlogger-profile"
+
+	e.logf("assert profile is installed")
+	e.assertAppArmorProfileIsInstalled(nodes, profileName, maxNodeIterations, sleepBetweenIterations)
+
+	e.logf("creating workload")
+
+	podWithPolicy := fmt.Sprintf(aaPodWithPolicyFmt, profileName)
+	e.writeAndCreate(podWithPolicy, "pod-w-profile.yml")
+
+	podName := "aa-errorlogger"
+
+	e.waitFor("condition=ready", "pod", podName)
+
+	e.logf("the workload should be running")
+	podWithPolicyPhase := e.kubectl(
+		"get", "pods", podName, "-o", "jsonpath={.status.phase}")
+	e.Truef(strings.EqualFold(podWithPolicyPhase, "running"),
+		"The pod without profile's phase should be 'Running', instead it's: %s",
+		podWithPolicyPhase)
+
+	e.logf("cleaning up")
+
+	e.logf("removing workload")
+	e.kubectl("delete", "pod", podName)
+
+	e.logf("removing profile")
+	e.kubectl("delete", "apparmorprofile", profileName)
+
+	e.logf("assert profile was removed")
+	e.assertAppArmorProfileIsRemoved(nodes, profileName, maxNodeIterations, sleepBetweenIterations)
+}
+
+func (e *e2e) assertAppArmorProfileIsInstalled(
+	nodes []string, profile string, nodeIterations int, sleep time.Duration,
+) {
+	for i := 0; i < nodeIterations; i++ {
+		var missingPolName string
+
+		for _, node := range nodes {
+			allLoaddedProfiles := e.execNode(node, "sudo", "aa-status")
+			loadedProifles := []string{}
+			for _, p := range strings.Split(allLoaddedProfiles, "\n") {
+				p = strings.TrimSpace(p)
+				loadedProifles = append(loadedProifles, p)
+			}
+			if !e.sliceContainsString(loadedProifles, profile) {
+				missingPolName = node
+				break
+			}
+		}
+
+		if missingPolName != "" {
+			if i == nodeIterations-1 {
+				e.Fail(fmt.Sprintf(
+					"The AppArmorProfile %s wasn't found in the %s node",
+					profile, missingPolName,
+				))
+			} else {
+				e.logf(fmt.Sprintf("The profile %s wasn't found, trying again", profile))
+				time.Sleep(sleep)
+			}
+		}
+	}
+}
+
+func (e *e2e) assertAppArmorProfileIsRemoved(nodes []string, profile string, nodeIterations int, sleep time.Duration) {
+	for i := 0; i < nodeIterations; i++ {
+		var missingPolName string
+
+		for _, node := range nodes {
+			loadedProfiles := e.execNode(node, "sudo", "cat", "/sys/kernel/security/apparmor/profiles")
+			if e.sliceContainsString(strings.Split(loadedProfiles, "\n"), profile) {
+				missingPolName = node
+				break
+			}
+		}
+
+		if missingPolName != "" {
+			if i == nodeIterations-1 {
+				e.Fail(fmt.Sprintf(
+					"The AppArmor errorlogger was found in the %s node with the name %s",
+					missingPolName, profile,
+				))
+			} else {
+				e.logf("the profile was stil present, trying again")
+				time.Sleep(sleep)
+			}
+		}
+	}
+}

--- a/test/tc_apparmor_base_usage_test.go
+++ b/test/tc_apparmor_base_usage_test.go
@@ -43,7 +43,6 @@ spec:
     }
 `
 
-	//nolint:lll // full yaml
 	aaPodWithPolicyFmt = `
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

This e2e test covers the basic use case which loads and unloads apparmor profiles into the cluster nodes.

This is based on work done in #1074.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Relates #718

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

NONE

```release-note
Add a e2e test for apparmor profile which covers base functionlity such as loading and unloading profiles itno the cluster nodes.
```
