### PR TITLE
Make selinuxd images configurable

### DIFF
--- a/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
+++ b/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
@@ -108,6 +108,10 @@ data:
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
             "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+        },
+        {
+            "regex":"Fedora \\d+",
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
         }
     ]
   selinuxd.cil: |

--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -860,6 +860,8 @@ spec:
                   value: quay.io/security-profiles-operator/selinuxd-el8:latest
                 - name: RELATED_IMAGE_SELINUXD_EL9
                   value: quay.io/security-profiles-operator/selinuxd-el9:latest
+                - name: RELATED_IMAGE_SELINUXD_FEDORA
+                  value: quay.io/security-profiles-operator/selinuxd-fedora:latest
                 - name: OPERATOR_NAMESPACE
                   valueFrom:
                     fieldRef:
@@ -985,5 +987,7 @@ spec:
     name: selinuxd-el8
   - image: quay.io/security-profiles-operator/selinuxd-el9:latest
     name: selinuxd-el9
+  - image: quay.io/security-profiles-operator/selinuxd-fedora:latest
+    name: selinuxd-fedora
   replaces: security-profiles-operator.v0.8.3
   version: 0.8.5-dev

--- a/deploy/base/profiles/selinuxd-image-mapping.json
+++ b/deploy/base/profiles/selinuxd-image-mapping.json
@@ -6,5 +6,9 @@
     {
         "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
         "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+    },
+    {
+        "regex":"Fedora \\d+",
+        "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
     }
 ]

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -32,6 +32,8 @@ spec:
           value: {{ .Values.selinuxdImage.el8.registry }}/{{ .Values.selinuxdImage.el8.repository }}:{{ .Values.selinuxdImage.el8.tag }}
         - name: RELATED_IMAGE_SELINUXD_EL9
           value: {{ .Values.selinuxdImage.el9.registry }}/{{ .Values.selinuxdImage.el9.repository }}:{{ .Values.selinuxdImage.el9.tag }}
+        - name: RELATED_IMAGE_SELINUXD_FEDORA
+          value: {{ .Values.selinuxdImage.fedora.registry }}/{{ .Values.selinuxdImage.fedora.repository }}:{{ .Values.selinuxdImage.fedora.tag }}
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -27,11 +27,11 @@ spec:
         - name: RELATED_IMAGE_RBAC_PROXY
           value: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         - name: RELATED_IMAGE_SELINUXD
-          value: quay.io/security-profiles-operator/selinuxd
+          value: {{ .Values.selinuxdImage.default.registry }}/{{ .Values.selinuxdImage.default.repository }}:{{ .Values.selinuxdImage.default.tag }}
         - name: RELATED_IMAGE_SELINUXD_EL8
-          value: quay.io/security-profiles-operator/selinuxd-el8:latest
+          value: {{ .Values.selinuxdImage.el8.registry }}/{{ .Values.selinuxdImage.el8.repository }}:{{ .Values.selinuxdImage.el8.tag }}
         - name: RELATED_IMAGE_SELINUXD_EL9
-          value: quay.io/security-profiles-operator/selinuxd-el9:latest
+          value: {{ .Values.selinuxdImage.el9.registry }}/{{ .Values.selinuxdImage.el9.repository }}:{{ .Values.selinuxdImage.el9.tag }}
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -978,6 +978,10 @@ data:
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
             "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+        },
+        {
+            "regex":"Fedora \\d+",
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
         }
     ]
   selinuxd.cil: |

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -6,6 +6,20 @@ spoImage:
   repository: k8s-staging-sp-operator/security-profiles-operator
   tag: latest
 
+selinuxdImage:
+  default:
+    registry: quay.io
+    repository: security-profiles-operator/selinuxd
+    tag: latest
+  el8:
+    registry: quay.io
+    repository: security-profiles-operator/selinuxd-el8
+    tag: latest
+  el9:
+    registry: quay.io
+    repository: security-profiles-operator/selinuxd-el9
+    tag: latest
+
 enableSelinux: false
 enableLogEnricher: false
 enableAppArmor: false

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -19,6 +19,10 @@ selinuxdImage:
     registry: quay.io
     repository: security-profiles-operator/selinuxd-el9
     tag: latest
+  fedora:
+    registry: quay.io
+    repository: security-profiles-operator/selinuxd-fedora
+    tag: latest
 
 enableSelinux: false
 enableLogEnricher: false

--- a/deploy/kustomize-deployment/manager_deployment.yaml
+++ b/deploy/kustomize-deployment/manager_deployment.yaml
@@ -43,6 +43,8 @@ spec:
               value: quay.io/security-profiles-operator/selinuxd-el8:latest
             - name: RELATED_IMAGE_SELINUXD_EL9
               value: quay.io/security-profiles-operator/selinuxd-el9:latest
+            - name: RELATED_IMAGE_SELINUXD_FEDORA
+              value: quay.io/security-profiles-operator/selinuxd-fedora:latest
             - name: OPERATOR_NAMESPACE
               valueFrom:
                 fieldRef:

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -3093,6 +3093,10 @@ data:
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
             "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+        },
+        {
+            "regex":"Fedora \\d+",
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
         }
     ]
   selinuxd.cil: |
@@ -3184,6 +3188,8 @@ spec:
           value: quay.io/security-profiles-operator/selinuxd-el8:latest
         - name: RELATED_IMAGE_SELINUXD_EL9
           value: quay.io/security-profiles-operator/selinuxd-el9:latest
+        - name: RELATED_IMAGE_SELINUXD_FEDORA
+          value: quay.io/security-profiles-operator/selinuxd-fedora:latest
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3075,6 +3075,10 @@ data:
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
             "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+        },
+        {
+            "regex":"Fedora \\d+",
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
         }
     ]
   selinuxd.cil: |
@@ -3175,6 +3179,8 @@ spec:
           value: quay.io/security-profiles-operator/selinuxd-el8:latest
         - name: RELATED_IMAGE_SELINUXD_EL9
           value: quay.io/security-profiles-operator/selinuxd-el9:latest
+        - name: RELATED_IMAGE_SELINUXD_FEDORA
+          value: quay.io/security-profiles-operator/selinuxd-fedora:latest
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -3106,6 +3106,10 @@ data:
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
             "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+        },
+        {
+            "regex":"Fedora \\d+",
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
         }
     ]
   selinuxd.cil: |
@@ -3195,6 +3199,8 @@ spec:
           value: quay.io/security-profiles-operator/selinuxd-el8:latest
         - name: RELATED_IMAGE_SELINUXD_EL9
           value: quay.io/security-profiles-operator/selinuxd-el9:latest
+        - name: RELATED_IMAGE_SELINUXD_FEDORA
+          value: quay.io/security-profiles-operator/selinuxd-fedora:latest
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3093,6 +3093,10 @@ data:
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
             "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+        },
+        {
+            "regex":"Fedora \\d+",
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
         }
     ]
   selinuxd.cil: |
@@ -3182,6 +3186,8 @@ spec:
           value: quay.io/security-profiles-operator/selinuxd-el8:latest
         - name: RELATED_IMAGE_SELINUXD_EL9
           value: quay.io/security-profiles-operator/selinuxd-el9:latest
+        - name: RELATED_IMAGE_SELINUXD_FEDORA
+          value: quay.io/security-profiles-operator/selinuxd-fedora:latest
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3064,6 +3064,10 @@ data:
         {
             "regex":"(.*)(CoreOS).*([\\d+])\\.9[\\d+]\\.(.*)",
             "imageFromVar":"RELATED_IMAGE_SELINUXD_EL9"
+        },
+        {
+            "regex":"Fedora \\d+",
+            "imageFromVar":"RELATED_IMAGE_SELINUXD_FEDORA"
         }
     ]
   selinuxd.cil: |
@@ -3182,6 +3186,8 @@ spec:
           value: quay.io/security-profiles-operator/selinuxd-el8:latest
         - name: RELATED_IMAGE_SELINUXD_EL9
           value: quay.io/security-profiles-operator/selinuxd-el9:latest
+        - name: RELATED_IMAGE_SELINUXD_FEDORA
+          value: quay.io/security-profiles-operator/selinuxd-fedora:latest
         - name: OPERATOR_NAMESPACE
           valueFrom:
             fieldRef:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature

#### What this PR does / why we need it:

Makes selinuxd images configurable (in Helm chart)

One reason would be mirroring images on own registry, and pulling images from there.

However, while deploying SPO on Fedora CoreOS I found out that default image is not working for my deployment. This makes images configurable in more convenient manner.

See [discussion on Slack](https://kubernetes.slack.com/archives/C013FQNB0A2/p1718011082988209)

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Make selinuxd images configurable in Helm chart
```
