### PR TITLE
fix flaky recorder: use recorder pid to determine mntns

### DIFF
--- a/internal/pkg/cli/recorder/recorder.go
+++ b/internal/pkg/cli/recorder/recorder.go
@@ -105,7 +105,7 @@ func (r *Recorder) Run() error {
 			return fmt.Errorf("run command: %w", err)
 		}
 
-		mntns, err = r.FindProcMountNamespace(r.bpfRecorder, pid)
+		mntns, err = r.FindProcMountNamespace(r.bpfRecorder, uint32(os.Getpid()))
 		if err != nil {
 			return fmt.Errorf("finding mntns of PID %d: %w", pid, err)
 		}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind flake

#### What this PR does / why we need it:

Since the process we spawn is in the same mount namespace as the recorder, we can just use our own pid to determine the namespace and avoid any race.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Implicitly.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
