### PR TITLE
Fix string comparison on not found resources

### DIFF
--- a/internal/pkg/manager/spod/bindata/ca.go
+++ b/internal/pkg/manager/spod/bindata/ca.go
@@ -18,6 +18,7 @@ package bindata
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -25,11 +26,12 @@ import (
 	certmanagermetav1 "github.com/cert-manager/cert-manager/pkg/apis/meta/v1"
 	"github.com/go-logr/logr"
 	configv1 "github.com/openshift/api/config/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
@@ -69,14 +71,24 @@ func GetCAInjectType(
 func IsNotFound(err error) bool {
 	if runtime.IsNotRegisteredError(err) ||
 		meta.IsNoMatchError(err) ||
-		errors.IsNotFound(err) {
+		apierrors.IsNotFound(err) {
 		return true
+	}
+
+	// Introduced in controller-runtime v0.15.0, which makes a simple
+	// `apierrors.IsNotFound(err)` not work any more.
+	groupErr := &discovery.ErrGroupDiscoveryFailed{}
+	if errors.As(err, &groupErr) {
+		for _, err := range groupErr.Groups {
+			if apierrors.IsNotFound(err) {
+				return true
+			}
+		}
 	}
 
 	// Fallback
 	for _, msg := range []string{
 		"failed to get restmapping",
-		"could not find the requested resource",
 	} {
 		if strings.Contains(err.Error(), msg) {
 			return true
@@ -116,7 +128,7 @@ func GetCertManagerResources(namespace string) *CertManagerResources {
 func (c *CertManagerResources) Create(ctx context.Context, cl client.Client) error {
 	for k, o := range c.objectMap() {
 		if err := cl.Create(ctx, o); err != nil {
-			if errors.IsAlreadyExists(err) {
+			if apierrors.IsAlreadyExists(err) {
 				continue
 			}
 			return fmt.Errorf("creating %s: %w", k, err)


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
This converts the errors to the correct types and then checks if the resources are actually not found.


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Refers to https://github.com/kubernetes-sigs/controller-runtime/issues/2354
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
