### PR TITLE
AppArmor: make policy field optional if abstract policy is specified

### DIFF
--- a/bundle/manifests/security-profiles-operator.x-k8s.io_apparmorprofiles.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_apparmorprofiles.yaml
@@ -38,10 +38,56 @@ spec:
           spec:
             description: AppArmorProfileSpec defines the desired state of AppArmorProfile
             properties:
+              abstract:
+                properties:
+                  capability:
+                    properties:
+                      allowedCapabilities:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  executable:
+                    properties:
+                      allowedExecutables:
+                        items:
+                          type: string
+                        type: array
+                      allowedLibraries:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  filesystem:
+                    properties:
+                      readOnlyPaths:
+                        items:
+                          type: string
+                        type: array
+                      readWritePaths:
+                        items:
+                          type: string
+                        type: array
+                      writeOnlyPaths:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  network:
+                    properties:
+                      allowRaw:
+                        type: boolean
+                      allowedProtocols:
+                        properties:
+                          allowTcp:
+                            type: boolean
+                          allowUdp:
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
               policy:
                 type: string
-            required:
-            - policy
             type: object
           status:
             description: AppArmorProfileStatus defines the observed state of AppArmorProfile

--- a/deploy/base-crds/crds/apparmorprofile.yaml
+++ b/deploy/base-crds/crds/apparmorprofile.yaml
@@ -40,8 +40,54 @@ spec:
             properties:
               policy:
                 type: string
-            required:
-            - policy
+              abstract:
+                type: object
+                properties:
+                  executable:
+                    type: object
+                    properties:
+                      allowedExecutables:
+                        type: array
+                        items:
+                          type: string
+                      allowedLibraries:
+                        type: array
+                        items:
+                          type: string
+                  filesystem:
+                    type: object
+                    properties:
+                      readOnlyPaths:
+                        type: array
+                        items:
+                          type: string
+                      writeOnlyPaths:
+                        type: array
+                        items:
+                          type: string
+                      readWritePaths:
+                        type: array
+                        items:
+                          type: string
+                  network:
+                    type: object
+                    properties:
+                      allowRaw:
+                        type: boolean
+                      allowedProtocols:
+                        type: object
+                        properties:
+                          allowTcp:
+                            type: boolean
+                          allowUdp:
+                            type: boolean
+                  capability:
+                    type: object
+                    properties:
+                      allowedCapabilities:
+                        type: array
+                        items:
+                          type: string
             type: object
           status:
             description: AppArmorProfileStatus defines the observed state of AppArmorProfile

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -2179,10 +2179,56 @@ spec:
           spec:
             description: AppArmorProfileSpec defines the desired state of AppArmorProfile
             properties:
+              abstract:
+                properties:
+                  capability:
+                    properties:
+                      allowedCapabilities:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  executable:
+                    properties:
+                      allowedExecutables:
+                        items:
+                          type: string
+                        type: array
+                      allowedLibraries:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  filesystem:
+                    properties:
+                      readOnlyPaths:
+                        items:
+                          type: string
+                        type: array
+                      readWritePaths:
+                        items:
+                          type: string
+                        type: array
+                      writeOnlyPaths:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  network:
+                    properties:
+                      allowRaw:
+                        type: boolean
+                      allowedProtocols:
+                        properties:
+                          allowTcp:
+                            type: boolean
+                          allowUdp:
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
               policy:
                 type: string
-            required:
-            - policy
             type: object
           status:
             description: AppArmorProfileStatus defines the observed state of AppArmorProfile

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2179,10 +2179,56 @@ spec:
           spec:
             description: AppArmorProfileSpec defines the desired state of AppArmorProfile
             properties:
+              abstract:
+                properties:
+                  capability:
+                    properties:
+                      allowedCapabilities:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  executable:
+                    properties:
+                      allowedExecutables:
+                        items:
+                          type: string
+                        type: array
+                      allowedLibraries:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  filesystem:
+                    properties:
+                      readOnlyPaths:
+                        items:
+                          type: string
+                        type: array
+                      readWritePaths:
+                        items:
+                          type: string
+                        type: array
+                      writeOnlyPaths:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  network:
+                    properties:
+                      allowRaw:
+                        type: boolean
+                      allowedProtocols:
+                        properties:
+                          allowTcp:
+                            type: boolean
+                          allowUdp:
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
               policy:
                 type: string
-            required:
-            - policy
             type: object
           status:
             description: AppArmorProfileStatus defines the observed state of AppArmorProfile

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -49,10 +49,56 @@ spec:
           spec:
             description: AppArmorProfileSpec defines the desired state of AppArmorProfile
             properties:
+              abstract:
+                properties:
+                  capability:
+                    properties:
+                      allowedCapabilities:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  executable:
+                    properties:
+                      allowedExecutables:
+                        items:
+                          type: string
+                        type: array
+                      allowedLibraries:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  filesystem:
+                    properties:
+                      readOnlyPaths:
+                        items:
+                          type: string
+                        type: array
+                      readWritePaths:
+                        items:
+                          type: string
+                        type: array
+                      writeOnlyPaths:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  network:
+                    properties:
+                      allowRaw:
+                        type: boolean
+                      allowedProtocols:
+                        properties:
+                          allowTcp:
+                            type: boolean
+                          allowUdp:
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
               policy:
                 type: string
-            required:
-            - policy
             type: object
           status:
             description: AppArmorProfileStatus defines the observed state of AppArmorProfile

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -2179,10 +2179,56 @@ spec:
           spec:
             description: AppArmorProfileSpec defines the desired state of AppArmorProfile
             properties:
+              abstract:
+                properties:
+                  capability:
+                    properties:
+                      allowedCapabilities:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  executable:
+                    properties:
+                      allowedExecutables:
+                        items:
+                          type: string
+                        type: array
+                      allowedLibraries:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  filesystem:
+                    properties:
+                      readOnlyPaths:
+                        items:
+                          type: string
+                        type: array
+                      readWritePaths:
+                        items:
+                          type: string
+                        type: array
+                      writeOnlyPaths:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  network:
+                    properties:
+                      allowRaw:
+                        type: boolean
+                      allowedProtocols:
+                        properties:
+                          allowTcp:
+                            type: boolean
+                          allowUdp:
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
               policy:
                 type: string
-            required:
-            - policy
             type: object
           status:
             description: AppArmorProfileStatus defines the observed state of AppArmorProfile

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2179,10 +2179,56 @@ spec:
           spec:
             description: AppArmorProfileSpec defines the desired state of AppArmorProfile
             properties:
+              abstract:
+                properties:
+                  capability:
+                    properties:
+                      allowedCapabilities:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  executable:
+                    properties:
+                      allowedExecutables:
+                        items:
+                          type: string
+                        type: array
+                      allowedLibraries:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  filesystem:
+                    properties:
+                      readOnlyPaths:
+                        items:
+                          type: string
+                        type: array
+                      readWritePaths:
+                        items:
+                          type: string
+                        type: array
+                      writeOnlyPaths:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  network:
+                    properties:
+                      allowRaw:
+                        type: boolean
+                      allowedProtocols:
+                        properties:
+                          allowTcp:
+                            type: boolean
+                          allowUdp:
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
               policy:
                 type: string
-            required:
-            - policy
             type: object
           status:
             description: AppArmorProfileStatus defines the observed state of AppArmorProfile

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -49,10 +49,56 @@ spec:
           spec:
             description: AppArmorProfileSpec defines the desired state of AppArmorProfile
             properties:
+              abstract:
+                properties:
+                  capability:
+                    properties:
+                      allowedCapabilities:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  executable:
+                    properties:
+                      allowedExecutables:
+                        items:
+                          type: string
+                        type: array
+                      allowedLibraries:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  filesystem:
+                    properties:
+                      readOnlyPaths:
+                        items:
+                          type: string
+                        type: array
+                      readWritePaths:
+                        items:
+                          type: string
+                        type: array
+                      writeOnlyPaths:
+                        items:
+                          type: string
+                        type: array
+                    type: object
+                  network:
+                    properties:
+                      allowRaw:
+                        type: boolean
+                      allowedProtocols:
+                        properties:
+                          allowTcp:
+                            type: boolean
+                          allowUdp:
+                            type: boolean
+                        type: object
+                    type: object
+                type: object
               policy:
                 type: string
-            required:
-            - policy
             type: object
           status:
             description: AppArmorProfileStatus defines the observed state of AppArmorProfile

--- a/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
@@ -79,18 +79,22 @@ func (a *aaProfileManager) InstallProfile(bp profilebasev1alpha1.StatusBaseUser)
 	// AppArmor profiles can currently have either an abstract or a concrete representation.
 	// This mostly is an XOR, but we also permit the case where both match.
 	var policy string
-	if profile.Spec.Abstract != (v1alpha1.AppArmorAbstract{}) {
+	hasAbstractPolicy := profile.Spec.Abstract != (v1alpha1.AppArmorAbstract{})
+	hasConcretePolicy := profile.Spec.Policy != ""
+	switch {
+	case hasAbstractPolicy:
 		var err error
 		policy, err = crd2armor.GenerateProfile(profile.GetProfileName(), &profile.Spec.Abstract)
 		if err != nil {
 			return false, fmt.Errorf("generating raw apparmor profile: %w", err)
 		}
-	}
-	if profile.Spec.Policy != "" {
-		if policy != "" && policy != profile.Spec.Policy {
+		if hasConcretePolicy && policy != profile.Spec.Policy {
 			return false, errors.New("abstract and concrete policy do not match")
 		}
+	case hasConcretePolicy:
 		policy = profile.Spec.Policy
+	default:
+		return false, errors.New("profile has neither an abstract nor a concrete policy")
 	}
 	return a.loadProfile(a.logger, profile.GetProfileName(), policy)
 }

--- a/internal/pkg/daemon/profilerecorder/profilerecorder.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder.go
@@ -56,7 +56,6 @@ import (
 	spodv1alpha1 "sigs.k8s.io/security-profiles-operator/api/spod/v1alpha1"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/controller"
-	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/apparmorprofile/crd2armor"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/bpfrecorder"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/enricher"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/metrics"
@@ -868,13 +867,6 @@ func (r *RecorderReconciler) collectApparmorBpfProfile(
 	spec := apparmorprofileapi.AppArmorProfileSpec{
 		Abstract: r.generateAppArmorProfileAbstract(response),
 	}
-
-	// Stored the raw profile in the required policy field.
-	policy, err := crd2armor.GenerateProfile(profileToCollect.name, &spec.Abstract)
-	if err != nil {
-		return nil, fmt.Errorf("generating raw apparmor profile: %w", err)
-	}
-	spec.Policy = policy
 
 	profile := &apparmorprofileapi.AppArmorProfile{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION


#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

This PR makes the `policy` field optional for AppArmor policies.

#### Which issue(s) this PR fixes:

#2388

#### Does this PR have test?

Covered by existing tests

#### Does this PR introduce a user-facing change?

```release-note
AppArmor profiles can now have either an abstract or a concrete policy.
```
