### PR TITLE
Fix CRI-O related runtime binary path

### DIFF
--- a/hack/ci/Vagrantfile-fedora
+++ b/hack/ci/Vagrantfile-fedora
@@ -57,7 +57,6 @@ gpgkey=https://pkgs.k8s.io/addons:/cri-o:/prerelease:/main/rpm/repodata/repomd.x
 EOF
 
       dnf install -y \
-        cri-o \
         conntrack \
         container-selinux \
         gcc \
@@ -71,6 +70,11 @@ EOF
         make \
         openssl \
         podman
+
+      # conmon installs to /usr/libexec/crio/conmon
+      # https://github.com/containers/conmon/issues/517
+      dnf download --repo cri-o --arch x86_64 cri-o
+      rpm -i --nodeps --force cri-o-*.rpm
 
       # Load the prebuilt container image
       podman load -i /vagrant/image.tar


### PR DESCRIPTION


#### What type of PR is this?



/kind failing-test

#### What this PR does / why we need it:
The binaries are now under `/usr/libexec/crio` instead of `crio-*` prefixed. We now fix those paths to make the CI work again.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
