### PR TITLE
apparmor recorder: add hugepage support

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
@@ -267,7 +267,6 @@ func (b *AppArmorRecorder) processExecFsEvents(mid mntnsID) BpfAppArmorFileProce
 	}
 
 	for fileName, access := range b.recordedFiles[mid] {
-
 		// Workaround for HUGETLB support with apparmor:
 		// AppArmor treats mmap(..., MAP_ANONYMOUS | MAP_HUGETLB) calls as
 		// file access to "", which is then attached to "/" (attach_disconnected).

--- a/test/spoc/demobinary.go
+++ b/test/spoc/demobinary.go
@@ -1,3 +1,6 @@
+//go:build linux && !no_bpf
+// +build linux,!no_bpf
+
 /*
 Copyright 2024 The Kubernetes Authors.
 

--- a/test/spoc/demobinary.go
+++ b/test/spoc/demobinary.go
@@ -48,6 +48,7 @@ func main() {
 	netUDP := flag.Bool("net-udp", false, "spawn a udp server")
 	netIcmp := flag.Bool("net-icmp", false, "open an icmp socket, exercise NET_RAW capability.")
 	library := flag.String("load-library", "", "load a shared library")
+	hugepage := flag.Bool("hugepage", false, "allocate a huge page.")
 	sleep := flag.Int("sleep", 0, "sleep N seconds before exiting.")
 	crash := flag.Bool("crash", false, "crash instead of exiting.")
 
@@ -137,6 +138,12 @@ func main() {
 			log.Fatal("❌ Error loading library: ", C.GoString(C.dlerror()))
 		}
 		log.Println("✅ Library loaded successfully:", *library)
+	}
+	if *hugepage {
+		if _, err := syscall.Mmap(-1, 0, 8192, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_PRIVATE|syscall.MAP_ANON|syscall.MAP_HUGETLB); err != nil {
+			log.Fatal("❌ Error allocating huge page:", err)
+		}
+		log.Println("✅ Huge page allocated successfully.")
 	}
 	if *sleep > 0 {
 		log.Println("⏳ Sleeping for", *sleep, "seconds...")

--- a/test/spoc/demobinary.go
+++ b/test/spoc/demobinary.go
@@ -38,6 +38,8 @@ import (
 const LogPrefixEnvVar = "LOGPREFIX"
 
 // Demo binary to exercise various capabilities that may be restricted by seccomp/apparmor.
+//
+//nolint:gocognit // complexity is ok
 func main() {
 	log.SetPrefix(fmt.Sprintf("%s[pid:%d] ", os.Getenv(LogPrefixEnvVar), os.Getpid()))
 	log.SetFlags(log.Lshortfile)
@@ -143,8 +145,15 @@ func main() {
 		log.Println("✅ Library loaded successfully:", *library)
 	}
 	if *hugepage {
-		if _, err := syscall.Mmap(-1, 0, 8192, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_PRIVATE|syscall.MAP_ANON|syscall.MAP_HUGETLB); err != nil {
+		data, err := syscall.Mmap(-1, 0, 8192,
+			syscall.PROT_READ|syscall.PROT_WRITE,
+			syscall.MAP_PRIVATE|syscall.MAP_ANON|syscall.MAP_HUGETLB)
+		if err != nil {
 			log.Fatal("❌ Error allocating huge page:", err)
+		}
+		err = syscall.Munmap(data)
+		if err != nil {
+			log.Fatal("❌ Error deallocating huge page:", err)
 		}
 		log.Println("✅ Huge page allocated successfully.")
 	}

--- a/test/spoc/e2e_spoc_test.go
+++ b/test/spoc/e2e_spoc_test.go
@@ -128,11 +128,14 @@ func recordAppArmorTest(t *testing.T) {
 	})
 
 	t.Run("huge pages", func(t *testing.T) {
-		page, err := syscall.Mmap(-1, 0, 8192, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_PRIVATE|syscall.MAP_ANON|syscall.MAP_HUGETLB)
+		page, err := syscall.Mmap(-1, 0, 8192,
+			syscall.PROT_READ|syscall.PROT_WRITE,
+			syscall.MAP_PRIVATE|syscall.MAP_ANON|syscall.MAP_HUGETLB)
 		if err != nil {
 			t.Skip("No huge page support.")
 		} else {
-			syscall.Munmap(page)
+			err = syscall.Munmap(page)
+			require.NoError(t, err)
 		}
 		profile := recordAppArmor(t, "./demobinary", "./demobinary-child", "--hugepage")
 		require.Contains(t, *profile.Filesystem.ReadWritePaths, "/")

--- a/test/spoc/e2e_spoc_test.go
+++ b/test/spoc/e2e_spoc_test.go
@@ -28,6 +28,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"syscall"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -124,6 +125,17 @@ func recordAppArmorTest(t *testing.T) {
 		profile = recordAppArmor(t, "./demobinary-child", "./demobinary-child", "--file-read", "/dev/null")
 		require.Contains(t, (*profile.Executable.AllowedExecutables)[0], "/demobinary-child")
 		require.Contains(t, *profile.Filesystem.ReadOnlyPaths, "/dev/null")
+	})
+
+	t.Run("huge pages", func(t *testing.T) {
+		page, err := syscall.Mmap(-1, 0, 8192, syscall.PROT_READ|syscall.PROT_WRITE, syscall.MAP_PRIVATE|syscall.MAP_ANON|syscall.MAP_HUGETLB)
+		if err != nil {
+			t.Skip("No huge page support.")
+		} else {
+			syscall.Munmap(page)
+		}
+		profile := recordAppArmor(t, "./demobinary", "./demobinary-child", "--hugepage")
+		require.Contains(t, *profile.Filesystem.ReadWritePaths, "/")
 	})
 
 	t.Run("no-proc-start", func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes our AppArmor recorder to detect anonymous huge table usage and work around related AppArmor limitations. This is slightly ugly, but all other workarounds are even more ugly.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Yes

#### Does this PR introduce a user-facing change?

```release-note
Fix AppArmor recording for workloads that use anonymous hugepages.
```
