### PR TITLE
Avoid listing pods in the recording webhook handler which leads sometimes to a webhook timeout issue

### DIFF
--- a/internal/pkg/webhooks/recording/recording.go
+++ b/internal/pkg/webhooks/recording/recording.go
@@ -353,7 +353,6 @@ func (p *podSeccompRecorder) setFinalizers(
 	selector labels.Selector,
 	podLabels labels.Set,
 ) error {
-
 	if op == admissionv1.Delete {
 		if controllerutil.ContainsFinalizer(profileRecording, finalizer) {
 			controllerutil.RemoveFinalizer(profileRecording, finalizer)
@@ -367,38 +366,6 @@ func (p *podSeccompRecorder) setFinalizers(
 	}
 
 	return p.impl.UpdateResource(ctx, p.log, profileRecording, "profilerecording")
-}
-
-func anyPodMatch(
-	op admissionv1.Operation,
-	selector labels.Selector,
-	podLabels labels.Set,
-	podName string,
-	foundPods *corev1.PodList,
-) bool {
-	if len(foundPods.Items) > 0 {
-		if op != admissionv1.Delete {
-			return true
-		}
-
-		for i := range foundPods.Items {
-			pod := foundPods.Items[i]
-
-			if podName == pod.Name {
-				continue
-			}
-
-			// if we ever get here, then we are deleting but we encountered
-			// a pod different than the one we're deleting, so there are still pods
-			return true
-		}
-	}
-
-	if op != admissionv1.Delete && selector.Matches(podLabels) {
-		return true
-	}
-
-	return false
 }
 
 func (p *podSeccompRecorder) warnEventIfContainerPrivileged(

--- a/internal/pkg/webhooks/recording/recording.go
+++ b/internal/pkg/webhooks/recording/recording.go
@@ -335,10 +335,8 @@ func (p *podSeccompRecorder) setActiveWorkloads(
 	newActiveWorkloads := profileRecording.Status.ActiveWorkloads
 	if op == admissionv1.Delete {
 		newActiveWorkloads = utils.RemoveIfExists(newActiveWorkloads, podName)
-	} else {
-		if selector.Matches(podLabels) {
-			newActiveWorkloads = utils.AppendIfNotExists(newActiveWorkloads, podName)
-		}
+	} else if selector.Matches(podLabels) {
+		newActiveWorkloads = utils.AppendIfNotExists(newActiveWorkloads, podName)
 	}
 
 	profileRecording.Status.ActiveWorkloads = newActiveWorkloads
@@ -357,11 +355,9 @@ func (p *podSeccompRecorder) setFinalizers(
 		if controllerutil.ContainsFinalizer(profileRecording, finalizer) {
 			controllerutil.RemoveFinalizer(profileRecording, finalizer)
 		}
-	} else {
-		if selector.Matches(podLabels) {
-			if !controllerutil.ContainsFinalizer(profileRecording, finalizer) {
-				controllerutil.AddFinalizer(profileRecording, finalizer)
-			}
+	} else if selector.Matches(podLabels) {
+		if !controllerutil.ContainsFinalizer(profileRecording, finalizer) {
+			controllerutil.AddFinalizer(profileRecording, finalizer)
 		}
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design


Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Avoid listing pods in the recording webhook handler, because this operation is sometimes really slow leading to a webhook timeout problem.

It seems that listing pods in a cluster with many pods is quite slow, even though the number of pods in the namespace from where they are listed is low. 

This looks like a performance problem in the Kubernetes API server. A list pods API call can take sometime over 30 seconds which is the maximum timeout for a webhook handler in Kubernetes.

The recording webhook doesn't need to list all pods being recorded anyhow in order to maintain the status in the ProfileRecording CR. Every time a Pod is being created/updated or deleted, the webhook handler is called with the Pod object, so it can update the status accordingly.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
N/A

#### Special notes for your reviewer:p

None

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE

```
