### PR TITLE
add daemonset resource values to Helm chart

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -13,8 +13,14 @@ please refer to [Installation Guide](https://github.com/kubernetes-sigs/security
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | `pod affinity rules` |
-| autoscaling.enabled | bool | `false` | `enable autosclaing or not` |
+| autoscaling.enabled | bool | `false` | `enable autoscaling or not` |
 | daemon.affinity | object | `{}` | `daemonset affinity rules` |
+| daemon.resources.limits.cpu | string | unlimited | `cpu limits for the daemonset` |
+| daemon.resources.limits.ephemeral-storage | string | `"200Mi"` | `storage limits for the daemonset` |
+| daemon.resources.limits.memory  | string | `"128Mi"` | `memory limits for the daemonset` |
+| daemon.resources.requests.cpu | string | `"100m"` | `cpu requests for the daemonset` |
+| daemon.resources.requests.ephemeral-storage | string | `"50Mi"` | `storage requests for the daemonset` |
+| daemon.resources.requests.memory | string | `"64Mi"` | `memory requests for the daemonset` |
 | daemon.tolerations | list | `[]` | `a list of daemonset tolerations rules` |
 | enableAppArmor | bool | `false` | `enable apparmor or not` |
 | enableBpfRecorder | bool | `false` | `enable BpfRecorder or not` |

--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -10,6 +10,8 @@ spec:
   affinity:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  daemonResourceRequirements:
+    {{- toYaml .Values.daemon.resources | nindent 4 }}
   enableSelinux: {{ .Values.enableSelinux }}
   enableLogEnricher: {{ .Values.enableLogEnricher }}
   enableAppArmor: {{ .Values.enableAppArmor }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -69,6 +69,14 @@ daemon:
   - effect: NoExecute
     key: node.kubernetes.io/not-ready
     operator: Exists
+  resources:
+    limits:
+      memory: 128Mi
+      ephemeral-storage: 200Mi
+    requests:
+      cpu: 100m
+      memory: 64Mi
+      ephemeral-storage: 50Mi
 
 autoscaling:
   enabled: false

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -351,6 +351,8 @@ kubectl -n security-profiles-operator patch spod spod --type merge -p
 '{"spec":{"daemonResourceRequirements": {"requests": {"memory": "256Mi", "cpu": "250m"}, "limits": {"memory": "512Mi", "cpu": "500m"}}}}'
 ```
 
+These values can also be specified via the Helm chart.
+
 ## Restrict the allowed syscalls in seccomp profiles
 
 The operator doesn't restrict by default the allowed syscalls in the seccomp profiles. This means that any


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Allows spod daemonset resource requests and limits to be set via the Helm chart, defaulting to the same [values](https://github.com/kubernetes-sigs/security-profiles-operator/blob/4937f53c40b75f69a55db936879a814903ecda55/internal/pkg/manager/spod/bindata/spod.go#L354-L362) set in the code.

#### Which issue(s) this PR fixes:
Fixes https://github.com/kubernetes-sigs/security-profiles-operator/issues/2455
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
N/A
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
