### PR TITLE
AppArmor recorder: replace path variance at earliest opportunity

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
@@ -133,6 +133,7 @@ func (b *AppArmorRecorder) handleFileEvent(fileEvent *bpfEvent) {
 	defer b.lockRecordedFiles.Unlock()
 
 	fileName := fileDataToString(&fileEvent.Data)
+	fileName = replaceVarianceInFilePath(fileName)
 
 	log.Printf("File access: %s, flags=%d pid=%d mntns=%d\n", fileName, fileEvent.Flags, fileEvent.Pid, fileEvent.Mntns)
 
@@ -266,8 +267,6 @@ func (b *AppArmorRecorder) processExecFsEvents(mid mntnsID) BpfAppArmorFileProce
 	}
 
 	for fileName, access := range b.recordedFiles[mid] {
-		fileName = replaceVarianceInFilePath(fileName)
-
 		knownLibrary := isKnownFile(fileName, knownLibrariesPrefixes) || fileName == b.programName
 		knownRead := isKnownFile(fileName, knownReadPrefixes)
 		knownWrite := isKnownFile(fileName, knownWritePrefixes)

--- a/test/spoc/demobinary.go
+++ b/test/spoc/demobinary.go
@@ -42,7 +42,7 @@ func main() {
 
 	capSysAdmin := flag.Bool("cap-sys-admin", false, "exercise CAP_SYS_ADMIN")
 	fileWrite := flag.String("file-write", "", "write file (e.g. /dev/null)")
-	fileRead := flag.String("file-read", "", "read file (e.g. /dev/null)")
+	fileRead := flag.String("file-read", "", "read file (e.g. /dev/null). Multiple files may be separated by comma.")
 	fileSymlink := flag.String("file-symlink", "", "Create symlink using the following syntax: OLD:NEW")
 	netTCP := flag.Bool("net-tcp", false, "spawn a tcp server")
 	netUDP := flag.Bool("net-udp", false, "spawn a udp server")
@@ -88,11 +88,13 @@ func main() {
 		log.Println("✅ Symlink created:", newname, "->", oldname)
 	}
 	if *fileRead != "" {
-		_, err := os.ReadFile(*fileRead)
-		if err != nil {
-			log.Fatal("❌ Error reading file:", err)
+		for _, file := range strings.Split(*fileRead, ",") {
+			_, err := os.ReadFile(file)
+			if err != nil {
+				log.Fatal("❌ Error reading file:", err)
+			}
+			log.Println("✅ File read successful:", *fileRead)
 		}
-		log.Println("✅ File read successful:", *fileRead)
 	}
 	if *netTCP {
 		listener, err := net.Listen("tcp", ":0")

--- a/test/spoc/e2e_spoc_test.go
+++ b/test/spoc/e2e_spoc_test.go
@@ -82,7 +82,7 @@ func recordAppArmorTest(t *testing.T) {
 				count++
 			}
 		}
-		require.Equal(t, count, 1)
+		require.Equal(t, 1, count)
 
 		profile = recordAppArmor(t, "--file-read", "/dev/null", "--file-write", "/dev/null")
 		require.Contains(t, *profile.Filesystem.ReadWritePaths, "/dev/null")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The AppArmor recorder should deduplicate all paths it encounters.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Yes.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix a bug where AppArmor profiles would contain the same path more than once.
```
