### PR TITLE
`spoc record`: drop sudo privileges

### DIFF
--- a/cmd/spoc/main.go
+++ b/cmd/spoc/main.go
@@ -83,6 +83,10 @@ func main() {
 					Name:  recorder.FlagNoProcStart,
 					Usage: "do not start the target command and record until ctrl+c/SIGINT.",
 				},
+				&cli.BoolFlag{
+					Name:  recorder.FlagPrivileged,
+					Usage: "do not drop sudo privileges when running the target command.",
+				},
 			},
 		},
 		&cli.Command{

--- a/internal/pkg/cli/command/command.go
+++ b/internal/pkg/cli/command/command.go
@@ -17,11 +17,19 @@ limitations under the License.
 package command
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
+	"os/user"
+	"slices"
+	"strconv"
+	"strings"
+	"syscall"
 )
+
+var errNoSudoEnvironment = errors.New("not in a sudo environment")
 
 type Command struct {
 	impl
@@ -40,6 +48,12 @@ func New(options *Options) *Command {
 // Run the Command.
 func (c *Command) Run() (pid uint32, err error) {
 	c.cmd = c.Command(c.options.command, c.options.args...)
+	if c.options.DropSudoPrivileges {
+		err := c.DropSudoPrivileges()
+		if err != nil && !errors.Is(err, errNoSudoEnvironment) {
+			log.Printf("Failed to drop sudo privileges: %v", err)
+		}
+	}
 	if err := c.CmdStart(c.cmd); err != nil {
 		return pid, fmt.Errorf("start command: %w", err)
 	}
@@ -60,6 +74,65 @@ func (c *Command) Run() (pid uint32, err error) {
 	log.Printf("Running command with PID: %d", pid)
 
 	return pid, nil
+}
+
+func getHomeDirectory(uid uint32) (string, error) {
+	usr, err := user.LookupId(strconv.FormatUint(uint64(uid), 10))
+	if err == nil && usr.HomeDir != "" {
+		return usr.HomeDir, nil
+	}
+	//nolint:gosec // uid is trusted here
+	cmd := exec.Command(
+		"sudo",
+		fmt.Sprintf("--user=#%d", uid),
+		"--set-home",
+		"bash",
+		"-c",
+		"echo -n ~",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("home dir lookup failed: %w", err)
+	}
+	if len(out) == 0 {
+		return "", errors.New("home dir lookup failed: no output")
+	}
+	return string(out), nil
+}
+
+func (c *Command) DropSudoPrivileges() error {
+	uid, err := strconv.ParseUint(os.Getenv("SUDO_UID"), 10, 32)
+	if err != nil {
+		return errNoSudoEnvironment
+	}
+	gid, err := strconv.ParseUint(os.Getenv("SUDO_GID"), 10, 32)
+	if err != nil {
+		return errNoSudoEnvironment
+	}
+	userName := os.Getenv("SUDO_USER")
+	if userName == "" {
+		return errNoSudoEnvironment
+	}
+	home, err := c.GetHomeDirectory(uint32(uid))
+	if err != nil {
+		return fmt.Errorf("failed to drop privileges: %w", err)
+	}
+
+	c.cmd.SysProcAttr = &syscall.SysProcAttr{
+		Credential: &syscall.Credential{
+			Uid: uint32(uid),
+			Gid: uint32(gid),
+		},
+	}
+	c.cmd.Env = append(
+		slices.DeleteFunc(
+			c.cmd.Environ(),
+			func(s string) bool { return strings.HasPrefix(s, "SUDO_") },
+		),
+		"HOME="+home,
+		"USER="+userName,
+	)
+	return nil
 }
 
 func (c *Command) Wait() error {

--- a/internal/pkg/cli/command/commandfakes/fake_impl.go
+++ b/internal/pkg/cli/command/commandfakes/fake_impl.go
@@ -69,6 +69,19 @@ type FakeImpl struct {
 	commandReturnsOnCall map[int]struct {
 		result1 *exec.Cmd
 	}
+	GetHomeDirectoryStub        func(uint32) (string, error)
+	getHomeDirectoryMutex       sync.RWMutex
+	getHomeDirectoryArgsForCall []struct {
+		arg1 uint32
+	}
+	getHomeDirectoryReturns struct {
+		result1 string
+		result2 error
+	}
+	getHomeDirectoryReturnsOnCall map[int]struct {
+		result1 string
+		result2 error
+	}
 	NotifyStub        func(chan<- os.Signal, ...os.Signal)
 	notifyMutex       sync.RWMutex
 	notifyArgsForCall []struct {
@@ -336,6 +349,70 @@ func (fake *FakeImpl) CommandReturnsOnCall(i int, result1 *exec.Cmd) {
 	}{result1}
 }
 
+func (fake *FakeImpl) GetHomeDirectory(arg1 uint32) (string, error) {
+	fake.getHomeDirectoryMutex.Lock()
+	ret, specificReturn := fake.getHomeDirectoryReturnsOnCall[len(fake.getHomeDirectoryArgsForCall)]
+	fake.getHomeDirectoryArgsForCall = append(fake.getHomeDirectoryArgsForCall, struct {
+		arg1 uint32
+	}{arg1})
+	stub := fake.GetHomeDirectoryStub
+	fakeReturns := fake.getHomeDirectoryReturns
+	fake.recordInvocation("GetHomeDirectory", []interface{}{arg1})
+	fake.getHomeDirectoryMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) GetHomeDirectoryCallCount() int {
+	fake.getHomeDirectoryMutex.RLock()
+	defer fake.getHomeDirectoryMutex.RUnlock()
+	return len(fake.getHomeDirectoryArgsForCall)
+}
+
+func (fake *FakeImpl) GetHomeDirectoryCalls(stub func(uint32) (string, error)) {
+	fake.getHomeDirectoryMutex.Lock()
+	defer fake.getHomeDirectoryMutex.Unlock()
+	fake.GetHomeDirectoryStub = stub
+}
+
+func (fake *FakeImpl) GetHomeDirectoryArgsForCall(i int) uint32 {
+	fake.getHomeDirectoryMutex.RLock()
+	defer fake.getHomeDirectoryMutex.RUnlock()
+	argsForCall := fake.getHomeDirectoryArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImpl) GetHomeDirectoryReturns(result1 string, result2 error) {
+	fake.getHomeDirectoryMutex.Lock()
+	defer fake.getHomeDirectoryMutex.Unlock()
+	fake.GetHomeDirectoryStub = nil
+	fake.getHomeDirectoryReturns = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) GetHomeDirectoryReturnsOnCall(i int, result1 string, result2 error) {
+	fake.getHomeDirectoryMutex.Lock()
+	defer fake.getHomeDirectoryMutex.Unlock()
+	fake.GetHomeDirectoryStub = nil
+	if fake.getHomeDirectoryReturnsOnCall == nil {
+		fake.getHomeDirectoryReturnsOnCall = make(map[int]struct {
+			result1 string
+			result2 error
+		})
+	}
+	fake.getHomeDirectoryReturnsOnCall[i] = struct {
+		result1 string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeImpl) Notify(arg1 chan<- os.Signal, arg2 ...os.Signal) {
 	fake.notifyMutex.Lock()
 	fake.notifyArgsForCall = append(fake.notifyArgsForCall, struct {
@@ -442,6 +519,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.cmdWaitMutex.RUnlock()
 	fake.commandMutex.RLock()
 	defer fake.commandMutex.RUnlock()
+	fake.getHomeDirectoryMutex.RLock()
+	defer fake.getHomeDirectoryMutex.RUnlock()
 	fake.notifyMutex.RLock()
 	defer fake.notifyMutex.RUnlock()
 	fake.signalMutex.RLock()

--- a/internal/pkg/cli/command/consts.go
+++ b/internal/pkg/cli/command/consts.go
@@ -1,0 +1,22 @@
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package command
+
+const (
+	// FlagPrivileged is the flag for running commands without dropping sudo privileges.
+	FlagPrivileged string = "privileged"
+)

--- a/internal/pkg/cli/command/impl.go
+++ b/internal/pkg/cli/command/impl.go
@@ -33,6 +33,7 @@ type impl interface {
 	CmdStart(*exec.Cmd) error
 	CmdPid(*exec.Cmd) uint32
 	CmdWait(*exec.Cmd) error
+	GetHomeDirectory(uid uint32) (string, error)
 }
 
 func (*defaultImpl) Notify(c chan<- os.Signal, sig ...os.Signal) {
@@ -60,4 +61,8 @@ func (*defaultImpl) CmdPid(cmd *exec.Cmd) uint32 {
 
 func (*defaultImpl) CmdWait(cmd *exec.Cmd) error {
 	return cmd.Wait()
+}
+
+func (*defaultImpl) GetHomeDirectory(uid uint32) (string, error) {
+	return getHomeDirectory(uid)
 }

--- a/internal/pkg/cli/command/options.go
+++ b/internal/pkg/cli/command/options.go
@@ -24,8 +24,9 @@ import (
 
 // Options define all possible options for the command.
 type Options struct {
-	command string
-	args    []string
+	command            string
+	args               []string
+	DropSudoPrivileges bool
 }
 
 // Command returns the command name.
@@ -35,7 +36,9 @@ func (o *Options) Command() string {
 
 // Default returns a default options instance.
 func Default() *Options {
-	return &Options{}
+	return &Options{
+		DropSudoPrivileges: true,
+	}
 }
 
 // FromContext can be used to create Options from an CLI context.
@@ -48,6 +51,10 @@ func FromContext(ctx *cli.Context) (*Options, error) {
 	}
 	options.command = args[0]
 	options.args = args[1:]
+
+	if ctx.IsSet(FlagPrivileged) {
+		options.DropSudoPrivileges = false
+	}
 
 	return options, nil
 }

--- a/internal/pkg/cli/recorder/consts.go
+++ b/internal/pkg/cli/recorder/consts.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package recorder
 
-import "sigs.k8s.io/security-profiles-operator/internal/pkg/cli"
+import (
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/cli"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/cli/command"
+)
 
 const (
 	// FlagOutputFile is the flag for defining the output file location.
@@ -36,6 +39,9 @@ const (
 	// FlagNoProcStart can be used to indicate that the target process is managed
 	// externally and should not be started.
 	FlagNoProcStart string = "no-proc-start"
+
+	// FlagPrivileged is the flag for running commands without dropping sudo privileges.
+	FlagPrivileged string = command.FlagPrivileged
 )
 
 // Type is the enum for all available recorder types.

--- a/test/spoc/demobinary.go
+++ b/test/spoc/demobinary.go
@@ -73,7 +73,7 @@ func main() {
 		// make file writable for other users so that sudo/non-sudo testing works.
 		err = os.Chmod(*fileWrite, fileMode)
 		if err != nil {
-			log.Fatal("❌ Error setting file permissions:", err)
+			log.Println("Error setting file permissions:", err)
 		}
 	}
 	if *fileSymlink != "" {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR improves `sudo spoc record` so that the recorded process runs with regular user privileges by default. Running with elevated privileges is harmful because additional (unnecessary) capabilities get recorded with libc:

```shell
$ sudo build/spoc record -t apparmor -o /dev/stdout head -1 README.md 2>/dev/null
apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
kind: AppArmorProfile
metadata:
  creationTimestamp: null
  name: head
spec:
  abstract:
    executable:
      allowedLibraries:
      - /usr/bin/head
    filesystem:
      readOnlyPaths:
      - /etc/locale.alias
status: {}
```
```shell
$ sudo build/spoc record -t apparmor -o /dev/stdout --privileged head -1 README.md 2>/dev/null
apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
kind: AppArmorProfile
metadata:
  creationTimestamp: null
  name: head
spec:
  abstract:
    capability:
      allowedCapabilities:
      - dac_override.  🛑
      - dac_read_search. 🛑
    executable:
      allowedLibraries:
      - /usr/bin/head
    filesystem:
      readOnlyPaths:
      - /etc/locale.alias
status: {}

```

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Updated the spoc e2e tests.

#### Does this PR introduce a user-facing change?

```release-note
`spoc record` now drops privileges when spawning the process it observes.
```
