### PR TITLE
Fix dead link in installation and usage docs

### DIFF
--- a/installation-usage.md
+++ b/installation-usage.md
@@ -1361,9 +1361,9 @@ securityprofilesoperatordaemon.security-profiles-operator.x-k8s.io/spod patched
 
 Alternatively, make sure the operator deployment sets the `ENABLE_LOG_ENRICHER` variable,
 to `true`, either by setting the environment variable in the deployment or by enabling
-the variable trough a `Subscription` resource, when installing the operator using OLM
-(see [Restricting the operator to specific nodes](#restricting-the-operator-to-specific-nodes)
-for an example of setting another variable).
+the variable trough a `Subscription` resource, when installing the operator using OLM.
+See [Constrain spod scheduling](#constrain-spod-scheduling) for an example of
+setting `tolerations` and `affinity` on the SPOD.
 
 Now the operator will take care of re-deploying the `spod` DaemonSet and the
 enricher should listening on new changes to the audit logs:


### PR DESCRIPTION



#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
The link does not exist, so we now link to the "Constrain spod scheduling" section.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Updated dead documentation link on how to constrain the spod to specific nodes.
```
