### PR TITLE
Use http/1.1 for webhooks, metrics and profiling endpoints

### DIFF
--- a/test/e2e_flaky_test.go
+++ b/test/e2e_flaky_test.go
@@ -47,6 +47,14 @@ func (e *e2e) TestSecurityProfilesOperator_Flaky() {
 			"Seccomp: Metrics",
 			e.testCaseSeccompMetrics,
 		},
+		{
+			"SPOD: Test webhook HTTP version",
+			e.testCaseWebhookHTTP,
+		},
+		{
+			"SPOD: Test Metrics HTTP version",
+			e.testCaseMetricsHTTP,
+		},
 	}
 	for _, testCase := range testCases {
 		tc := testCase

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -128,6 +128,10 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			e.testCaseProfilingChange,
 		},
 		{
+			"SPOD: Profiling server protocol",
+			e.testCaseProfilingHTTP,
+		},
+		{
 			"SPOD: Enable memory optimiztaion",
 			e.testCaseMemOptmEnable,
 		},

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -58,6 +58,8 @@ var (
 	envSeccompTestsEnabled       = os.Getenv("E2E_TEST_SECCOMP")
 	envBpfRecorderTestsEnabled   = os.Getenv("E2E_TEST_BPF_RECORDER")
 	envWebhookConfigTestsEnabled = os.Getenv("E2E_TEST_WEBHOOK_CONFIG")
+	envWebhookHTTPTestsEnabled   = os.Getenv("E2E_TEST_WEBHOOK_HTTP")
+	envMetricsHTTPTestsEnabled   = os.Getenv("E2E_TEST_METRICS_HTTP")
 	containerRuntime             = os.Getenv("CONTAINER_RUNTIME")
 	nodeRootfsPrefix             = os.Getenv("NODE_ROOTFS_PREFIX")
 	operatorManifest             = os.Getenv("OPERATOR_MANIFEST")
@@ -102,6 +104,8 @@ type e2e struct {
 	skipNamespacedTests   bool
 	skipFlakyTests        bool
 	testWebhookConfig     bool
+	testWebhookHTTP       bool
+	testMetricsHTTP       bool
 	singleNodeEnvironment bool
 	logger                logr.Logger
 	execNode              func(node string, args ...string) string
@@ -176,6 +180,16 @@ func TestSuite(t *testing.T) {
 		testWebhookConfig = true
 	}
 
+	testWebhookHTTP, err := strconv.ParseBool(envWebhookHTTPTestsEnabled)
+	if err != nil {
+		testWebhookHTTP = true
+	}
+
+	testMetricsHTTP, err := strconv.ParseBool(envMetricsHTTPTestsEnabled)
+	if err != nil {
+		testMetricsHTTP = true
+	}
+
 	if operatorManifest == "" {
 		operatorManifest = defaultManifest
 	}
@@ -203,6 +217,8 @@ func TestSuite(t *testing.T) {
 				skipNamespacedTests: skipNamespacedTests,
 				operatorManifest:    operatorManifest,
 				testWebhookConfig:   testWebhookConfig,
+				testWebhookHTTP:     testWebhookHTTP,
+				testMetricsHTTP:     testMetricsHTTP,
 				skipFlakyTests:      skipFlakyTests,
 			},
 			"", "",
@@ -235,6 +251,8 @@ func TestSuite(t *testing.T) {
 				skipNamespacedTests: skipNamespacedTests,
 				operatorManifest:    operatorManifest,
 				testWebhookConfig:   testWebhookConfig,
+				testWebhookHTTP:     testWebhookHTTP,
+				testMetricsHTTP:     testMetricsHTTP,
 				skipFlakyTests:      skipFlakyTests,
 			},
 			skipBuildImages,
@@ -262,6 +280,8 @@ func TestSuite(t *testing.T) {
 				skipNamespacedTests: skipNamespacedTests,
 				operatorManifest:    operatorManifest,
 				testWebhookConfig:   testWebhookConfig,
+				testWebhookHTTP:     testWebhookHTTP,
+				testMetricsHTTP:     testMetricsHTTP,
 				skipFlakyTests:      skipFlakyTests,
 				// NOTE(jaosorior): Our current vanilla jobs are
 				// single-node only.
@@ -612,35 +632,43 @@ func (e *e2e) kubectlRunOperatorNS(args ...string) string {
 }
 
 const (
-	curlBaseCMD = "curl -ksfL --retry 5 --retry-delay 3 --show-error "
-	curlCMD     = curlBaseCMD + "-H \"Authorization: Bearer `cat /var/run/secrets/kubernetes.io/serviceaccount/token`\" "
-	metricsURL  = "https://metrics.security-profiles-operator.svc.cluster.local/"
-	curlSpodCMD = curlCMD + metricsURL + "metrics-spod"
-	curlCtrlCMD = curlCMD + metricsURL + "metrics"
+	curlBaseCMD    = "curl -ksL --retry 5 --retry-delay 3 --show-error "
+	headerAuth     = "-H \"Authorization: Bearer `cat /var/run/secrets/kubernetes.io/serviceaccount/token`\" "
+	curlCMD        = curlBaseCMD + headerAuth + "-f "
+	curlHTTPVerCMD = curlBaseCMD + headerAuth + "-I -w '%{http_version}\n' -o/dev/null "
+	metricsURL     = "https://metrics.security-profiles-operator.svc.cluster.local/"
+	webhooksURL    = "https://webhook-service.security-profiles-operator.svc.cluster.local/"
+	curlSpodCMD    = curlCMD + metricsURL + "metrics-spod"
+	curlCtrlCMD    = curlCMD + metricsURL + "metrics"
 )
 
-func (e *e2e) getSpodMetrics() string {
+func (e *e2e) runAndRetryPodCMD(podCMD string) string {
 	r := rand.New(rand.NewSource(time.Now().UnixNano())) // #nosec
 	letters := []rune("abcdefghijklmnopqrstuvwxyz")
 	b := make([]rune, 10)
 	for i := range b {
 		b[i] = letters[r.Intn(len(letters))]
 	}
+	maxTries := 0
 	// Sometimes the metrics command does not output anything in CI. We fix
 	// that by retrying the metrics retrieval several times.
 	var output string
 	if err := spoutil.Retry(func() error {
-		output = e.kubectlRunOperatorNS("pod-"+string(b), "--", "bash", "-c", curlSpodCMD)
+		output = e.kubectlRunOperatorNS("pod-"+string(b), "--", "bash", "-c", podCMD)
 		if len(strings.Split(output, "\n")) > 1 {
 			return nil
 		}
 		output = ""
-		return fmt.Errorf("no metrics output yet")
+		return fmt.Errorf("no output from pod command")
 	}, func(err error) bool {
 		e.logf("retry on error: %s", err)
-		return true
+		if maxTries < 3 {
+			maxTries++
+			return true
+		}
+		return false
 	}); err != nil {
-		e.Failf("unable to retrieve SPOD metrics", "error: %s", err)
+		e.Failf("unable to run pod command", "error: %s", err)
 	}
 	return output
 }

--- a/test/tc_bpf_recorder_test.go
+++ b/test/tc_bpf_recorder_test.go
@@ -96,7 +96,7 @@ func (e *e2e) testCaseBpfRecorderStaticPod() {
 	e.kubectl("delete", "-f", exampleRecordingBpfPath)
 	e.kubectl("delete", "sp", resourceName)
 
-	metrics := e.getSpodMetrics()
+	metrics := e.runAndRetryPodCMD(curlSpodCMD)
 	// we don't use resource name here, because the metrics are tracked by the annotation name which contains
 	// underscores instead of dashes
 	metricName := recordingName + "_nginx"
@@ -332,7 +332,7 @@ func (e *e2e) testCaseBpfRecorderWithMemoryOptimization() {
 	e.kubectl("delete", "-f", exampleRecordingBpfPath)
 	e.kubectl("delete", "sp", resourceName)
 
-	metrics := e.getSpodMetrics()
+	metrics := e.runAndRetryPodCMD(curlSpodCMD)
 	// we don't use resource name here, because the metrics are tracked by the annotation name which contains
 	// underscores instead of dashes
 	metricName := recordingName + "_nginx"

--- a/test/tc_log_enricher_test.go
+++ b/test/tc_log_enricher_test.go
@@ -113,7 +113,7 @@ spec:
 		// we only run the metrics checks in a single node environment because otherwise it's a lottery
 		// which spod instance do we hit and the test is not stable
 
-		metrics := e.getSpodMetrics()
+		metrics := e.runAndRetryPodCMD(curlSpodCMD)
 		e.Regexp(fmt.Sprintf(`(?m)security_profiles_operator_seccomp_profile_audit_total{`+
 			`container="%s",`+
 			`executable="/usr/sbin/nginx",`+

--- a/test/tc_metrics_test.go
+++ b/test/tc_metrics_test.go
@@ -35,7 +35,7 @@ func (e *e2e) testCaseSeccompMetrics([]string) {
 	)
 
 	e.logf("Retrieving spo metrics for getting assertions")
-	output := e.getSpodMetrics()
+	output := e.runAndRetryPodCMD(curlSpodCMD)
 	metricDeletions := e.parseMetric(output, operationDelete)
 	metricUpdates := e.parseMetric(output, operationUpdate)
 
@@ -61,7 +61,7 @@ spec:
 	e.kubectlRunOperatorNS("pod-2", "--", "bash", "-c", curlCtrlCMD)
 
 	e.logf("Retrieving spo metrics for validation")
-	outputSpod := e.getSpodMetrics()
+	outputSpod := e.runAndRetryPodCMD(curlSpodCMD)
 	e.Contains(outputSpod, "promhttp_metric_handler_requests_total")
 
 	e.logf("Asserting metrics values")
@@ -102,7 +102,7 @@ func (e *e2e) testCaseSelinuxMetrics(nodes []string) {
 	e.assertSelinuxPolicyIsRemoved(nodes, rawPolicyName, maxNodeIterations, sleepBetweenIterations)
 
 	e.logf("Retrieving spo metrics for validation")
-	outputSpod := e.getSpodMetrics()
+	outputSpod := e.runAndRetryPodCMD(curlSpodCMD)
 	e.Contains(outputSpod, "promhttp_metric_handler_requests_total")
 
 	e.logf("Asserting metrics values")
@@ -125,4 +125,20 @@ func (e *e2e) parseMetric(content, metric string) int {
 		}
 	}
 	return 0
+}
+
+func (e *e2e) testCaseMetricsHTTP([]string) {
+	if !e.testMetricsHTTP {
+		e.T().Skip("Skipping metrics HTTP version related tests")
+	}
+	e.logf("Test metrics HTTP version")
+
+	endpoints := []string{
+		curlHTTPVerCMD + metricsURL + "metrics",
+		curlHTTPVerCMD + metricsURL + "metrics-spod",
+	}
+	for _, endpoint := range endpoints {
+		output := e.runAndRetryPodCMD(endpoint)
+		e.Contains(output, "1.1\n")
+	}
 }

--- a/test/tc_profiling_test.go
+++ b/test/tc_profiling_test.go
@@ -17,7 +17,13 @@ limitations under the License.
 package e2e_test
 
 import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"strings"
 	"time"
+
+	spoutil "sigs.k8s.io/security-profiles-operator/internal/pkg/util"
 )
 
 func (e *e2e) testCaseProfilingChange([]string) {
@@ -35,4 +41,72 @@ func (e *e2e) testCaseProfilingChange([]string) {
 	)
 
 	e.Contains(logs, "Profiling support enabled: true")
+}
+
+func (e *e2e) testCaseProfilingHTTP([]string) {
+	e.selinuxOnlyTestCase()
+	e.logf("Test profiling HTTP version")
+
+	e.logf("Enable spod profiling to test endpoint HTTP version")
+	e.kubectlOperatorNS("patch", "spod", "spod", "-p", `{"spec":{"enableProfiling": true}}`, "--type=merge")
+	time.Sleep(defaultWaitTime)
+
+	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
+
+	output := e.getProfilingHTTPVersion()
+	e.Contains(output, "1.1\n")
+}
+
+func (e *e2e) getProfilingEndpoint(i int) string {
+	podName := e.kubectlOperatorNS("get", "pods", "-l", "name=spod", "-o",
+		fmt.Sprintf("jsonpath={.items[%d].metadata.name}", i))
+	podIP := e.kubectlOperatorNS("get", "pods", "-l", "name=spod", "-o",
+		fmt.Sprintf("jsonpath={.items[?(@.metadata.name=='%s')].status.podIP}", podName))
+	podPort := e.kubectlOperatorNS("get", "pods", "-l", "name=spod", "-o",
+		fmt.Sprintf("jsonpath={.items[?(@.metadata.name=='%s')]"+
+			".spec.containers[?(@.name=='security-profiles-operator')]"+
+			".env[?(@.name=='SPO_PROFILING_PORT')].value}", podName))
+	return "http://" + podIP + ":" + podPort + "/debug/pprof/heap"
+}
+
+// This function is inspired by e2e.runAndRetryPodCMD().
+func (e *e2e) getProfilingHTTPVersion() string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano())) // #nosec
+	letters := []rune("abcdefghijklmnopqrstuvwxyz")
+	b := make([]rune, 10)
+	for i := range b {
+		b[i] = letters[r.Intn(len(letters))]
+	}
+
+	nPodsOutput := e.kubectlOperatorNS("get", "daemonsets", "spod", "-o",
+		"jsonpath={.status.numberAvailable}")
+	nPods, err := strconv.Atoi(nPodsOutput)
+	if err != nil {
+		e.Failf("could not get size of spod daemonset", "error: %s", err)
+	}
+	index := 0
+
+	// Sometimes the endpoint does not output anything in CI. We fix
+	// that by retrying the endpoint several times.
+	var output string
+	if err := spoutil.Retry(func() error {
+		profilingEndpoint := e.getProfilingEndpoint(index)
+		profilingCurlCMD := curlHTTPVerCMD + profilingEndpoint
+		output = e.kubectlRunOperatorNS("pod-"+string(b), "--", "bash", "-c", profilingCurlCMD)
+		if len(strings.Split(output, "\n")) > 1 {
+			return nil
+		}
+		output = ""
+		return fmt.Errorf("no output from profiling curl command")
+	}, func(err error) bool {
+		e.logf("retry on error: %s", err)
+		if index < nPods {
+			index++
+			return true
+		}
+		return false
+	}); err != nil {
+		e.Failf("unable to get profiling endpoint http version", "error: %s", err)
+	}
+	return output
 }

--- a/test/tc_webhook_config_test.go
+++ b/test/tc_webhook_config_test.go
@@ -97,3 +97,19 @@ func (e *e2e) getWebhookAttribute(hook, attr string) string {
 		"spo-mutating-webhook-configuration",
 		"--output", "jsonpath="+jsonPath)
 }
+
+func (e *e2e) testCaseWebhookHTTP([]string) {
+	if !e.testWebhookHTTP {
+		e.T().Skip("Skipping webhook HTTP version related tests")
+	}
+	e.logf("Test webhook HTTP version")
+
+	endpoints := []string{
+		curlHTTPVerCMD + webhooksURL + "mutate-v1-pod-binding",
+		curlHTTPVerCMD + webhooksURL + "mutate-v1-pod-recording",
+	}
+	for _, endpoint := range endpoints {
+		output := e.runAndRetryPodCMD(endpoint)
+		e.Contains(output, "1.1")
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
This mitigates an HTTP/2 Stream Cancellation Attack that can lead to a denial-of-service.

#### Which issue(s) this PR fixes:

[CVE-2023-44487](https://github.com/advisories/GHSA-qppj-fm5r-hxr3)

#### Does this PR have test?

Yes, added test cases for Metrics, Webhooks and profiling endpoints checking that they are serving HTTP/1.1

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

None

```release-note
NONE
```
