### PR TITLE
Extend the apparmor e2e test to apply the recorded profile

### DIFF
--- a/hack/ci/e2e-apparmor.sh
+++ b/hack/ci/e2e-apparmor.sh
@@ -83,9 +83,9 @@ wait_for_pod_status() {
 }
 
 check_profile_enforcement() {
-  local comamnd="$1"
+  local command="$1"
   local apparmor_profile="$2"
-  local pid="$(pidof $comamnd)"
+  local pid="$(pidof $command)"
   local enforce="$(cat /proc/${pid}/attr/current)"
   local reference="$apparmor_profile (enforce)"
   if [[ "$reference" != "$enforce" ]]; then
@@ -122,7 +122,7 @@ record_apparmor_profile() {
 
   wait_for apparmorprofile $APPARMOR_PROFILE_NAME
 
-  echo "Verifing apparmor profile"
+  echo "Verifying apparmor profile"
   echo "-------------------------"
 
   echo "Checking the recorded appamror profile matches the reference"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

It extends the e2e test for apprmor to use the recorded profile and also it checks if the profile is enforced on the container.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
Fixes #2310

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

NONE
```

cc @mhils 