### PR TITLE
OCPBUGS-17164: Fix SelinuxProfile inherit issue

### DIFF
--- a/internal/pkg/daemon/selinuxprofile/selinuxprofile.go
+++ b/internal/pkg/daemon/selinuxprofile/selinuxprofile.go
@@ -134,7 +134,7 @@ func (sph *selinuxProfileHandler) validateAndTrackInherit(
 	// We default to System if Kind is left empty
 	case selxv1alpha2.SystemPolicyKind, "":
 		return sph.handleInheritSystemPolicy(ancestorRef)
-	case "SelinuxPolicy":
+	case "SelinuxProfile":
 		return sph.handleInheritSPOPolicy(ancestorRef, namespace)
 	}
 	return fmt.Errorf("%s/%s: %w", ancestorRef.Kind, ancestorRef.Name, ErrUnknownKindForEntry)

--- a/internal/pkg/daemon/selinuxprofile/selinuxprofile_test.go
+++ b/internal/pkg/daemon/selinuxprofile/selinuxprofile_test.go
@@ -124,7 +124,7 @@ func Test_selinuxProfileHandler(t *testing.T) {
 				Spec: selxv1alpha2.SelinuxProfileSpec{
 					Inherit: []selxv1alpha2.PolicyRef{
 						{
-							Kind: "SelinuxPolicy",
+							Kind: "SelinuxProfile",
 							Name: "foo",
 						},
 					},
@@ -188,7 +188,7 @@ func Test_selinuxProfileHandler(t *testing.T) {
 				Spec: selxv1alpha2.SelinuxProfileSpec{
 					Inherit: []selxv1alpha2.PolicyRef{
 						{
-							Kind: "SelinuxPolicy",
+							Kind: "SelinuxProfile",
 							Name: "unexistent-ref",
 						},
 					},
@@ -203,7 +203,7 @@ func Test_selinuxProfileHandler(t *testing.T) {
 			},
 			wantValidateErr: true,
 			wantErrMatches: []string{
-				"couldn't find inherit reference SelinuxPolicy/unexistent-ref",
+				"couldn't find inherit reference SelinuxProfile/unexistent-ref",
 			},
 			existingObjs: []client.Object{
 				spodinstance.DeepCopy(),
@@ -250,7 +250,7 @@ func Test_selinuxProfileHandler(t *testing.T) {
 				Spec: selxv1alpha2.SelinuxProfileSpec{
 					Inherit: []selxv1alpha2.PolicyRef{
 						{
-							Kind: "SelinuxPolicy",
+							Kind: "SelinuxProfile",
 							Name: "foo",
 						},
 					},


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This pr fixes SelinuxProfile inherits another SelinuxProfile. The issue is caused by wrong Inherit type name being used.

#### Which issue(s) this PR fixes:

Fixes [OCPBUGS-17164](https://issues.redhat.com/browse/OCPBUGS-17164)


#### Does this PR have test?

Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

```release-note
Fixes a issue when we create a raw SELinux profile that inherit another SELinux profile.
```