### PR TITLE
Filter out unnecessary files from apparmor profile

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/apparmor_filters.go
+++ b/internal/pkg/daemon/bpfrecorder/apparmor_filters.go
@@ -54,3 +54,11 @@ var knownReadPrefixes = []string{
 var knownWritePrefixes = []string{
 	"/dev/log",
 }
+
+// excludedFilePrefixes of known file paths which should be filter out
+// from the apparmor profile.
+var excludedFilePrefixes = []string{
+	"/run/containerd/io.containerd.runtime.v2.task/k8s.io",
+	"/usr/bin/runc",
+	"/proc/@{pid}/attr/apparmor/exec",
+}

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
@@ -105,3 +105,42 @@ func TestAllowAnyFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestShouldExcludeFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		filePath string
+		want     bool
+	}{
+		{
+			name:     "Should exclude containerd file",
+			filePath: "/run/containerd/io.containerd.runtime.v2.task/k8s.io/1806f41e981228490db1cf974bcec4e137762e99f31d5fe81be3672baa5be2eb/rootfs",
+			want:     true,
+		},
+		{
+			name:     "Should exclude runc binary",
+			filePath: "/usr/bin/runc",
+			want:     true,
+		},
+		{
+			name:     "Should exclude apparmor/exec",
+			filePath: "/proc/@{pid}/attr/apparmor/exec",
+			want:     true,
+		},
+		{
+			name:     "Should not exclude normal files",
+			filePath: "/etc/group",
+			want:     false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			got := shouldExcludeFile(test.filePath)
+			require.Equal(t, test.want, got)
+		})
+	}
+}

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
@@ -116,7 +116,7 @@ func TestShouldExcludeFile(t *testing.T) {
 	}{
 		{
 			name:     "Should exclude containerd file",
-			filePath: "/run/containerd/io.containerd.runtime.v2.task/k8s.io/1806f41e981228490db1cf974bcec4e137762e99f31d5fe81be3672baa5be2eb/rootfs",
+			filePath: "/run/containerd/io.containerd.runtime.v2.task/k8s.io/1806f41e981228490db/rootfs",
 			want:     true,
 		},
 		{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Filter out unnecessary files from apparmor profile. These files are not required for the execution but they
are rather a side effect of recording the whole resources of a container runtime execution.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

partial fix for #2576

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Cleanup uncecessary files from a recorded apparmor profile.

```

cc @mhils 