### PR TITLE
spoc: only include abstract policy in recorded apparmor profiles

### DIFF
--- a/internal/pkg/cli/recorder/recorder.go
+++ b/internal/pkg/cli/recorder/recorder.go
@@ -401,16 +401,6 @@ func (r *Recorder) buildProfileCRD(writer io.Writer, spec *seccompprofileapi.Sec
 }
 
 func (r *Recorder) buildAppArmorProfileCRD(writer io.Writer, spec *apparmorprofileapi.AppArmorProfileSpec) error {
-	programName, err := filepath.Abs(r.options.commandOptions.Command())
-	if err != nil {
-		return fmt.Errorf("get program name: %w", err)
-	}
-	// Raw apparmor profile is expected in the required policy field.
-	policy, err := crd2armor.GenerateProfile(programName, &spec.Abstract)
-	if err != nil {
-		return fmt.Errorf("generating raw apparmor profile: %w", err)
-	}
-	spec.Policy = policy
 	profile := &apparmorprofileapi.AppArmorProfile{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "AppArmorProfile",


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR unbreaks some spoc-related workflows. Profiles recorded by spoc should only have an abstract profile. `spoc convert` can be used to render the raw AppArmor template.

#### Which issue(s) this PR fixes:

refs #2388

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
AppArmor profiles recorded by spoc now include the abstract profile only, which ensures that the raw profile does not diverge.
```
