### PR TITLE
OCPBUGS-25373: Message is not a required field in the CRDs

### DIFF
--- a/bundle/manifests/security-profiles-operator.x-k8s.io_rawselinuxprofiles.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_rawselinuxprofiles.yaml
@@ -123,7 +123,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_seccompprofiles.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_seccompprofiles.yaml
@@ -264,7 +264,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_securityprofilesoperatordaemons.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_securityprofilesoperatordaemons.yaml
@@ -1383,7 +1383,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_selinuxprofiles.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_selinuxprofiles.yaml
@@ -160,7 +160,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type

--- a/deploy/base-crds/crds/seccompprofile.yaml
+++ b/deploy/base-crds/crds/seccompprofile.yaml
@@ -261,7 +261,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type

--- a/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
@@ -1380,7 +1380,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type

--- a/deploy/base-crds/crds/selinuxpolicy.yaml
+++ b/deploy/base-crds/crds/selinuxpolicy.yaml
@@ -120,7 +120,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -302,7 +301,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -483,7 +483,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -1956,7 +1955,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -2097,7 +2095,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -2281,7 +2278,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -483,7 +483,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -1956,7 +1955,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -2097,7 +2095,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -2281,7 +2278,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -413,7 +413,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -701,7 +700,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -2174,7 +2172,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -2352,7 +2349,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -483,7 +483,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -1956,7 +1955,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -2097,7 +2095,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -2281,7 +2278,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -483,7 +483,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -1956,7 +1955,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -2097,7 +2095,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -2281,7 +2278,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -413,7 +413,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -701,7 +700,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -2174,7 +2172,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type
@@ -2352,7 +2349,6 @@ spec:
                       type: string
                   required:
                   - lastTransitionTime
-                  - message
                   - reason
                   - status
                   - type


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:
 
- Removes `message` from the required list of CRD fields
  - This fixes errors when upgrading SPO from v0.8.0 to v0.8.1.
  - Related: https://github.com/k8s-operatorhub/community-operators/pull/3580

#### Which issue(s) this PR fixes:
None

#### Does this PR have test?
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Remove "message" from the required list of CRD fields to fix issues when upgrading SPO to v0.8.1
```
