### PR TITLE
Use crate-ci/typos tag

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -202,6 +202,6 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.2
-      - uses: crate-ci/typos@37e2b40f24407ec641ec44d4b81e76a8826b7b84 # v4.0.0
+      - uses: crate-ci/typos@v1.16.2
         with:
           config: .typos.toml


### PR DESCRIPTION



#### What type of PR is this?


/kind failing-test


#### What this PR does / why we need it:
Dependabot tries to update the commit based on the repo, but the repo does not only host the GitHub action. It also contains the binary tags, which clash with the action. This means we now use the action tag rather than the commit.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
