### PR TITLE
Change to macos-13 runner for flatcar-e2e tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,6 +137,7 @@ jobs:
    steps:
       - name: Upgrade vagrant-box
         run: |
+          brew update --cask
           brew upgrade --cask vagrant
       - name: Install virtualbox
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -130,11 +130,17 @@ jobs:
   e2e-flatcar:
    needs: image
 
-   runs-on: macos-12
+   runs-on: macos-13
    timeout-minutes: 90
    env:
      RUN: ./hack/ci/run-flatcar.sh
    steps:
+      - name: Upgrade vagrant-box
+        run: |
+          brew upgrade --cask vagrant
+      - name: Install virtualbox
+        run: |
+          brew install --cask virtualbox
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.2
       - name: Vagrant box version
         id: vagrant-box

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -248,7 +248,7 @@ dependencies:
       match: BTFHUB_COMMIT
 
   - name: flatcar
-    version: 3510.2.0
+    version: 3510.2.2
     refPaths:
     - path: hack/ci/Vagrantfile-flatcar
       match: flatcar_production_vagrant

--- a/hack/ci/Vagrantfile-flatcar
+++ b/hack/ci/Vagrantfile-flatcar
@@ -4,7 +4,7 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "flatcar-stable"
   config.vm.box_check_update = true
-  config.vm.box_url = "https://stable.release.flatcar-linux.net/amd64-usr/3510.2.0/flatcar_production_vagrant.box"
+  config.vm.box_url = "https://stable.release.flatcar-linux.net/amd64-usr/3510.2.2/flatcar_production_vagrant.box"
   memory = 8192
   cpus = 4
 
@@ -92,7 +92,7 @@ Vagrant.configure("2") do |config|
       # Install tools
       curl -sSL -o $DOWNLOAD_DIR/jq "https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64"
       chmod +x $DOWNLOAD_DIR/jq
-      curl -sSL -o $DOWNLOAD_DIR/flatcar_developer_container.bin.bz2 "https://stable.release.flatcar-linux.net/amd64-usr/3510.2.0/flatcar_developer_container.bin.bz2"
+      curl -sSL -o $DOWNLOAD_DIR/flatcar_developer_container.bin.bz2 "https://stable.release.flatcar-linux.net/amd64-usr/3510.2.2/flatcar_developer_container.bin.bz2"
       bzcat $DOWNLOAD_DIR/flatcar_developer_container.bin.bz2 > $DOWNLOAD_DIR/flatcar_developer_container.bin
 
       curl -sSL "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-linux-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz


### PR DESCRIPTION
Signed-off-by: Cosmin Cojocar <gcojocar@adobe.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind failing-test

#### What this PR does / why we need it:

Changes the runner image to macos-13 for flatcar e2e tests and install the missing virtualbox utility.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
