### PR TITLE
Disable e2e tests for now

### DIFF
--- a/.github/workflows/helm-chart-lint.yaml
+++ b/.github/workflows/helm-chart-lint.yaml
@@ -27,7 +27,7 @@ jobs:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@e8788873172cb653a90ca2e819d79d65a66d4e76 # v2.4.0
+        uses: helm/chart-testing-action@b43128a8b25298e1e7b043b78ea6613844e079b1 # v2.6.0
 
       - name: Run chart-testing (lint)
         run: >

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,8 +56,10 @@ jobs:
           path: image.tar
 
   e2e-fedora:
+    # TODO(saschagrunert): re-enable when
+    # https://github.com/actions/runner-images/issues/8730 is resolved
+    if: false
     needs: image
-
     runs-on: macos-12
     timeout-minutes: 90
     env:
@@ -86,8 +88,10 @@ jobs:
           $RUN hack/ci/e2e-fedora.sh
 
   e2e-ubuntu:
+    # TODO(saschagrunert): re-enable when
+    # https://github.com/actions/runner-images/issues/8730 is resolved
+    if: false
     needs: image
-
     runs-on: macos-12
     timeout-minutes: 90
     env:
@@ -116,42 +120,47 @@ jobs:
           $RUN hack/ci/e2e-ubuntu.sh
 
   e2e-flatcar:
-   needs: image
-
-   runs-on: macos-12
-   timeout-minutes: 90
-   env:
-     RUN: ./hack/ci/run-flatcar.sh
-   steps:
-      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v3.5.2
-      - name: Vagrant box version
-        id: vagrant-box
-        run: |
-          echo "version=$(curl -s  https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vagrant.json | jq '.versions[0].version' | tr -d '".')" >> $GITHUB_OUTPUT
-        shell: bash
-      - name: Upgrade vagrant box
-        run: |
-          ln -sf hack/ci/Vagrantfile-flatcar Vagrantfile
-          vagrant box update
-      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
-        with:
-          name: image
-          path: .
-      - name: Boot Virtual Machine
-        run: make vagrant-up-flatcar
-      - name: Show environment information
-        run: |
-          $RUN kubectl wait --for=condition=ready --timeout=600s node localhost
-          $RUN kubectl get nodes -o wide
-      - name: Run E2E tests
-        run: $RUN hack/ci/e2e-flatcar-dev-container.sh
-      - name: Run Flaky E2E tests
-        continue-on-error: true
-        run: |
-          $RUN "echo \"export E2E_TEST_FLAKY_TESTS_ONLY=true\" >> /vagrant/hack/ci/env-flatcar.sh"
-          $RUN hack/ci/e2e-flatcar-dev-container.sh
+    # TODO(saschagrunert): re-enable when
+    # https://github.com/actions/runner-images/issues/8730 is resolved
+    if: false
+    needs: image
+    runs-on: macos-12
+    timeout-minutes: 90
+    env:
+      RUN: ./hack/ci/run-flatcar.sh
+    steps:
+       - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v3.5.2
+       - name: Vagrant box version
+         id: vagrant-box
+         run: |
+           echo "version=$(curl -s  https://stable.release.flatcar-linux.net/amd64-usr/current/flatcar_production_vagrant.json | jq '.versions[0].version' | tr -d '".')" >> $GITHUB_OUTPUT
+         shell: bash
+       - name: Upgrade vagrant box
+         run: |
+           ln -sf hack/ci/Vagrantfile-flatcar Vagrantfile
+           vagrant box update
+       - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a
+         with:
+           name: image
+           path: .
+       - name: Boot Virtual Machine
+         run: make vagrant-up-flatcar
+       - name: Show environment information
+         run: |
+           $RUN kubectl wait --for=condition=ready --timeout=600s node localhost
+           $RUN kubectl get nodes -o wide
+       - name: Run E2E tests
+         run: $RUN hack/ci/e2e-flatcar-dev-container.sh
+       - name: Run Flaky E2E tests
+         continue-on-error: true
+         run: |
+           $RUN "echo \"export E2E_TEST_FLAKY_TESTS_ONLY=true\" >> /vagrant/hack/ci/env-flatcar.sh"
+           $RUN hack/ci/e2e-flatcar-dev-container.sh
 
   baseprofiles:
+    # TODO(saschagrunert): re-enable when
+    # https://github.com/actions/runner-images/issues/8730 is resolved
+    if: false
     needs: image
     runs-on: macos-12
     timeout-minutes: 90

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -76,10 +76,13 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			"Seccomp: Verify base profile merge",
 			e.testCaseBaseProfile,
 		},
-		{
-			"Seccomp: Verify base profile merge from OCI registry",
-			e.testCaseBaseProfileOCI,
-		},
+		// TODO: re-enable when we found a workaround to the flaky GitHub registry connection
+		/*
+			{
+				"Seccomp: Verify base profile merge from OCI registry",
+				e.testCaseBaseProfileOCI,
+			},
+		*/
 		{
 			"Seccomp: Allowed syscalls",
 			e.testCaseAllowedSyscalls,

--- a/test/tc_base_profiles_oci_test.go
+++ b/test/tc_base_profiles_oci_test.go
@@ -23,6 +23,7 @@ import (
 	"time"
 )
 
+//nolint:unused // test is flaky and therefore got deactivated
 func (e *e2e) testCaseBaseProfileOCI([]string) {
 	e.seccompOnlyTestCase()
 


### PR DESCRIPTION


#### What type of PR is this?


/kind failing-test

#### What this PR does / why we need it:
Disable the vagrant based e2e tests until
https://github.com/actions/runner-images/issues/8730 is resolved.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
