### PR TITLE
Update CRI-O to v1.27.1

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -176,7 +176,7 @@ dependencies:
       match: VERSION
 
   - name: CRI-O
-    version: v1.27.0
+    version: v1.27.1
     refPaths:
     - path: hack/ci/install-cri-o.sh
       match: TAG

--- a/hack/ci/install-cri-o.sh
+++ b/hack/ci/install-cri-o.sh
@@ -15,7 +15,7 @@
 
 set -euo pipefail
 
-TAG=v1.27.0
+TAG=v1.27.1
 
 curl_retry() {
     curl -sSfL --retry 5 --retry-delay 3 "$@"


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Bumping CRI-O to the latest release.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
