### PR TITLE
Fix a bunch of test outputs

### DIFF
--- a/test/tc_base_profiles_oci_test.go
+++ b/test/tc_base_profiles_oci_test.go
@@ -107,7 +107,7 @@ spec:
 		}
 		if strings.Contains(output, "CreateContainerError") {
 			output := e.kubectl("describe", "pod", "hello")
-			e.FailNowf("Unable to create container: %v", output)
+			e.FailNowf("Unable to create container", output)
 		}
 		time.Sleep(time.Second)
 	}

--- a/test/tc_base_profiles_test.go
+++ b/test/tc_base_profiles_test.go
@@ -85,9 +85,7 @@ spec:
 	defer e.kubectl("delete", "-f", helloProfileFile.Name())
 
 	e.logf("Waiting for profile to be reconciled")
-	e.kubectlOperatorNS("logs", "-l", "name=spod")
 	e.waitFor("condition=ready", "sp", "hello")
-	e.kubectlOperatorNS("logs", "-l", "name=spod")
 
 	e.logf("Creating hello-world pod")
 	helloPodFile, err := os.CreateTemp("", "hello-pod*.yaml")


### PR DESCRIPTION


#### What type of PR is this?

/kind cleanup


#### What this PR does / why we need it:
- We do not need to print the logs of the spod twice in `test/tc_base_profiles_test.go`.
- The failf message does not need an `%v` format specifier.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
