### PR TITLE
AppArmor: Add read permission for executables

### DIFF
--- a/examples/apparmorprofile-sleep.yaml
+++ b/examples/apparmorprofile-sleep.yaml
@@ -6,7 +6,7 @@ policy: |2
 
     # Executable rules
 
-    /bin/busybox ix,
+    /bin/busybox ixr,
 
 
     /lib/ld-musl-x86_64.so.1 mr,

--- a/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
+++ b/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
@@ -32,7 +32,7 @@ profile {{.Name}} flags=(attach_disconnected,mediate_deleted) {
 
   # Executable rules
 {{ if ne .Abstract.Executable nil }}{{ if ne .Abstract.Executable.AllowedExecutables nil }}
-{{range $allowed := .Abstract.Executable.AllowedExecutables}}  {{$allowed}} ix,
+{{range $allowed := .Abstract.Executable.AllowedExecutables}}  {{$allowed}} ixr,
 {{end}}{{end}}
 {{ if ne .Abstract.Executable.AllowedLibraries nil }}
 {{range $allowedlib := .Abstract.Executable.AllowedLibraries}}  {{$allowedlib}} mr,


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Depending on how processes are spawned, `ix` is not enough and we also need to explicitly permit reading the executable.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fix a bug where recorded AppArmor profiles would prevent executables from spawning.
```
