### PR TITLE
Add Initial Support for AppArmor Profile Merging

### DIFF
--- a/internal/pkg/cli/merger/merger.go
+++ b/internal/pkg/cli/merger/merger.go
@@ -25,6 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/yaml"
 
+	apparmorprofileapi "sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1alpha1"
 	seccompprofileapi "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"
 	selinuxprofileapi "sigs.k8s.io/security-profiles-operator/api/selinuxprofile/v1alpha2"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/manager/recordingmerger"
@@ -80,6 +81,12 @@ func (p *Merger) Run() error {
 			var profile selinuxprofileapi.SelinuxProfile
 			if err := yaml.Unmarshal(content, &profile); err != nil {
 				return fmt.Errorf("unmarshal to selinux profile: %w", err)
+			}
+			contents[i] = &profile
+		case "AppArmorProfile":
+			var profile apparmorprofileapi.AppArmorProfile
+			if err := yaml.Unmarshal(content, &profile); err != nil {
+				return fmt.Errorf("unmarshal to apparmor profile: %w", err)
 			}
 			contents[i] = &profile
 		default:

--- a/internal/pkg/manager/recordingmerger/merge_utils.go
+++ b/internal/pkg/manager/recordingmerger/merge_utils.go
@@ -19,7 +19,6 @@ package recordingmerger
 import (
 	"context"
 	"fmt"
-	"slices"
 	"sort"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -386,6 +385,24 @@ func mergeDedupSortStrings(a, b *[]string) *[]string {
 	}
 	merged := append(*a, *b...)
 	sort.Strings(merged)
-	merged = slices.Compact(merged)
+	merged = compact(merged)
 	return &merged
+}
+
+// TODO: replace this with slices.Compact once all platform support Go 1.21.
+func compact(s []string) []string {
+	//nolint:all
+	if len(s) < 2 {
+		return s
+	}
+	i := 1
+	for k := 1; k < len(s); k++ {
+		if s[k] != s[k-1] {
+			if i != k {
+				s[i] = s[k]
+			}
+			i++
+		}
+	}
+	return s[:i]
 }

--- a/internal/pkg/manager/recordingmerger/merge_utils.go
+++ b/internal/pkg/manager/recordingmerger/merge_utils.go
@@ -406,3 +406,11 @@ func compact(s []string) []string {
 	}
 	return s[:i]
 }
+
+// TODO: remove once all platform support Go 1.21.
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/pkg/manager/recordingmerger/merge_utils_test.go
+++ b/internal/pkg/manager/recordingmerger/merge_utils_test.go
@@ -23,13 +23,15 @@ import (
 	"github.com/containers/common/pkg/seccomp"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	apparmorprofileapi "sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1alpha1"
 	seccompprofile "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"
 	selinuxprofileapi "sigs.k8s.io/security-profiles-operator/api/selinuxprofile/v1alpha2"
 )
 
-func ifaceAsSortedSeccompProfile(iface mergeableProfile) *seccompprofile.SeccompProfile {
-	prof, ok := iface.getProfile().(*seccompprofile.SeccompProfile)
+func ifaceAsSortedSeccompProfile(iface client.Object) *seccompprofile.SeccompProfile {
+	prof, ok := iface.(*seccompprofile.SeccompProfile)
 	if !ok {
 		return nil
 	}
@@ -42,8 +44,8 @@ func ifaceAsSortedSeccompProfile(iface mergeableProfile) *seccompprofile.Seccomp
 	return prof
 }
 
-func ifaceAsSortedSelinuxProfile(iface mergeableProfile) *selinuxprofileapi.SelinuxProfile {
-	prof, ok := iface.getProfile().(*selinuxprofileapi.SelinuxProfile)
+func ifaceAsSortedSelinuxProfile(iface client.Object) *selinuxprofileapi.SelinuxProfile {
+	prof, ok := iface.(*selinuxprofileapi.SelinuxProfile)
 	if !ok {
 		return nil
 	}
@@ -61,16 +63,16 @@ func TestMergeProfiles(t *testing.T) {
 
 	for _, tc := range []struct {
 		name    string
-		prepare func(*testing.T) []mergeableProfile
-		assert  func(profile mergeableProfile) error
+		prepare func(*testing.T) []client.Object
+		assert  func(profile client.Object) error
 	}{
 		{
 			name: "Two seccomp profiles",
-			prepare: func(t *testing.T) []mergeableProfile {
+			prepare: func(t *testing.T) []client.Object {
 				t.Helper()
 
-				parts := []seccompprofile.SeccompProfile{
-					{
+				return []client.Object{
+					&seccompprofile.SeccompProfile{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "test-abc",
 						},
@@ -85,7 +87,7 @@ func TestMergeProfiles(t *testing.T) {
 							},
 						},
 					},
-					{
+					&seccompprofile.SeccompProfile{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "test-ced",
 						},
@@ -101,16 +103,8 @@ func TestMergeProfiles(t *testing.T) {
 						},
 					},
 				}
-
-				partialSpecs := make([]mergeableProfile, len(parts))
-				for i := range parts {
-					var err error
-					partialSpecs[i], err = newMergeableProfile(&parts[i])
-					require.NoError(t, err)
-				}
-				return partialSpecs
 			},
-			assert: func(mergedProfIface mergeableProfile) error {
+			assert: func(mergedProfIface client.Object) error {
 				t.Helper()
 
 				mergedProf := ifaceAsSortedSeccompProfile(mergedProfIface)
@@ -123,11 +117,11 @@ func TestMergeProfiles(t *testing.T) {
 		},
 		{
 			name: "Two selinux profiles",
-			prepare: func(t *testing.T) []mergeableProfile {
+			prepare: func(t *testing.T) []client.Object {
 				t.Helper()
 
-				parts := []selinuxprofileapi.SelinuxProfile{
-					{
+				return []client.Object{
+					&selinuxprofileapi.SelinuxProfile{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "test-foobarbaz1",
 						},
@@ -143,7 +137,7 @@ func TestMergeProfiles(t *testing.T) {
 							},
 						},
 					},
-					{
+					&selinuxprofileapi.SelinuxProfile{
 						ObjectMeta: metav1.ObjectMeta{
 							Name: "test-foobarbaz2",
 						},
@@ -161,16 +155,8 @@ func TestMergeProfiles(t *testing.T) {
 						},
 					},
 				}
-
-				partialSpecs := make([]mergeableProfile, len(parts))
-				for i := range parts {
-					var err error
-					partialSpecs[i], err = newMergeableProfile(&parts[i])
-					require.NoError(t, err)
-				}
-				return partialSpecs
 			},
-			assert: func(profile mergeableProfile) error {
+			assert: func(profile client.Object) error {
 				t.Helper()
 
 				mergedProf := ifaceAsSortedSelinuxProfile(profile)
@@ -181,13 +167,90 @@ func TestMergeProfiles(t *testing.T) {
 				return nil
 			},
 		},
+		{
+			name: "Two apparmor profiles",
+			prepare: func(t *testing.T) []client.Object {
+				t.Helper()
+
+				return []client.Object{
+					&apparmorprofileapi.AppArmorProfile{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-foobarbaz1",
+						},
+						Spec: apparmorprofileapi.AppArmorProfileSpec{
+							Abstract: apparmorprofileapi.AppArmorAbstract{
+								Executable: &apparmorprofileapi.AppArmorExecutablesRules{
+									AllowedExecutables: &[]string{"execA", "execB"},
+									AllowedLibraries:   &[]string{"libA"},
+								},
+								Filesystem: &apparmorprofileapi.AppArmorFsRules{
+									ReadOnlyPaths:  &[]string{"read1", "merged-rw1"},
+									WriteOnlyPaths: &[]string{"write1", "merged-rw2"},
+									ReadWritePaths: &[]string{"readwrite1"},
+								},
+								Network: &apparmorprofileapi.AppArmorNetworkRules{
+									AllowRaw: func() *bool { b := true; return &b }(),
+								},
+							},
+						},
+					},
+					&apparmorprofileapi.AppArmorProfile{
+						ObjectMeta: metav1.ObjectMeta{
+							Name: "test-foobarbaz2",
+						},
+						Spec: apparmorprofileapi.AppArmorProfileSpec{
+							Abstract: apparmorprofileapi.AppArmorAbstract{
+								Executable: &apparmorprofileapi.AppArmorExecutablesRules{
+									AllowedExecutables: &[]string{"execA", "execC"},
+								},
+								Filesystem: &apparmorprofileapi.AppArmorFsRules{
+									WriteOnlyPaths: &[]string{"merged-rw1"},
+									ReadWritePaths: &[]string{"merged-rw2"},
+								},
+								Network: &apparmorprofileapi.AppArmorNetworkRules{
+									AllowRaw: func() *bool { b := false; return &b }(),
+									Protocols: &apparmorprofileapi.AppArmorAllowedProtocols{
+										AllowTCP: func() *bool { b := true; return &b }(),
+									},
+								},
+							},
+						},
+					},
+				}
+			},
+			assert: func(profile client.Object) error {
+				t.Helper()
+
+				prof, ok := profile.(*apparmorprofileapi.AppArmorProfile)
+				require.True(t, ok)
+
+				require.Equal(t, prof.Spec.Abstract, apparmorprofileapi.AppArmorAbstract{
+					Executable: &apparmorprofileapi.AppArmorExecutablesRules{
+						AllowedExecutables: &[]string{"execA", "execB", "execC"},
+						AllowedLibraries:   &[]string{"libA"},
+					},
+					Filesystem: &apparmorprofileapi.AppArmorFsRules{
+						ReadOnlyPaths:  &[]string{"read1"},
+						WriteOnlyPaths: &[]string{"write1"},
+						ReadWritePaths: &[]string{"merged-rw1", "merged-rw2", "readwrite1"},
+					},
+					Network: &apparmorprofileapi.AppArmorNetworkRules{
+						AllowRaw: func() *bool { b := true; return &b }(),
+						Protocols: &apparmorprofileapi.AppArmorAllowedProtocols{
+							AllowTCP: func() *bool { b := true; return &b }(),
+						},
+					},
+				})
+				return nil
+			},
+		},
 	} {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
 			partialProfiles := tc.prepare(t)
-			mergedProfIface, err := mergeMergeableProfiles(partialProfiles)
+			mergedProfIface, err := MergeProfiles(partialProfiles)
 			require.Nil(t, err)
 			err = tc.assert(mergedProfIface)
 			require.Nil(t, err)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds profile merging for AppArmor profiles. While the in-cluster recording parts aren't quite there yet, it already works with `spoc merge`. There are more optimizations we could do here (most importantly merging profiles with wildcard paths), but this is a start. :)

#### Which issue(s) this PR fixes:

refs (but not fixes) #718

#### Does this PR have test?

Yes.

#### Does this PR introduce a user-facing change?

```release-note
Added initial support for merging AppArmor profiles with `spoc merge`.
```
