### PR TITLE
Ignore `exit` syscall for runc base profile

### DIFF
--- a/hack/ci/e2e-seccomp.sh
+++ b/hack/ci/e2e-seccomp.sh
@@ -98,8 +98,8 @@ EOT
     k delete seccompprofile $RECORDING
   done
 
-  echo "Diffing output, while ignoring flaky syscalls 'rt_sigreturn', 'sched_yield' and 'tgkill'"
-  git diff --exit-code -U0 -I rt_sigreturn -I sched_yield -I tgkill examples
+  echo "Diffing output, while ignoring flaky syscalls 'rt_sigreturn', 'sched_yield', 'tgkill', and 'exit'"
+  git diff --exit-code -U0 -I rt_sigreturn -I sched_yield -I tgkill -I exit examples
 
   for RUNTIME in "${RUNTIMES[@]}"; do
     echo "Verifying that the profile for runtime $RUNTIME is available in the GitHub container registry"


### PR DESCRIPTION


#### What type of PR is this?
/kind failing-test

#### What this PR does / why we need it:
Recent runs flake because they either see or won't see the exit syscall. We now ignore it to stabilize the CI.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
