### PR TITLE
Add a default profile option for profileBindings

### DIFF
--- a/api/profilebinding/v1alpha1/profilebinding_types.go
+++ b/api/profilebinding/v1alpha1/profilebinding_types.go
@@ -25,6 +25,7 @@ type ProfileBindingKind string
 const (
 	ProfileBindingKindSeccompProfile ProfileBindingKind = "SeccompProfile"
 	ProfileBindingKindSelinuxProfile ProfileBindingKind = "SelinuxProfile"
+	SelectAllContainersImage         string             = "*"
 )
 
 // ProfileBindingSpec defines the desired state of ProfileBinding.
@@ -32,6 +33,7 @@ type ProfileBindingSpec struct {
 	// ProfileRef references a SeccompProfile or other profile type in the current namespace.
 	ProfileRef ProfileRef `json:"profileRef"`
 	// Image name within pod containers to match to the profile.
+	// Use the "*" string to bind the profile to all pods.
 	Image string `json:"image"`
 }
 

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_profilebindings.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_profilebindings.yaml
@@ -38,6 +38,7 @@ spec:
             properties:
               image:
                 description: Image name within pod containers to match to the profile.
+                  Use the "*" string to bind the profile to all pods.
                 type: string
               profileRef:
                 description: ProfileRef references a SeccompProfile or other profile

--- a/deploy/base-crds/crds/profilebinding.yaml
+++ b/deploy/base-crds/crds/profilebinding.yaml
@@ -35,6 +35,7 @@ spec:
             properties:
               image:
                 description: Image name within pod containers to match to the profile.
+                  Use the "*" string to bind the profile to all pods.
                 type: string
               profileRef:
                 description: ProfileRef references a SeccompProfile or other profile

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -37,6 +37,7 @@ spec:
             properties:
               image:
                 description: Image name within pod containers to match to the profile.
+                  Use the "*" string to bind the profile to all pods.
                 type: string
               profileRef:
                 description: ProfileRef references a SeccompProfile or other profile

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -37,6 +37,7 @@ spec:
             properties:
               image:
                 description: Image name within pod containers to match to the profile.
+                  Use the "*" string to bind the profile to all pods.
                 type: string
               profileRef:
                 description: ProfileRef references a SeccompProfile or other profile

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -108,6 +108,7 @@ spec:
             properties:
               image:
                 description: Image name within pod containers to match to the profile.
+                  Use the "*" string to bind the profile to all pods.
                 type: string
               profileRef:
                 description: ProfileRef references a SeccompProfile or other profile

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -37,6 +37,7 @@ spec:
             properties:
               image:
                 description: Image name within pod containers to match to the profile.
+                  Use the "*" string to bind the profile to all pods.
                 type: string
               profileRef:
                 description: ProfileRef references a SeccompProfile or other profile

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -37,6 +37,7 @@ spec:
             properties:
               image:
                 description: Image name within pod containers to match to the profile.
+                  Use the "*" string to bind the profile to all pods.
                 type: string
               profileRef:
                 description: ProfileRef references a SeccompProfile or other profile

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -108,6 +108,7 @@ spec:
             properties:
               image:
                 description: Image name within pod containers to match to the profile.
+                  Use the "*" string to bind the profile to all pods.
                 type: string
               profileRef:
                 description: ProfileRef references a SeccompProfile or other profile

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/cert-manager/cert-manager v1.13.3
 	github.com/containers/common v0.49.3
 	github.com/go-logr/logr v1.4.1
+	github.com/google/go-cmp v0.6.0
 	github.com/google/go-containerregistry v0.18.0
 	github.com/imdario/mergo v0.3.16
 	github.com/jellydator/ttlcache/v3 v3.1.1
@@ -153,7 +154,6 @@ require (
 	github.com/gomarkdown/markdown v0.0.0-20210514010506-3b9f47219fe7 // indirect
 	github.com/google/certificate-transparency-go v1.1.7 // indirect
 	github.com/google/gnostic-models v0.6.9-0.20230804172637-c7be7c783f49 // indirect
-	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/google/go-github/v55 v55.0.0 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -631,6 +631,21 @@ spec:
   image: nginx:1.19.1
 ```
 
+You can enable a default profile binding by using the string "*" as the image name.
+This will only apply a profile binding if no other profile binding matches a container in the pod.
+
+```yaml
+apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+kind: ProfileBinding
+metadata:
+  name: nginx-binding
+spec:
+  profileRef:
+    kind: SeccompProfile
+    name: profile-complain
+  image: *
+```
+
 If the Pod is already running, it will need to be restarted in order to pick up
 the profile binding. Once the binding is created and the Pod is created or
 recreated, the SeccompProfile should be applied to the container whose image

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -205,9 +205,14 @@ func (p *podBinder) updatePod(ctx context.Context, profilebindings []profilebind
 		}
 	}
 
-	if !podChanged && (podBindProfile == nil || podProfileBinding == nil) {
+	if podChanged {
+		return pod, admission.Response{}
+	}
+
+	if podBindProfile == nil || podProfileBinding == nil {
 		return pod, admission.Allowed("pod unchanged")
 	}
+
 	if !p.addPodSecurityContext(pod, *podBindProfile) {
 		return pod, admission.Allowed("pod unchanged")
 	}

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -119,6 +119,7 @@ func (p *podBinder) Handle(ctx context.Context, req admission.Request) admission
 	podChanged := false
 	podID := req.Namespace + "/" + req.Name
 	pod := &corev1.Pod{}
+	applyToAllContainers = false
 
 	var containers sync.Map
 	if req.Operation != "DELETE" {

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -118,7 +118,7 @@ func (p *podBinder) Handle(ctx context.Context, req admission.Request) admission
 	}
 	profilebindings := profileBindings.Items
 
-	pod, admissionResponse := p.updatePod(ctx, profilebindings, req)
+	pod, admissionResponse := p.updatePod(ctx, profilebindings, &req)
 	if !cmp.Equal(admissionResponse, admission.Response{}) {
 		return admissionResponse
 	}
@@ -132,7 +132,7 @@ func (p *podBinder) Handle(ctx context.Context, req admission.Request) admission
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
 }
 
-func (p *podBinder) updatePod(ctx context.Context, profilebindings []profilebindingv1alpha1.ProfileBinding, req admission.Request) (*corev1.Pod, admission.Response) {
+func (p *podBinder) updatePod(ctx context.Context, profilebindings []profilebindingv1alpha1.ProfileBinding, req *admission.Request) (*corev1.Pod, admission.Response) {
 	var err error
 	var podBindProfile *interface{}
 	var containers sync.Map
@@ -141,7 +141,7 @@ func (p *podBinder) updatePod(ctx context.Context, profilebindings []profilebind
 	pod := &corev1.Pod{}
 	podChanged := false
 	if req.Operation != "DELETE" {
-		pod, err = p.impl.DecodePod(req)
+		pod, err = p.impl.DecodePod(*req)
 		if err != nil {
 			p.log.Error(err, "failed to decode pod")
 			return pod, admission.Errored(http.StatusBadRequest, err)

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -132,7 +132,11 @@ func (p *podBinder) Handle(ctx context.Context, req admission.Request) admission
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledPod)
 }
 
-func (p *podBinder) updatePod(ctx context.Context, profilebindings []profilebindingv1alpha1.ProfileBinding, req *admission.Request) (*corev1.Pod, admission.Response) {
+func (p *podBinder) updatePod(
+	ctx context.Context,
+	profilebindings []profilebindingv1alpha1.ProfileBinding,
+	req *admission.Request,
+) (*corev1.Pod, admission.Response) {
 	var err error
 	var podBindProfile *interface{}
 	var containers sync.Map

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -205,16 +205,14 @@ func (p *podBinder) updatePod(ctx context.Context, profilebindings []profilebind
 		}
 	}
 
-	if !podChanged {
-		if podBindProfile == nil || podProfileBinding == nil {
-			return pod, admission.Allowed("pod unchanged")
-		}
-		podChanged = p.addPodSecurityContext(pod, *podBindProfile)
-		if podChanged {
-			if err := p.addPodToBinding(ctx, podID, podProfileBinding); err != nil {
-				return pod, admission.Errored(http.StatusInternalServerError, err)
-			}
-		}
+	if !podChanged && (podBindProfile == nil || podProfileBinding == nil) {
+		return pod, admission.Allowed("pod unchanged")
+	}
+	if !p.addPodSecurityContext(pod, *podBindProfile) {
+		return pod, admission.Allowed("pod unchanged")
+	}
+	if err := p.addPodToBinding(ctx, podID, podProfileBinding); err != nil {
+		return pod, admission.Errored(http.StatusInternalServerError, err)
 	}
 	return pod, admission.Response{}
 }

--- a/test/e2e_flaky_test.go
+++ b/test/e2e_flaky_test.go
@@ -66,8 +66,8 @@ func (e *e2e) TestSecurityProfilesOperator_Flaky() {
 	// TODO(jaosorior): Re-introduce this to the namespaced tests once we
 	// fix the issue with the certs.
 	e.Run("cluster-wide: Seccomp: Verify profile binding", func() {
-		e.testCaseSeccompProfileBinding(nodes)
-		e.testCaseSeccompProfileBindingDefaultProfile(nodes)
+		e.testCaseSeccompProfileBinding(nodes, "quay.io/security-profiles-operator/test-hello-world:latest")
+		e.testCaseSeccompProfileBinding(nodes, "*")
 	})
 
 	e.Run("cluster-wide: Seccomp: Verify profile recording logs", func() {

--- a/test/e2e_flaky_test.go
+++ b/test/e2e_flaky_test.go
@@ -67,6 +67,7 @@ func (e *e2e) TestSecurityProfilesOperator_Flaky() {
 	// fix the issue with the certs.
 	e.Run("cluster-wide: Seccomp: Verify profile binding", func() {
 		e.testCaseSeccompProfileBinding(nodes)
+		e.testCaseSeccompProfileBindingDefaultProfile(nodes)
 	})
 
 	e.Run("cluster-wide: Seccomp: Verify profile recording logs", func() {

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -161,6 +161,7 @@ func (e *e2e) TestSecurityProfilesOperator() {
 
 	e.Run("cluster-wide: Selinux: Verify profile binding", func() {
 		e.testCaseSelinuxProfileBinding()
+		e.testCaseSelinuxDefaultProfileBinding()
 		e.testCaseSelinuxProfileBindingNsNotEnabled()
 	})
 

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -160,8 +160,8 @@ func (e *e2e) TestSecurityProfilesOperator() {
 	}
 
 	e.Run("cluster-wide: Selinux: Verify profile binding", func() {
-		e.testCaseSelinuxProfileBinding()
-		e.testCaseSelinuxDefaultProfileBinding()
+		e.testCaseSelinuxProfileBinding("busybox:latest")
+		e.testCaseSelinuxProfileBinding("*")
 		e.testCaseSelinuxProfileBindingNsNotEnabled()
 	})
 

--- a/test/tc_seccomp_profilebindings_test.go
+++ b/test/tc_seccomp_profilebindings_test.go
@@ -26,7 +26,7 @@ func (e *e2e) testCaseSeccompProfileBinding(_ []string, image string) {
 	e.seccompOnlyTestCase()
 
 	const exampleProfilePath = "examples/seccompprofile.yaml"
-	var testBinding = fmt.Sprintf(`
+	testBinding := fmt.Sprintf(`
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
 kind: ProfileBinding
 metadata:

--- a/test/tc_seccomp_profilebindings_test.go
+++ b/test/tc_seccomp_profilebindings_test.go
@@ -129,3 +129,111 @@ spec:
 
 	e.Contains(output, "in-use-by-active-pods")
 }
+
+func (e *e2e) testCaseSeccompProfileBindingDefaultProfile([]string) {
+	e.seccompOnlyTestCase()
+
+	const exampleProfilePath = "examples/seccompprofile.yaml"
+	const testBinding = `
+apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
+kind: ProfileBinding
+metadata:
+  name: hello-binding
+spec:
+  profileRef:
+    kind: SeccompProfile
+    name: profile-allow-unsafe
+  image: *
+`
+	const testPod = `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello
+spec:
+  containers:
+  - image: quay.io/security-profiles-operator/test-hello-world:latest
+    name: hello
+    resources: {}
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+        - ALL
+      runAsUser: 1000
+      runAsNonRoot: true
+  restartPolicy: Never
+`
+
+	restoreNs := e.switchToNs(nsBindingEnabled)
+	defer restoreNs()
+	e.enableBindingHookInNs(nsBindingEnabled)
+
+	e.kubectl("create", "-f", exampleProfilePath)
+	defer e.kubectl("delete", "-f", exampleProfilePath)
+	e.waitFor("condition=ready", "seccompprofile", "profile-allow-unsafe")
+
+	e.logf("Creating test profile binding")
+	testBindingFile, err := os.CreateTemp("", "hello-binding*.yaml")
+	e.Nil(err)
+	defer os.Remove(testBindingFile.Name())
+	_, err = testBindingFile.WriteString(testBinding)
+	e.Nil(err)
+	err = testBindingFile.Close()
+	e.Nil(err)
+	e.kubectl("create", "-f", testBindingFile.Name())
+	defer e.kubectl("delete", "-f", testBindingFile.Name())
+
+	e.logf("Creating test pod")
+	testPodFile, err := os.CreateTemp("", "hello-pod*.yaml")
+	e.Nil(err)
+	defer os.Remove(testPodFile.Name())
+
+	_, err = testPodFile.WriteString(testPod)
+	e.Nil(err)
+	err = testPodFile.Close()
+	e.Nil(err)
+	e.kubectl("create", "-f", testPodFile.Name())
+	defer e.kubectl("delete", "pod", "hello")
+
+	e.logf("Waiting for test pod to be initialized")
+	e.waitFor("condition=initialized", "pod", "hello")
+
+	output := e.kubectl("get", "pod", "hello")
+	for strings.Contains(output, "ContainerCreating") {
+		output = e.kubectl("get", "pod", "hello")
+	}
+
+	e.logf("Testing that container is launched without runtime permission errors")
+	output = e.kubectl("describe", "pod", "hello")
+	e.NotContains(output, "Error: failed to start containerd task")
+
+	e.logf("Testing that container ran successfully")
+	output = e.kubectl("logs", "hello")
+	e.Contains(output, "Hello from Docker!")
+
+	namespace := e.getCurrentContextNamespace(defaultNamespace)
+
+	e.logf("Testing that pod has securityContext")
+	output = e.kubectl(
+		"get", "pod", "hello",
+		"--output", "jsonpath={.spec.containers[0].securityContext.seccompProfile.localhostProfile}",
+	)
+	e.Equal(fmt.Sprintf("operator/%s/profile-allow-unsafe.json", namespace), output)
+
+	e.logf("Testing that profile binding has pod reference")
+	output = e.kubectl("get", "profilebinding", "hello-binding", "--output", "jsonpath={.status.activeWorkloads[0]}")
+	e.Equal(fmt.Sprintf("%s/hello", namespace), output)
+	output = e.kubectl("get", "profilebinding", "hello-binding", "--output", "jsonpath={.metadata.finalizers[0]}")
+	e.Equal("active-workload-lock", output)
+
+	e.logf("Testing that profile has pod reference")
+	output = e.kubectl("get", "seccompprofile", "profile-allow-unsafe",
+		"--output", "jsonpath={.status.activeWorkloads[0]}")
+
+	e.Equal(fmt.Sprintf("%s/hello", namespace), output)
+	output = e.kubectl("get", "seccompprofile", "profile-allow-unsafe",
+		"--output", "jsonpath={.metadata.finalizers}")
+
+	e.Contains(output, "in-use-by-active-pods")
+}

--- a/test/tc_seccomp_profilebindings_test.go
+++ b/test/tc_seccomp_profilebindings_test.go
@@ -153,7 +153,7 @@ metadata:
 spec:
   containers:
   - image: quay.io/security-profiles-operator/test-hello-world:latest
-    name: foo
+    name: hello
     resources: {}
     securityContext:
       allowPrivilegeEscalation: false

--- a/test/tc_selinux_profilebindings_test.go
+++ b/test/tc_selinux_profilebindings_test.go
@@ -30,7 +30,46 @@ const (
 func (e *e2e) testCaseSelinuxProfileBinding() {
 	e.selinuxOnlyTestCase()
 
-	cleanup := e.profileBindingTestPrep(nsBindingEnabled, true)
+	cleanup := e.profileBindingTestPrep(nsBindingEnabled, true, , "busybox:latest")
+	defer cleanup()
+
+	e.logf("the workload should not have errored")
+	log := e.kubectl("logs", testPodName, "-c", "errorloggerbinding")
+	e.Emptyf(log, "container should not have returned a 'Permissions Denied' error")
+
+	namespace := e.getCurrentContextNamespace(defaultNamespace)
+
+	e.logf("Getting selinux profile usage")
+	selinuxUsage := e.getSELinuxPolicyUsage(selinuxTestProfileName)
+
+	e.logf("Testing that pod has securityContext")
+	output := e.kubectl(
+		"get", "pod", testPodName,
+		"--output", "jsonpath={.spec.initContainers[0].securityContext.seLinuxOptions.type}",
+	)
+	e.Equal(selinuxUsage, output)
+
+	e.logf("Testing that profile binding has pod reference")
+	output = e.kubectl("get", "profilebinding", selinuxBindingName, "--output", "jsonpath={.status.activeWorkloads[0]}")
+	e.Equal(fmt.Sprintf("%s/%s", namespace, testPodName), output)
+	output = e.kubectl("get", "profilebinding", selinuxBindingName, "--output", "jsonpath={.metadata.finalizers[0]}")
+	e.Equal("active-workload-lock", output)
+
+	e.logf("Testing that profile has pod reference")
+	output = e.kubectl("get", "selinuxprofile", selinuxTestProfileName,
+		"--output", "jsonpath={.status.activeWorkloads[0]}")
+
+	e.Equal(fmt.Sprintf("%s/%s", namespace, testPodName), output)
+	output = e.kubectl("get", "selinuxprofile", selinuxTestProfileName,
+		"--output", "jsonpath={.metadata.finalizers[*]}")
+
+	e.Contains(output, "in-use-by-active-pods")
+}
+
+func (e *e2e) testCaseSelinuxDefaultProfileBinding() {
+	e.selinuxOnlyTestCase()
+
+	cleanup := e.profileBindingTestPrep(nsBindingEnabled, true, , "busybox:latest")
 	defer cleanup()
 
 	e.logf("the workload should not have errored")
@@ -69,7 +108,7 @@ func (e *e2e) testCaseSelinuxProfileBinding() {
 func (e *e2e) testCaseSelinuxProfileBindingNsNotEnabled() {
 	e.selinuxOnlyTestCase()
 
-	cleanup := e.profileBindingTestPrep(nsBindingDisabled, false)
+	cleanup := e.profileBindingTestPrep(nsBindingDisabled, false, "busybox:latest")
 	defer cleanup()
 
 	e.logf("the workload should have errored")
@@ -80,6 +119,7 @@ func (e *e2e) testCaseSelinuxProfileBindingNsNotEnabled() {
 func (e *e2e) profileBindingTestPrep(
 	ns string,
 	labelNs bool,
+	image string,
 ) func() {
 	selinuxTestProfile := fmt.Sprintf(`
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha2
@@ -126,8 +166,8 @@ spec:
   profileRef:
     kind: SelinuxProfile
     name: %s
-  image: busybox:latest
-`, selinuxBindingName, selinuxTestProfileName)
+  image: %s
+`, selinuxBindingName, selinuxTestProfileName, image)
 
 	testPod := fmt.Sprintf(`
 apiVersion: v1
@@ -136,7 +176,7 @@ metadata:
   name: %s
 spec:
   initContainers:
-  - image: busybox:latest
+  - image: %s
     name: errorloggerbinding
     command: ["sh"]
     args: ["-c", "echo \"Time: $(date). Some error info.\" >> /var/log/test.log || /bin/true"]
@@ -152,7 +192,7 @@ spec:
     hostPath:
       path: /var/log
       type: Directory
-`, testPodName)
+`, testPodName, image)
 
 	restoreNs := e.switchToNs(ns)
 	if labelNs {

--- a/test/tc_selinux_profilebindings_test.go
+++ b/test/tc_selinux_profilebindings_test.go
@@ -30,7 +30,7 @@ const (
 func (e *e2e) testCaseSelinuxProfileBinding() {
 	e.selinuxOnlyTestCase()
 
-	cleanup := e.profileBindingTestPrep(nsBindingEnabled, true, , "busybox:latest")
+	cleanup := e.profileBindingTestPrep(nsBindingEnabled, true, "busybox:latest")
 	defer cleanup()
 
 	e.logf("the workload should not have errored")
@@ -69,7 +69,7 @@ func (e *e2e) testCaseSelinuxProfileBinding() {
 func (e *e2e) testCaseSelinuxDefaultProfileBinding() {
 	e.selinuxOnlyTestCase()
 
-	cleanup := e.profileBindingTestPrep(nsBindingEnabled, true, , "busybox:latest")
+	cleanup := e.profileBindingTestPrep(nsBindingEnabled, true, "*")
 	defer cleanup()
 
 	e.logf("the workload should not have errored")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR introduces an "Enforce for all pods" option for ProfileBinding. 

Container profile binding will have precedence here, but this will allow developers to create a default seccomp or selinux profile to be defaulted to all pods in a namespace. 

If there exists a default profile binding and there has been no match between a container and profile binding for a given pod, the default profile will be applied to the pod level securityContext. 

#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/security-profiles-operator/issues/1868

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Adds functionality to the profile binding functionality to establish a default seccomp/selinux profile for a given namespace.
Specific image bindings have priority over the default profiles allowing more tailored profiles for specific images while allowing customization of a default profile applied to all pods without having to specify specific images strings.
```
