### PR TITLE
OCPBUGS-22182:Fix nodestatus missing issue

### DIFF
--- a/internal/pkg/nodestatus/nodestatus.go
+++ b/internal/pkg/nodestatus/nodestatus.go
@@ -192,7 +192,7 @@ func (nsf *StatusClient) Exists(ctx context.Context) (bool, error) {
 	f := nsf.finalizerExists()
 	s, err := nsf.nodeStatusExists(ctx)
 
-	return s || f, err
+	return s && f, err
 }
 
 func (nsf *StatusClient) finalizerExists() bool {


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This fixes missing nodestatus issues when we have a crashed pod, we always check both finalizerExists and nodeStatusExists.

#### Which issue(s) this PR fixes:

Fixes #OCPBUGS-22182

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE


```release-note
Fixes missing nodestatus issues on some nodes when we have a crashed pod.
```
