### PR TITLE
Don't download runc manually

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -172,8 +172,6 @@ dependencies:
       match: baseProfileNameRunc
     - path: installation-usage.md
       match: baseProfileName
-    - path: hack/ci/Vagrantfile-ubuntu
-      match: RUNC_VERSION
 
   - name: cosign
     version: v2.2.1

--- a/hack/ci/Vagrantfile-ubuntu
+++ b/hack/ci/Vagrantfile-ubuntu
@@ -55,12 +55,6 @@ Vagrant.configure("2") do |config|
       apt-get remove --purge -y podman
       apt-get autoremove -y
 
-      # Some tests require runc
-      RUNC_VERSION=v1.1.12
-      RUNC_BINARY=/usr/bin/crio-runc
-      curl -sSfL --retry 5 --retry-delay 3 "https://github.com/opencontainers/runc/releases/download/$RUNC_VERSION/runc.amd64" -o "$RUNC_BINARY"
-      chmod +x "$RUNC_BINARY"
-
       # Baseprofile recording requires cosign
       COSIGN_VERSION=v2.2.1
       COSIGN_BINARY=/usr/bin/cosign


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Runc now ships as part of the package, so there is no need to download it manually any more.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
