### PR TITLE
Update golang 1.20 for openshift builds

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -12,13 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# go-toolset uses RH's Go fork which uses OpenSSL for FIPS-certified crypto
-# if this is not desirable, pass -tags no_openssl to SPO build
-# see https://access.redhat.com/documentation/en-us/red_hat_developer_tools/2018.4/html/using_go_toolset/chap-changes
-# for more details
+# hash below relates to tag: rhel-8-release-golang-1.20-openshift-4.14
+FROM registry.ci.openshift.org/openshift/release@sha256:50bd59f41a7bddb8469f45168ffbcda504834329aaf1a466d10cfb3d1a49f29f as build
 
-# hash below referred to latest
-FROM registry.access.redhat.com/ubi8/go-toolset@sha256:6c2c40207abfef2e46426f39c7fe0aca177b9da73d2b223bc0ddc7c5c56485c4 as build
 USER root
 WORKDIR /work
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -113,11 +113,11 @@ dependencies:
     - path: Dockerfile.ubi
       match: registry.access.redhat.com/ubi8/ubi-minimal
 
-  - name: ubi8-go-toolset
-    version: sha256:6c2c40207abfef2e46426f39c7fe0aca177b9da73d2b223bc0ddc7c5c56485c4
+  - name: openshift-release-golang
+    version: sha256:50bd59f41a7bddb8469f45168ffbcda504834329aaf1a466d10cfb3d1a49f29f
     refPaths:
     - path: Dockerfile.ubi
-      match: registry.access.redhat.com/ubi8/go-toolset
+      match: registry.ci.openshift.org/openshift/release
 
   - name: nix
     version: 2.15.1


### PR DESCRIPTION

#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:

- Update golang version for openshift to 1.20.
- At the moment there is no go-toolset image available for go1.20, so let's use an image from `registry.ci.openshift.org`.

#### Which issue(s) this PR fixes:

Using go1.20 helps mitigate the HTTP/2 rapid reset vulnerability.

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

NONE

```release-note
NONE
```
