### PR TITLE
Docs: Fix `enableAppArmor` variable

### DIFF
--- a/installation-usage.md
+++ b/installation-usage.md
@@ -1745,10 +1745,10 @@ running with the appropriate profile.
 
 ## Create an AppArmor profile
 
-Ensure that the Daemon has AppArmor enabled:
+Ensure that the daemon has AppArmor enabled:
 
 ```
-> kubectl -n security-profiles-operator patch spod spod --type=merge -p '{"spec":{"apparmorenabled":"true"}}'
+> kubectl -n security-profiles-operator patch spod spod --type=merge -p '{"spec":{"enableAppArmor":"true"}}'
 securityprofilesoperatordaemon.security-profiles-operator.x-k8s.io/spod patched
 ```
 


### PR DESCRIPTION


#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
`apparmorenabled` does not exist, it needs to be `enableAppArmor`.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
cc @pjbgf 
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `enableAppArmor` variable in `installation-usage.md`.
```
