### PR TITLE
Fix `enableAppArmor` boolean in docs

### DIFF
--- a/installation-usage.md
+++ b/installation-usage.md
@@ -1756,7 +1756,7 @@ running with the appropriate profile.
 Ensure that the daemon has AppArmor enabled:
 
 ```
-> kubectl -n security-profiles-operator patch spod spod --type=merge -p '{"spec":{"enableAppArmor":"true"}}'
+> kubectl -n security-profiles-operator patch spod spod --type=merge -p '{"spec":{"enableAppArmor":true}}'
 securityprofilesoperatordaemon.security-profiles-operator.x-k8s.io/spod patched
 ```
 


### PR DESCRIPTION


#### What type of PR is this?


/kind documentation


#### What this PR does / why we need it:
The docs interpret the bool as string which leads into a wrong command. Now it's fixed by omitting the `"`.


#### Which issue(s) this PR fixes:

Fixes https://github.com/kubernetes-sigs/security-profiles-operator/issues/2321


#### Does this PR have test?

None

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed `enableAppArmor` boolean in `installation-usage.md`.
```
