### PR TITLE
Update security-profiles-operator-profile_v1_configmap.yaml with clock_gettime syscall

### DIFF
--- a/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
+++ b/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
@@ -20,6 +20,7 @@ data:
             "capget",
             "capset",
             "chdir",
+            "clock_gettime",
             "clone",
             "clone3",
             "close",

--- a/deploy/base/profiles/security-profiles-operator.json
+++ b/deploy/base/profiles/security-profiles-operator.json
@@ -17,6 +17,7 @@
         "capget",
         "capset",
         "chdir",
+        "clock_gettime",
         "clone",
         "clone3",
         "close",

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -890,6 +890,7 @@ data:
             "capget",
             "capset",
             "chdir",
+            "clock_gettime",
             "clone",
             "clone3",
             "close",

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -3005,6 +3005,7 @@ data:
             "capget",
             "capset",
             "chdir",
+            "clock_gettime",
             "clone",
             "clone3",
             "close",

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -2987,6 +2987,7 @@ data:
             "capget",
             "capset",
             "chdir",
+            "clock_gettime",
             "clone",
             "clone3",
             "close",

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -3018,6 +3018,7 @@ data:
             "capget",
             "capset",
             "chdir",
+            "clock_gettime",
             "clone",
             "clone3",
             "close",

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3005,6 +3005,7 @@ data:
             "capget",
             "capset",
             "chdir",
+            "clock_gettime",
             "clone",
             "clone3",
             "close",

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -2976,6 +2976,7 @@ data:
             "capget",
             "capset",
             "chdir",
+            "clock_gettime",
             "clone",
             "clone3",
             "close",


### PR DESCRIPTION
Add clock_gettime to address issue referenced here:  https://github.com/kubernetes-sigs/security-profiles-operator/issues/891

Issue caused one spod pod to be in CBLO. 
Debugged by manually setting the default_action to SCMP_ACT_LOG and then checking the node logs.
Seccomp was being violated with the `clock_gettime` call. Adding that call here to fix that issue.

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes # https://github.com/kubernetes-sigs/security-profiles-operator/issues/891

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed issue with crashing SPOD daemon by allowing `clock_gettime` syscall.
```
