### PR TITLE
Install CRI-O and Podman side by side in Fedora tests

### DIFF
--- a/hack/ci/Vagrantfile-fedora
+++ b/hack/ci/Vagrantfile-fedora
@@ -53,6 +53,7 @@ gpgkey=https://pkgs.k8s.io/addons:/cri-o:/prerelease:/main/rpm/repodata/repomd.x
 EOF
 
       dnf install -y \
+        cri-o \
         conntrack \
         container-selinux \
         gcc \
@@ -71,9 +72,6 @@ EOF
       podman load -i /vagrant/image.tar
 
       # Setup CRI-O
-      dnf download --repo cri-o --arch x86_64 cri-o
-      rpm -i --nodeps --force cri-o-*.rpm
-
       printf '[crio.runtime]\nselinux = true' >/etc/crio/crio.conf.d/30-selinux.conf
       systemctl enable --now crio
 


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Recent package changes allow installing Podman and CRI-O together, so we no longer have to force install the RPM.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
