### PR TITLE
Move e2e manifest updates to the suite layer

### DIFF
--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -308,7 +308,6 @@ func (e *e2e) deployOperator(manifest string) {
 	e.updateManifest(manifest, "imagePullPolicy: Always", fmt.Sprintf("imagePullPolicy: %s", e.pullPolicy))
 	e.updateManifest(manifest, "image: .*gcr.io/k8s-staging-sp-operator/.*", fmt.Sprintf("image: %s", e.testImage))
 	e.updateManifest(manifest, "value: .*gcr.io/k8s-staging-sp-operator/.*", fmt.Sprintf("value: %s", e.testImage))
-	e.updateManifest(manifest, "value: .*quay.io/.*/selinuxd.*", fmt.Sprintf("value: %s", e.selinuxdImage))
 	if e.selinuxEnabled {
 		e.updateManifest(manifest, "enableSelinux: false", "enableSelinux: true")
 	}

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -327,6 +327,7 @@ func (e *kinde2e) SetupSuite() {
 
 	var err error
 	e.kubectlPath, err = exec.LookPath("kubectl")
+	e.updateManifest(e.operatorManifest, "value: .*quay.io/.*/selinuxd.*", fmt.Sprintf("value: %s", e.selinuxdImage))
 	e.Nil(err)
 }
 
@@ -517,6 +518,7 @@ func (e *vanilla) SetupSuite() {
 	e.e2e.waitForReadyPods = e.waitForReadyPodsVanilla
 	e.e2e.deployCertManager = e.deployCertManagerVanilla
 	e.e2e.setupRecordingSa = e.deployRecordingSa
+	e.updateManifest(e.operatorManifest, "value: .*quay.io/.*/selinuxd.*", fmt.Sprintf("value: %s", e.selinuxdImage))
 	e.Nil(err)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Currently, e2e tests on an OpenShift cluster will hang because the
selinuxd container gets stuck in a crash loop. This is because the
manifest is updated to point to an container image that doesn't work for
OpenShift (it's not using the correct version of SELinuxd for the
version of RHCOS under OpenShift).

This commit moves the manifest updates to the suite layer, where it's
possible to detect if e2e tests are running vanilla kube, kind, or
OpenShift. If we're running on OpenShift, we just don't update selinuxd
container image locations since what is in the deploy/operator.yaml
works.

#### Which issue(s) this PR fixes:
Fixes #1976

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

-->

#### Does this PR have test?
Yes

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:


#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
