### PR TITLE
OCPBUGS-17164: Fix SELinuxprofile inherit issue

### DIFF
--- a/internal/pkg/translator/obj2cil.go
+++ b/internal/pkg/translator/obj2cil.go
@@ -42,8 +42,12 @@ func Object2CIL(
 	// all templates must inherit from the system container. Without explicitly
 	// inheriting from the system container, the policy will not be loaded
 	// if it uses e.g. net_container or any other template because only the
-	// container template includes a "process" definition
-	cilbuilder.WriteString(getCILInheritline(systemContainerInherit))
+	// container template includes a "process" definition unless it is inhrienting
+	// another selinuxProfile object because the system container is already being
+	// inherited in that case.
+	if len(objInherits) == 0 {
+		cilbuilder.WriteString(getCILInheritline(systemContainerInherit))
+	}
 	for _, inherit := range systemInherits {
 		if inherit == systemContainerInherit {
 			// already appended above
@@ -52,7 +56,7 @@ func Object2CIL(
 		cilbuilder.WriteString(getCILInheritline(inherit))
 	}
 	for _, inherit := range objInherits {
-		cilbuilder.WriteString(getCILInheritline(inherit.GetPolicyUsage()))
+		cilbuilder.WriteString(getCILInheritline(inherit.GetPolicyName()))
 	}
 	if sp.Spec.Permissive {
 		cilbuilder.WriteString(typePermissive)

--- a/internal/pkg/translator/obj2cil_test.go
+++ b/internal/pkg/translator/obj2cil_test.go
@@ -31,6 +31,7 @@ func TestObject2CIL(t *testing.T) {
 		name        string
 		profile     *selxv1alpha2.SelinuxProfile
 		wantMatches []string
+		doNotMatch  []string
 		inheritsys  []string
 		inheritobjs []selxv1alpha2.SelinuxProfileObject
 	}{
@@ -178,8 +179,11 @@ func TestObject2CIL(t *testing.T) {
 			},
 			wantMatches: []string{
 				"\\(block test-selinux-recording-nginx_default",
-				"\\(blockinherit foo_default.process\\)",
-				"\\(allow process http_port_t \\( tcp_socket \\(.*name_bind.*\\)\\)\\)\n",
+				"\\(blockinherit foo_default\\)",
+				"\\(allow process http_port_t \\( tcp_socket \\(.*name_bind.*\\)\\)\\)\\n",
+			},
+			doNotMatch: []string{
+				"\\(blockinherit container\\)",
 			},
 			inheritobjs: []selxv1alpha2.SelinuxProfileObject{
 				&selxv1alpha2.SelinuxProfile{
@@ -313,6 +317,14 @@ func TestObject2CIL(t *testing.T) {
 					t.Errorf("Error matching parsed CIL to expected result: %s", err)
 				} else if !matched {
 					t.Errorf("The generated CIL didn't match expectation.\nExpected match for: %s\nGenerated CIL: %s", wantMatch, got)
+				}
+			}
+			for _, doNotMatch := range tt.doNotMatch {
+				matched, err := regexp.MatchString(doNotMatch, got)
+				if err != nil {
+					t.Errorf("Error matching parsed CIL to expected result: %s", err)
+				} else if matched {
+					t.Errorf("The generated CIL matched expectation.\nExpected no match for: %s\nGenerated CIL: %s", doNotMatch, got)
 				}
 			}
 		})


### PR DESCRIPTION
#### What type of PR is this?

/kind bug


#### What this PR does / why we need it:

In conjunction to PR#1904, this pr is also needed in order to fix the selinux profile inherit issue, do not inherit system container on all selinuxprofile. In additional, the `.process` suffix is breaking the profile install as well, so it is now removed.

#### Which issue(s) this PR fixes:

Fixes # OCPBUGS-17164

#### Does this PR have test?

Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None

```release-note
In conjunction to PR#1904, this pr is also needed in order to fix the selinux profile inherit issue for [OCPBUGS-17164](https://issues.redhat.com/browse/OCPBUGS-17164), do not add inherit system container line when we have selinuxprofile inherit.
```
