### PR TITLE
Fix for selinux policy constantly being processed

### DIFF
--- a/api/selinuxprofile/v1alpha2/selinuxprofile_types.go
+++ b/api/selinuxprofile/v1alpha2/selinuxprofile_types.go
@@ -18,11 +18,13 @@ package v1alpha2
 
 import (
 	"context"
+	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	profilebasev1alpha1 "sigs.k8s.io/security-profiles-operator/api/profilebase/v1alpha1"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/util"
 )
 
 const (
@@ -77,10 +79,30 @@ func (lk LabelKey) String() string {
 
 type ObjectClassKey string
 
+func (ock ObjectClassKey) String() string {
+	return string(ock)
+}
+
 type PermissionSet []string
 
 // Allow defines the allow policy for the profile.
 type Allow map[LabelKey]map[ObjectClassKey]PermissionSet
+
+func SortLabelKeys(allow Allow) []LabelKey {
+	keys := util.MapKeys(allow)
+	sort.SliceStable(keys, func(i, j int) bool {
+		return keys[i].String() < keys[j].String()
+	})
+	return keys
+}
+
+func SortObjectClassKeys(ock map[ObjectClassKey]PermissionSet) []ObjectClassKey {
+	keys := util.MapKeys(ock)
+	sort.SliceStable(keys, func(i, j int) bool {
+		return keys[i].String() < keys[j].String()
+	})
+	return keys
+}
 
 // SelinuxProfileStatus defines the observed state of SelinuxProfile.
 type SelinuxProfileStatus struct {

--- a/internal/pkg/translator/obj2cil.go
+++ b/internal/pkg/translator/obj2cil.go
@@ -58,11 +58,13 @@ func Object2CIL(
 		cilbuilder.WriteString(typePermissive)
 		cilbuilder.WriteString("\n")
 	}
-	for ttype, tclassMap := range sp.Spec.Allow {
-		for tclass, perms := range tclassMap {
-			cilbuilder.WriteString(getCILAllowLine(sp, ttype, tclass, perms))
+
+	for _, ttype := range selxv1alpha2.SortLabelKeys(sp.Spec.Allow) {
+		for _, tclass := range selxv1alpha2.SortObjectClassKeys(sp.Spec.Allow[ttype]) {
+			cilbuilder.WriteString(getCILAllowLine(sp, ttype, tclass, sp.Spec.Allow[ttype][tclass]))
 		}
 	}
+
 	cilbuilder.WriteString(getCILEnd())
 	return cilbuilder.String()
 }

--- a/internal/pkg/util/maps.go
+++ b/internal/pkg/util/maps.go
@@ -1,8 +1,24 @@
+/*
+Copyright 2020 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package util
 
 // To avoid having to use experimental library imports, the below is taken from https://cs.opensource.google/go/x/exp/+/master:maps/maps.go
 // Keys returns the keys of the map m.
-// The keys will be in an indeterminate order
+// The keys will be in an indeterminate order.
 func MapKeys[M ~map[K]V, K comparable, V any](m M) []K {
 	r := make([]K, 0, len(m))
 	for k := range m {

--- a/internal/pkg/util/maps.go
+++ b/internal/pkg/util/maps.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package util
 
-// To avoid having to use experimental library imports, the below is taken from https://cs.opensource.google/go/x/exp/+/master:maps/maps.go
+// To avoid having to use experimental library imports, the below is taken from 
+// https://cs.opensource.google/go/x/exp/+/master:maps/maps.go
+
 // Keys returns the keys of the map m.
 // The keys will be in an indeterminate order.
 func MapKeys[M ~map[K]V, K comparable, V any](m M) []K {

--- a/internal/pkg/util/maps.go
+++ b/internal/pkg/util/maps.go
@@ -1,0 +1,12 @@
+package util
+
+// To avoid having to use experimental library imports, the below is taken from https://cs.opensource.google/go/x/exp/+/master:maps/maps.go
+// Keys returns the keys of the map m.
+// The keys will be in an indeterminate order
+func MapKeys[M ~map[K]V, K comparable, V any](m M) []K {
+	r := make([]K, 0, len(m))
+	for k := range m {
+		r = append(r, k)
+	}
+	return r
+}

--- a/internal/pkg/util/maps.go
+++ b/internal/pkg/util/maps.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 package util
 
-// To avoid having to use experimental library imports, the below is taken from 
+// To avoid having to use experimental library imports, the below is taken from
 // https://cs.opensource.google/go/x/exp/+/master:maps/maps.go
 
 // Keys returns the keys of the map m.


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Sorts the allow rules in the selinux policy when doing the write to the node and doing the comparison between CRD and node policy which allows for consistent comparisons.

#### Which issue(s) this PR fixes:
Fixes #1842 

#### Does this PR have test?
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fixed selinux policy constantly being processed.
```