### PR TITLE
OCPBUGS-19744: Add RawSelinuxProfile type to the known type

### DIFF
--- a/internal/pkg/manager/nodestatus/nodestatus.go
+++ b/internal/pkg/manager/nodestatus/nodestatus.go
@@ -266,6 +266,8 @@ func (r *StatusReconciler) getProfileFromStatus(
 		prof = &seccompprofileapi.SeccompProfile{}
 	case "SelinuxProfile":
 		prof = &selxv1alpha2.SelinuxProfile{}
+	case "RawSelinuxProfile":
+		prof = &selxv1alpha2.RawSelinuxProfile{}
 	default:
 		return nil, fmt.Errorf("getting owner profile: %w", ErrUnknownOwnerKind)
 	}


### PR DESCRIPTION
#### What type of PR is this?


/kind bug

#### What this PR does / why we need it:

This fixes a issue when we create a raw SELinux profile, we were not able to recognize the owner of the nodestatus if a rawselinuxprofile is being created

#### Which issue(s) this PR fixes:

[Fixes OCPBUGS-19744](https://issues.redhat.com/browse/OCPBUGS-19744)

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
None

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixes a issue when we create a raw SELinux profile, we were not able to recognize the owner of the `NodeStatus` if a `RawSelinuxProfile` is being created.
```
