### PR TITLE
Switch to Kubernetes v1.28.0 in CI

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -82,7 +82,7 @@ dependencies:
       match: QEMUVERSION
 
   - name: e2e-kubernetes
-    version: 1.27.2
+    version: 1.28
     refPaths:
     - path: hack/ci/install-kubernetes.sh
       match: VERSION

--- a/hack/ci/Vagrantfile-ubuntu
+++ b/hack/ci/Vagrantfile-ubuntu
@@ -30,15 +30,15 @@ Vagrant.configure("2") do |config|
         tar xfz - -C /usr/local
 
       # Kubernetes
-      curl -fsSLo /etc/apt/keyrings/kubernetes-archive-keyring.asc https://packages.cloud.google.com/apt/doc/apt-key.gpg
-      echo "deb [signed-by=/etc/apt/keyrings/kubernetes-archive-keyring.asc] https://apt.kubernetes.io/ kubernetes-xenial main" > /etc/apt/sources.list.d/kubernetes.list
+      KUBERNETES_VERSION=v1.28
+      curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+      echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
       apt-get update
-      KUBERNETES_VERSION=1.27.2-00
       apt-get install -y \
         build-essential \
-        kubelet=$KUBERNETES_VERSION \
-        kubeadm=$KUBERNETES_VERSION \
-        kubectl=$KUBERNETES_VERSION \
+        kubelet \
+        kubeadm \
+        kubectl \
         podman \
         jq \
         moreutils \

--- a/hack/ci/install-kubernetes.sh
+++ b/hack/ci/install-kubernetes.sh
@@ -19,7 +19,7 @@ ENVFILE=$(dirname "${BASH_SOURCE[0]}")/env-fedora.sh
 . "$ENVFILE"
 
 K8SPATH="$GOPATH/src/k8s.io"
-VERSION=v1.27.2
+VERSION=v1.28.0
 
 download-kubernetes() {
     export KUBERNETES_RELEASE=$VERSION


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup

#### What this PR does / why we need it:
Update CI to use k8s 1.28.0
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
