### PR TITLE
AppArmor: add locale.alias to known read prefixes

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/apparmor_filters.go
+++ b/internal/pkg/daemon/bpfrecorder/apparmor_filters.go
@@ -47,6 +47,7 @@ var knownReadPrefixes = []string{
 	"/sys/kernel/mm/transparent_hugepage/hpage_pmd_size",
 	"/usr/share/locale/",
 	"/usr/lib/locale/",
+	"/etc/locale.alias",
 }
 
 // List of known paths for commonly written to files.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

This makes our AppArmor profiles slightly cleaner.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A
#### Does this PR introduce a user-facing change?

```release-note
NONE
```
