### PR TITLE
Make field disabling profiles after recording optional

### DIFF
--- a/api/profilebase/v1alpha1/profilebase.go
+++ b/api/profilebase/v1alpha1/profilebase.go
@@ -106,6 +106,7 @@ type StatusBaseUser interface {
 // SpecBase contains common attributes for a profile's spec.
 type SpecBase struct {
 	// Whether the profile is disabled and should be skipped during reconciliation.
+	// +optional
 	// +kubebuilder:default=false
-	Disabled bool `json:"disabled"`
+	Disabled bool `json:"disabled,omitempty"`
 }

--- a/api/profilerecording/v1alpha1/profilerecording_types.go
+++ b/api/profilerecording/v1alpha1/profilerecording_types.go
@@ -89,8 +89,9 @@ type ProfileRecordingSpec struct {
 	// after recording and thus skipped during reconcile. In case of SELinux profiles,
 	// reconcile can take a significant amount of time and for all profiles might not be needed.
 	// This Defaults to false.
+	// +optional
 	// +kubebuilder:default=false
-	DisableProfileAfterRecording bool `json:"disableProfileAfterRecording"`
+	DisableProfileAfterRecording bool `json:"disableProfileAfterRecording,omitempty"`
 }
 
 // ProfileRecordingStatus contains status of the ProfileRecording.

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_profilerecordings.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_profilerecordings.yaml
@@ -124,7 +124,6 @@ spec:
                 - logs
                 type: string
             required:
-            - disableProfileAfterRecording
             - kind
             - podSelector
             - recorder

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_rawselinuxprofiles.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_rawselinuxprofiles.yaml
@@ -50,8 +50,6 @@ spec:
                 type: boolean
               policy:
                 type: string
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_seccompprofiles.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_seccompprofiles.yaml
@@ -192,7 +192,6 @@ spec:
                 type: array
             required:
             - defaultAction
-            - disabled
             type: object
           status:
             description: SeccompProfileStatus contains status of the deployed SeccompProfile.

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_selinuxprofiles.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_selinuxprofiles.yaml
@@ -87,8 +87,6 @@ spec:
                 description: Permissive, when true will cause the SELinux profile
                   to only log violations instead of enforcing them.
                 type: boolean
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.

--- a/deploy/base-crds/crds/profilerecording.yaml
+++ b/deploy/base-crds/crds/profilerecording.yaml
@@ -121,7 +121,6 @@ spec:
                 - logs
                 type: string
             required:
-            - disableProfileAfterRecording
             - kind
             - podSelector
             - recorder

--- a/deploy/base-crds/crds/seccompprofile.yaml
+++ b/deploy/base-crds/crds/seccompprofile.yaml
@@ -189,7 +189,6 @@ spec:
                 type: array
             required:
             - defaultAction
-            - disabled
             type: object
           status:
             description: SeccompProfileStatus contains status of the deployed SeccompProfile.

--- a/deploy/base-crds/crds/selinuxpolicy.yaml
+++ b/deploy/base-crds/crds/selinuxpolicy.yaml
@@ -47,8 +47,6 @@ spec:
                 type: boolean
               policy:
                 type: string
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.
@@ -193,8 +191,6 @@ spec:
                 description: Permissive, when true will cause the SELinux profile
                   to only log violations instead of enforcing them.
                 type: boolean
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -199,7 +199,6 @@ spec:
                 - logs
                 type: string
             required:
-            - disableProfileAfterRecording
             - kind
             - podSelector
             - recorder
@@ -411,7 +410,6 @@ spec:
                 type: array
             required:
             - defaultAction
-            - disabled
             type: object
           status:
             description: SeccompProfileStatus contains status of the deployed SeccompProfile.
@@ -1952,8 +1950,6 @@ spec:
                 type: boolean
               policy:
                 type: string
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.
@@ -2100,8 +2096,6 @@ spec:
                 description: Permissive, when true will cause the SELinux profile
                   to only log violations instead of enforcing them.
                 type: boolean
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -199,7 +199,6 @@ spec:
                 - logs
                 type: string
             required:
-            - disableProfileAfterRecording
             - kind
             - podSelector
             - recorder
@@ -411,7 +410,6 @@ spec:
                 type: array
             required:
             - defaultAction
-            - disabled
             type: object
           status:
             description: SeccompProfileStatus contains status of the deployed SeccompProfile.
@@ -1952,8 +1950,6 @@ spec:
                 type: boolean
               policy:
                 type: string
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.
@@ -2100,8 +2096,6 @@ spec:
                 description: Permissive, when true will cause the SELinux profile
                   to only log violations instead of enforcing them.
                 type: boolean
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -270,7 +270,6 @@ spec:
                 - logs
                 type: string
             required:
-            - disableProfileAfterRecording
             - kind
             - podSelector
             - recorder
@@ -340,8 +339,6 @@ spec:
                 type: boolean
               policy:
                 type: string
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.
@@ -593,7 +590,6 @@ spec:
                 type: array
             required:
             - defaultAction
-            - disabled
             type: object
           status:
             description: SeccompProfileStatus contains status of the deployed SeccompProfile.
@@ -2171,8 +2167,6 @@ spec:
                 description: Permissive, when true will cause the SELinux profile
                   to only log violations instead of enforcing them.
                 type: boolean
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -199,7 +199,6 @@ spec:
                 - logs
                 type: string
             required:
-            - disableProfileAfterRecording
             - kind
             - podSelector
             - recorder
@@ -411,7 +410,6 @@ spec:
                 type: array
             required:
             - defaultAction
-            - disabled
             type: object
           status:
             description: SeccompProfileStatus contains status of the deployed SeccompProfile.
@@ -1952,8 +1950,6 @@ spec:
                 type: boolean
               policy:
                 type: string
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.
@@ -2100,8 +2096,6 @@ spec:
                 description: Permissive, when true will cause the SELinux profile
                   to only log violations instead of enforcing them.
                 type: boolean
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -199,7 +199,6 @@ spec:
                 - logs
                 type: string
             required:
-            - disableProfileAfterRecording
             - kind
             - podSelector
             - recorder
@@ -411,7 +410,6 @@ spec:
                 type: array
             required:
             - defaultAction
-            - disabled
             type: object
           status:
             description: SeccompProfileStatus contains status of the deployed SeccompProfile.
@@ -1952,8 +1950,6 @@ spec:
                 type: boolean
               policy:
                 type: string
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.
@@ -2100,8 +2096,6 @@ spec:
                 description: Permissive, when true will cause the SELinux profile
                   to only log violations instead of enforcing them.
                 type: boolean
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -270,7 +270,6 @@ spec:
                 - logs
                 type: string
             required:
-            - disableProfileAfterRecording
             - kind
             - podSelector
             - recorder
@@ -340,8 +339,6 @@ spec:
                 type: boolean
               policy:
                 type: string
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.
@@ -593,7 +590,6 @@ spec:
                 type: array
             required:
             - defaultAction
-            - disabled
             type: object
           status:
             description: SeccompProfileStatus contains status of the deployed SeccompProfile.
@@ -2171,8 +2167,6 @@ spec:
                 description: Permissive, when true will cause the SELinux profile
                   to only log violations instead of enforcing them.
                 type: boolean
-            required:
-            - disabled
             type: object
           status:
             description: SelinuxProfileStatus defines the observed state of SelinuxProfile.


### PR DESCRIPTION


#### What type of PR is this?

/kind bug
/kind regression

#### What this PR does / why we need it:

- Make `ProfileRecordingSpec.DisableProfileAfterRecording` and `SpecBase.Disabled` optional.
  - This addresses CRD validation errors when upgrading to v0.8.1
  - See also: https://github.com/kubernetes-sigs/security-profiles-operator/pull/1712

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

- I don't know exactly the impacts of making these fields optional.

```release-note
Make the field disabling profiles after recording optional
```
