### PR TITLE
Use latest golang in Vagrant based tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
         run: make vagrant-up-fedora
       - name: Show environment information
         run: |
-          $RUN kubectl wait --for=condition=ready --timeout=60s node fedora
+          $RUN kubectl wait --for=condition=ready --timeout=60s nodes --all
           $RUN kubectl get nodes -o wide
       - name: Set up git config
         run: |
@@ -102,7 +102,7 @@ jobs:
         run: make vagrant-up-ubuntu
       - name: Show environment information
         run: |
-          $RUN kubectl wait --for=condition=ready --timeout=60s node ubuntu2204
+          $RUN kubectl wait --for=condition=ready --timeout=60s nodes --all
           $RUN kubectl get nodes -o wide
       - name: Set up git config
         run: |
@@ -167,7 +167,7 @@ jobs:
         run: make vagrant-up-ubuntu
       - name: Show environment information
         run: |
-          $RUN kubectl wait --for=condition=ready --timeout=60s node ubuntu2204
+          $RUN kubectl wait --for=condition=ready --timeout=60s nodes --all
           $RUN kubectl get nodes -o wide
       - name: Set up git config
         run: |

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -10,12 +10,6 @@ dependencies:
       match: GO_VERSION
     - path: .github/workflows/olm_tests.yaml
       match: GO_VERSION
-    - path: hack/ci/Vagrantfile-fedora
-      match: GO_VERSION
-    - path: hack/ci/Vagrantfile-ubuntu
-      match: GO_VERSION
-    - path: hack/ci/Vagrantfile-flatcar
-      match: GO_VERSION
     - path: Makefile
       match: CI_IMAGE
 
@@ -100,8 +94,6 @@ dependencies:
     refPaths:
     - path: hack/ci/Vagrantfile-ubuntu
       match: config.vm.box
-    - path: .github/workflows/test.yml
-      match: node
 
   - name: debian-base-digest
     version: sha256:b9335fa66cdb5c1562c4f952e2d99f904dbe1618a6ed0d52487e70cf6cc280fd

--- a/hack/ci/Vagrantfile-fedora
+++ b/hack/ci/Vagrantfile-fedora
@@ -24,8 +24,9 @@ Vagrant.configure("2") do |config|
       # Use a non-localhost DNS to avoid cluster DNS lookup loops
       echo "nameserver 8.8.8.8" > /etc/resolv.conf
 
-      GO_VERSION=1.21
-      curl -sSfL -o- https://go.dev/dl/go$GO_VERSION.0.linux-amd64.tar.gz |
+      # Install Go
+      GO_VERSION=$(curl -sSfL "https://go.dev/VERSION?m=text" | head -n1)
+      curl -sSfL -o- https://go.dev/dl/$GO_VERSION.linux-amd64.tar.gz |
         tar xfz - -C /usr/local
 
       echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile

--- a/hack/ci/Vagrantfile-flatcar
+++ b/hack/ci/Vagrantfile-flatcar
@@ -61,9 +61,10 @@ Vagrant.configure("2") do |config|
       crictl --runtime-endpoint="unix:///run/containerd/containerd.sock" images
 
       # Install Go
-      GO_VERSION=1.21
       mkdir /opt/go
-      curl -sSfL -o- https://go.dev/dl/go$GO_VERSION.0.linux-amd64.tar.gz | tar xfz - -C /opt
+      GO_VERSION=$(curl -sSfL "https://go.dev/VERSION?m=text" | head -n1)
+      curl -sSfL -o- https://go.dev/dl/$GO_VERSION.linux-amd64.tar.gz |
+        tar xfz - -C /opt
 
       # Configure the kernel modules
       cat <<EOF | tee /etc/modules-load.d/k8s.conf

--- a/hack/ci/Vagrantfile-ubuntu
+++ b/hack/ci/Vagrantfile-ubuntu
@@ -25,8 +25,9 @@ Vagrant.configure("2") do |config|
       # Use a non-localhost DNS to avoid cluster DNS lookup loops
       echo "nameserver 8.8.8.8" > /etc/resolv.conf
 
-      GO_VERSION=1.21
-      curl -sSfL -o- https://go.dev/dl/go$GO_VERSION.0.linux-amd64.tar.gz |
+      # Install Go
+      GO_VERSION=$(curl -sSfL "https://go.dev/VERSION?m=text" | head -n1)
+      curl -sSfL -o- https://go.dev/dl/$GO_VERSION.linux-amd64.tar.gz |
         tar xfz - -C /usr/local
 
       # Kubernetes

--- a/hack/ci/install-kubernetes.sh
+++ b/hack/ci/install-kubernetes.sh
@@ -17,11 +17,10 @@ set -euox pipefail
 
 # Setup cluster
 IP=$(ip route get 1.2.3.4 | cut -d ' ' -f7 | tr -d '[:space:]')
-NODENAME=$(hostname -s)
 swapoff -a
 modprobe br_netfilter
 sysctl -w net.ipv4.ip_forward=1
-kubeadm init --apiserver-cert-extra-sans="$IP" --node-name "$NODENAME"
+kubeadm init --apiserver-cert-extra-sans="$IP"
 
 # Setup kubectl
 USER=vagrant


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Using the latest golang instead of the `.0` release.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
