### PR TITLE
spoc: abort apparmor recording if BPF LSM is not enabled

### DIFF
--- a/internal/pkg/cli/recorder/impl.go
+++ b/internal/pkg/cli/recorder/impl.go
@@ -44,6 +44,7 @@ type defaultImpl struct{}
 type impl interface {
 	LoadBpfRecorder(*bpfrecorder.BpfRecorder) error
 	UnloadBpfRecorder(*bpfrecorder.BpfRecorder)
+	BPFLSMEnabled() bool
 	CommandRun(*command.Command) (uint32, error)
 	CommandWait(*command.Command) error
 	WaitForPidExit(*bpfrecorder.BpfRecorder, context.Context, uint32) error
@@ -66,6 +67,10 @@ func (*defaultImpl) LoadBpfRecorder(b *bpfrecorder.BpfRecorder) error {
 
 func (*defaultImpl) UnloadBpfRecorder(b *bpfrecorder.BpfRecorder) {
 	b.Unload()
+}
+
+func (*defaultImpl) BPFLSMEnabled() bool {
+	return bpfrecorder.BPFLSMEnabled()
 }
 
 func (*defaultImpl) CommandRun(cmd *command.Command) (uint32, error) {

--- a/internal/pkg/cli/recorder/recorder.go
+++ b/internal/pkg/cli/recorder/recorder.go
@@ -82,7 +82,7 @@ func (r *Recorder) Run() error {
 	// https://github.com/kubernetes-sigs/security-profiles-operator/issues/2384
 	// Explicitly check for BPF LSM support as the recorder fails silently
 	// to support seccomp-only use cases.
-	if recordAppArmor && !bpfrecorder.BPFLSMEnabled() {
+	if recordAppArmor && !r.BPFLSMEnabled() {
 		return errors.New("BPF LSM is not enabled for this kernel")
 	}
 

--- a/internal/pkg/cli/recorder/recorder_test.go
+++ b/internal/pkg/cli/recorder/recorder_test.go
@@ -49,6 +49,7 @@ func TestRun(t *testing.T) {
 		mock.IteratorNextReturnsOnCall(0, true)
 		mock.IteratorKeyReturnsOnCall(0, []byte{1, 0, 0, 0, 0, 0, 0, 0})
 		mock.SyscallsGetValueReturns([]byte{1}, nil)
+		mock.BPFLSMEnabledReturns(true)
 	}
 
 	for _, tc := range []struct {
@@ -247,6 +248,19 @@ func TestRun(t *testing.T) {
 			assert: func(mock *recorderfakes.FakeImpl, err error) {
 				require.NoError(t, err)
 				require.Equal(t, 2, mock.PrintObjCallCount())
+			},
+		},
+		{
+			name: "no BPF LSM",
+			prepare: func(mock *recorderfakes.FakeImpl) *Options {
+				defaultMock(mock)
+				mock.BPFLSMEnabledReturns(false)
+				options := Default()
+				options.typ = TypeApparmor
+				return options
+			},
+			assert: func(mock *recorderfakes.FakeImpl, err error) {
+				require.Error(t, err)
 			},
 		},
 	} {

--- a/internal/pkg/cli/recorder/recorderfakes/fake_impl.go
+++ b/internal/pkg/cli/recorder/recorderfakes/fake_impl.go
@@ -36,6 +36,16 @@ import (
 )
 
 type FakeImpl struct {
+	BPFLSMEnabledStub        func() bool
+	bPFLSMEnabledMutex       sync.RWMutex
+	bPFLSMEnabledArgsForCall []struct {
+	}
+	bPFLSMEnabledReturns struct {
+		result1 bool
+	}
+	bPFLSMEnabledReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	CommandRunStub        func(*command.Command) (uint32, error)
 	commandRunMutex       sync.RWMutex
 	commandRunArgsForCall []struct {
@@ -225,6 +235,59 @@ type FakeImpl struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeImpl) BPFLSMEnabled() bool {
+	fake.bPFLSMEnabledMutex.Lock()
+	ret, specificReturn := fake.bPFLSMEnabledReturnsOnCall[len(fake.bPFLSMEnabledArgsForCall)]
+	fake.bPFLSMEnabledArgsForCall = append(fake.bPFLSMEnabledArgsForCall, struct {
+	}{})
+	stub := fake.BPFLSMEnabledStub
+	fakeReturns := fake.bPFLSMEnabledReturns
+	fake.recordInvocation("BPFLSMEnabled", []interface{}{})
+	fake.bPFLSMEnabledMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) BPFLSMEnabledCallCount() int {
+	fake.bPFLSMEnabledMutex.RLock()
+	defer fake.bPFLSMEnabledMutex.RUnlock()
+	return len(fake.bPFLSMEnabledArgsForCall)
+}
+
+func (fake *FakeImpl) BPFLSMEnabledCalls(stub func() bool) {
+	fake.bPFLSMEnabledMutex.Lock()
+	defer fake.bPFLSMEnabledMutex.Unlock()
+	fake.BPFLSMEnabledStub = stub
+}
+
+func (fake *FakeImpl) BPFLSMEnabledReturns(result1 bool) {
+	fake.bPFLSMEnabledMutex.Lock()
+	defer fake.bPFLSMEnabledMutex.Unlock()
+	fake.BPFLSMEnabledStub = nil
+	fake.bPFLSMEnabledReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeImpl) BPFLSMEnabledReturnsOnCall(i int, result1 bool) {
+	fake.bPFLSMEnabledMutex.Lock()
+	defer fake.bPFLSMEnabledMutex.Unlock()
+	fake.BPFLSMEnabledStub = nil
+	if fake.bPFLSMEnabledReturnsOnCall == nil {
+		fake.bPFLSMEnabledReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.bPFLSMEnabledReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
 }
 
 func (fake *FakeImpl) CommandRun(arg1 *command.Command) (uint32, error) {
@@ -1178,6 +1241,8 @@ func (fake *FakeImpl) WaitForPidExitReturnsOnCall(i int, result1 error) {
 func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.bPFLSMEnabledMutex.RLock()
+	defer fake.bPFLSMEnabledMutex.RUnlock()
 	fake.commandRunMutex.RLock()
 	defer fake.commandRunMutex.RUnlock()
 	fake.commandWaitMutex.RLock()

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
@@ -476,6 +476,8 @@ func (b *BpfRecorder) Load(startEventProcessor bool) (err error) {
 			// Only log an error here, if Apparmor cannot be loaded. This is because it is
 			// enabled by default, and there are Linux distributions which either do not
 			// support Apparmor or BPF LSM is not yet available.
+			//
+			// see also https://github.com/kubernetes-sigs/security-profiles-operator/issues/2384
 			b.logger.Error(err, "Loading bpf program")
 		}
 	}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### Which issue(s) this PR fixes:

https://github.com/kubernetes-sigs/security-profiles-operator/issues/2384

#### Does this PR have test?

Yes.

#### Does this PR introduce a user-facing change?

```release-note
Fix a bug where spoc would generate empty AppArmor profiles on systems without BPF LSM enabled.
```
