### PR TITLE
`spoc merge`: add `--check`

### DIFF
--- a/cmd/spoc/main.go
+++ b/cmd/spoc/main.go
@@ -85,9 +85,11 @@ func main() {
 			},
 		},
 		&cli.Command{
-			Name:      "merge",
-			Aliases:   []string{"m"},
-			Usage:     "merge multiple security profiles",
+			Name:    "merge",
+			Aliases: []string{"m"},
+			Usage:   "merge multiple security profiles",
+			Description: "Merge multiple security profiles into a combined profile. " +
+				"Permissions are additive. For AppArmor, the first profile may additionally contain glob paths.",
 			Action:    merge,
 			ArgsUsage: "INFILE...",
 			Flags: []cli.Flag{
@@ -97,6 +99,12 @@ func main() {
 					Usage:       "the output file path for the combined profile",
 					DefaultText: merger.DefaultOutputFile,
 					TakesFile:   true,
+				},
+				&cli.BoolFlag{
+					Name:    merger.FlagCheck,
+					Aliases: []string{"c"},
+					Usage: "do not write an output file, " +
+						"but exit with an error if the first profile is not a superset of all others.",
 				},
 			},
 		},

--- a/internal/pkg/cli/merger/consts.go
+++ b/internal/pkg/cli/merger/consts.go
@@ -24,4 +24,6 @@ var DefaultOutputFile = cli.DefaultFile
 const (
 	// FlagOutputFile is the flag for defining the output file location.
 	FlagOutputFile string = cli.FlagOutputFile
+
+	FlagCheck string = "check"
 )

--- a/internal/pkg/cli/merger/options.go
+++ b/internal/pkg/cli/merger/options.go
@@ -26,6 +26,7 @@ import (
 type Options struct {
 	inputFiles []string
 	outputFile string
+	check      bool
 }
 
 // Default returns a default options instance.
@@ -44,6 +45,8 @@ func FromContext(ctx *ucli.Context) (*Options, error) {
 		return nil, errors.New("no profiles provided")
 	}
 	options.inputFiles = args
+
+	options.check = ctx.IsSet(FlagCheck)
 
 	if ctx.IsSet(FlagOutputFile) {
 		options.outputFile = ctx.String(FlagOutputFile)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR adds a `--check` flag to spoc merge. This can be used to ensure that (automatically generated) profiles are subsets of a (hand-authored) profile in CI. This is better than manually calling `diff` as we ignore non-essential syntax such as comments.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Not yet.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
`spoc merge` now has a `--check` flag to ensure that a profile is a superset of other profiles.
```
