### PR TITLE
Improve the apparmor read-write file permissions to allow any file in a directory if already two files are allowed

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
@@ -63,3 +63,43 @@ func TestReplaceVarianceInFilePath(t *testing.T) {
 		})
 	}
 }
+
+func TestAllowAnyFiles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		paths []string
+		want  []string
+	}{
+		{
+			name:  "allow any files if at least two files are already allowed",
+			paths: []string{"/etc/nginx/conf.d/default.conf", "/dev/null", "/etc/nginx/conf.d/sedIWASqqq"},
+			want:  []string{"/etc/nginx/conf.d/*", "/dev/null"},
+		},
+		{
+			name: "allow any files if more than two files are already allowed",
+			paths: []string{"/etc/nginx/conf.d/default.conf", "/dev/null",
+				"/etc/nginx/conf.d/sedIWASqqq", "/etc/nginx/conf.d/abcd"},
+			want: []string{"/etc/nginx/conf.d/*", "/dev/null"},
+		},
+		{
+			name:  "do not allow any files ",
+			paths: []string{"/etc/nginx/conf.d/default.conf", "/dev/null"},
+			want:  []string{"/etc/nginx/conf.d/default.conf", "/dev/null"},
+		},
+		{
+			name:  "do not allow anything if nothing is allowed",
+			paths: []string{},
+			want:  []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := allowAnyFiles(test.paths)
+			require.Equal(t, test.want, got)
+		})
+	}
+}

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
@@ -79,8 +79,10 @@ func TestAllowAnyFiles(t *testing.T) {
 		},
 		{
 			name: "allow any files if more than two files are already allowed",
-			paths: []string{"/etc/nginx/conf.d/default.conf", "/dev/null",
-				"/etc/nginx/conf.d/sedIWASqqq", "/etc/nginx/conf.d/abcd"},
+			paths: []string{
+				"/etc/nginx/conf.d/default.conf", "/dev/null",
+				"/etc/nginx/conf.d/sedIWASqqq", "/etc/nginx/conf.d/abcd",
+			},
 			want: []string{"/etc/nginx/conf.d/*", "/dev/null"},
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

It improves the apparmor read-write file permissions to allow any files if at least two files are allowed. There
are binaries like nginx which typically creates files with random name on every start in the `/etc/nginx/conf.d/` directory. The random named files cannot be captured in advance and allowed in the apparmor profile, therefore any file needs to be allowed.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE

```
