### PR TITLE
Switch to clang 14 for debian based tests

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -238,6 +238,11 @@ dependencies:
       match: llvmPackages_\d+.clang-unwrapped
     - path: nix/derivation-bpf.nix
       match: llvm_\d+
+
+  # TODO: update to the latest clang of debian 12 packages are available.
+  - name: clang-debian-12
+    version: 14
+    refPaths:
     - path: hack/pull-security-profiles-operator-verify
       match: CLANG_VERSION
 

--- a/hack/pull-security-profiles-operator-verify
+++ b/hack/pull-security-profiles-operator-verify
@@ -3,7 +3,7 @@ set -euo pipefail
 
 ./hack/install-packages
 
-CLANG_VERSION=15
+CLANG_VERSION=14
 apt-get install -y software-properties-common
 curl -sSfL --retry 5 --retry-delay 3 https://apt.llvm.org/llvm.sh | bash -s -- $CLANG_VERSION all
 ln -sf /usr/bin/clang-format-$CLANG_VERSION /usr/bin/clang-format


### PR DESCRIPTION
#### What type of PR is this?

/kind failing-test


#### What this PR does / why we need it:
Downgrading clang in the verify job to 14 to fix the broken packages.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
