### PR TITLE
MULTIARCH-4654: Enabled the Security Profiles Operator for ppc64le

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -23,15 +23,17 @@ USER root
 WORKDIR /work
 
 RUN dnf install -y \
-  libseccomp-devel
+  libseccomp-devel \
+  libbpf
 
 ADD . /work
 RUN mkdir -p build
 
 # Use latest golang
-RUN GO_VERSION=$(curl -sSfL "https://go.dev/VERSION?m=text" | head -n1) && \
-    curl -sSfL -o- https://go.dev/dl/$GO_VERSION.linux-amd64.tar.gz | \
-        tar xfz - -C /usr/local
+RUN ARCH=$(arch | sed 's|x86_64|amd64|g' | sed 's|aarch64|arm64|g') && \
+    GO_VERSION=$(curl -sSfL https://go.dev/VERSION?m=text | head -n1) && \
+    curl -sSfL https://go.dev/dl/${GO_VERSION}.linux-${ARCH}.tar.gz | \
+    tar -xzf - -C /usr/local
 ENV PATH="/usr/local/go/bin:$PATH"
 
 ARG APPARMOR_ENABLED=0
@@ -48,7 +50,8 @@ ARG version
 USER root
 
 RUN microdnf install -y \
-  libseccomp
+  libseccomp \
+  libbpf
 
 LABEL name="Security Profiles Operator" \
   version=$version \

--- a/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
+++ b/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
@@ -134,11 +134,54 @@ data:
   security-profiles-operator.json: |
     {
       "defaultAction": "SCMP_ACT_ERRNO",
-      "architectures": [
-        "SCMP_ARCH_X86_64",
-        "SCMP_ARCH_X86",
-        "SCMP_ARCH_X32",
-        "SCMP_ARCH_AARCH64"
+      "archMap": [
+        {
+          "architecture": "SCMP_ARCH_X86_64",
+          "subArchitectures": [
+            "SCMP_ARCH_X86",
+            "SCMP_ARCH_X32"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_AARCH64",
+          "subArchitectures": [
+            "SCMP_ARCH_ARM"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_MIPS64",
+          "subArchitectures": [
+            "SCMP_ARCH_MIPS",
+            "SCMP_ARCH_MIPS64N32"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_MIPS64N32",
+          "subArchitectures": [
+            "SCMP_ARCH_MIPS",
+            "SCMP_ARCH_MIPS64"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_MIPSEL64",
+          "subArchitectures": [
+            "SCMP_ARCH_MIPSEL",
+            "SCMP_ARCH_MIPSEL64N32"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_MIPSEL64N32",
+          "subArchitectures": [
+            "SCMP_ARCH_MIPSEL",
+            "SCMP_ARCH_MIPSEL64"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_S390X",
+          "subArchitectures": [
+            "SCMP_ARCH_S390"
+          ]
+        }
       ],
       "syscalls": [
         {
@@ -205,6 +248,7 @@ data:
             "setuid",
             "sigaltstack",
             "socket",
+            "stat",
             "statfs",
             "tgkill",
             "uname",

--- a/deploy/base/clusterserviceversion.yaml
+++ b/deploy/base/clusterserviceversion.yaml
@@ -11,6 +11,7 @@ metadata:
     operatorframework.io/suggested-namespace: security-profiles-operator
     operators.openshift.io/valid-subscription: '["OpenShift Kubernetes Engine", "OpenShift Container Platform", "OpenShift Platform Plus"]'
     operatorframework.io/cluster-monitoring: "true"
+    operatorframework.io/os.linux: supported
   name: security-profiles-operator.v0.0.0
   namespace: placeholder
 spec:

--- a/deploy/base/profiles/bpf-recorder.json
+++ b/deploy/base/profiles/bpf-recorder.json
@@ -1,10 +1,32 @@
 {
   "defaultAction": "SCMP_ACT_ERRNO",
-  "architectures": [
-    "SCMP_ARCH_X86_64",
-    "SCMP_ARCH_X86",
-    "SCMP_ARCH_X32",
-    "SCMP_ARCH_AARCH64"
+  "archMap": [
+    {
+      "architecture": "SCMP_ARCH_X86_64",
+      "subArchitectures": [
+        "SCMP_ARCH_X86",
+        "SCMP_ARCH_X32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_AARCH64",
+      "subArchitectures": [
+        "SCMP_ARCH_ARM"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_PPC64LE",
+      "subArchitectures": [
+        "SCMP_ARCH_PPC64",
+        "SCMP_ARCH_PPC"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_S390X",
+      "subArchitectures": [
+        "SCMP_ARCH_S390"
+      ]
+    }
   ],
   "syscalls": [
     {
@@ -78,6 +100,7 @@
         "setuid",
         "sigaltstack",
         "socket",
+        "stat",
         "statfs",
         "tgkill",
         "uname",

--- a/deploy/base/profiles/security-profiles-operator.json
+++ b/deploy/base/profiles/security-profiles-operator.json
@@ -1,11 +1,33 @@
 {
   "defaultAction": "SCMP_ACT_ERRNO",
-  "architectures": [
-    "SCMP_ARCH_X86_64",
-    "SCMP_ARCH_X86",
-    "SCMP_ARCH_X32",
-    "SCMP_ARCH_AARCH64"
-  ],
+    "archMap": [
+        {
+            "architecture": "SCMP_ARCH_X86_64",
+            "subArchitectures": [
+                "SCMP_ARCH_X86",
+                "SCMP_ARCH_X32"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_AARCH64",
+            "subArchitectures": [
+                "SCMP_ARCH_ARM"
+            ]
+        },
+        {
+        "architecture": "SCMP_ARCH_PPC64LE",
+            "subArchitectures": [
+                "SCMP_ARCH_PPC64",
+                "SCMP_ARCH_PPC"
+            ]
+        },
+        {
+            "architecture": "SCMP_ARCH_S390X",
+            "subArchitectures": [
+                "SCMP_ARCH_S390"
+            ]
+        }
+    ],
   "syscalls": [
     {
       "names": [
@@ -71,6 +93,7 @@
         "setuid",
         "sigaltstack",
         "socket",
+        "stat",
         "statfs",
         "tgkill",
         "uname",

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -689,11 +689,33 @@ data:
   bpf-recorder.json: |
     {
       "defaultAction": "SCMP_ACT_ERRNO",
-      "architectures": [
-        "SCMP_ARCH_X86_64",
-        "SCMP_ARCH_X86",
-        "SCMP_ARCH_X32",
-        "SCMP_ARCH_AARCH64"
+      "archMap": [
+        {
+          "architecture": "SCMP_ARCH_X86_64",
+          "subArchitectures": [
+            "SCMP_ARCH_X86",
+            "SCMP_ARCH_X32"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_AARCH64",
+          "subArchitectures": [
+            "SCMP_ARCH_ARM"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_PPC64LE",
+          "subArchitectures": [
+            "SCMP_ARCH_PPC64",
+            "SCMP_ARCH_PPC"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_S390X",
+          "subArchitectures": [
+            "SCMP_ARCH_S390"
+          ]
+        }
       ],
       "syscalls": [
         {
@@ -767,6 +789,7 @@ data:
             "setuid",
             "sigaltstack",
             "socket",
+            "stat",
             "statfs",
             "tgkill",
             "uname",
@@ -820,12 +843,34 @@ data:
   security-profiles-operator.json: |
     {
       "defaultAction": "SCMP_ACT_ERRNO",
-      "architectures": [
-        "SCMP_ARCH_X86_64",
-        "SCMP_ARCH_X86",
-        "SCMP_ARCH_X32",
-        "SCMP_ARCH_AARCH64"
-      ],
+        "archMap": [
+            {
+                "architecture": "SCMP_ARCH_X86_64",
+                "subArchitectures": [
+                    "SCMP_ARCH_X86",
+                    "SCMP_ARCH_X32"
+                ]
+            },
+            {
+                "architecture": "SCMP_ARCH_AARCH64",
+                "subArchitectures": [
+                    "SCMP_ARCH_ARM"
+                ]
+            },
+            {
+            "architecture": "SCMP_ARCH_PPC64LE",
+                "subArchitectures": [
+                    "SCMP_ARCH_PPC64",
+                    "SCMP_ARCH_PPC"
+                ]
+            },
+            {
+                "architecture": "SCMP_ARCH_S390X",
+                "subArchitectures": [
+                    "SCMP_ARCH_S390"
+                ]
+            }
+        ],
       "syscalls": [
         {
           "names": [
@@ -891,6 +936,7 @@ data:
             "setuid",
             "sigaltstack",
             "socket",
+            "stat",
             "statfs",
             "tgkill",
             "uname",

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2972,11 +2972,33 @@ data:
   bpf-recorder.json: |
     {
       "defaultAction": "SCMP_ACT_ERRNO",
-      "architectures": [
-        "SCMP_ARCH_X86_64",
-        "SCMP_ARCH_X86",
-        "SCMP_ARCH_X32",
-        "SCMP_ARCH_AARCH64"
+      "archMap": [
+        {
+          "architecture": "SCMP_ARCH_X86_64",
+          "subArchitectures": [
+            "SCMP_ARCH_X86",
+            "SCMP_ARCH_X32"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_AARCH64",
+          "subArchitectures": [
+            "SCMP_ARCH_ARM"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_PPC64LE",
+          "subArchitectures": [
+            "SCMP_ARCH_PPC64",
+            "SCMP_ARCH_PPC"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_S390X",
+          "subArchitectures": [
+            "SCMP_ARCH_S390"
+          ]
+        }
       ],
       "syscalls": [
         {
@@ -3050,6 +3072,7 @@ data:
             "setuid",
             "sigaltstack",
             "socket",
+            "stat",
             "statfs",
             "tgkill",
             "uname",
@@ -3103,12 +3126,34 @@ data:
   security-profiles-operator.json: |
     {
       "defaultAction": "SCMP_ACT_ERRNO",
-      "architectures": [
-        "SCMP_ARCH_X86_64",
-        "SCMP_ARCH_X86",
-        "SCMP_ARCH_X32",
-        "SCMP_ARCH_AARCH64"
-      ],
+        "archMap": [
+            {
+                "architecture": "SCMP_ARCH_X86_64",
+                "subArchitectures": [
+                    "SCMP_ARCH_X86",
+                    "SCMP_ARCH_X32"
+                ]
+            },
+            {
+                "architecture": "SCMP_ARCH_AARCH64",
+                "subArchitectures": [
+                    "SCMP_ARCH_ARM"
+                ]
+            },
+            {
+            "architecture": "SCMP_ARCH_PPC64LE",
+                "subArchitectures": [
+                    "SCMP_ARCH_PPC64",
+                    "SCMP_ARCH_PPC"
+                ]
+            },
+            {
+                "architecture": "SCMP_ARCH_S390X",
+                "subArchitectures": [
+                    "SCMP_ARCH_S390"
+                ]
+            }
+        ],
       "syscalls": [
         {
           "names": [
@@ -3174,6 +3219,7 @@ data:
             "setuid",
             "sigaltstack",
             "socket",
+            "stat",
             "statfs",
             "tgkill",
             "uname",

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -2954,11 +2954,33 @@ data:
   bpf-recorder.json: |
     {
       "defaultAction": "SCMP_ACT_ERRNO",
-      "architectures": [
-        "SCMP_ARCH_X86_64",
-        "SCMP_ARCH_X86",
-        "SCMP_ARCH_X32",
-        "SCMP_ARCH_AARCH64"
+      "archMap": [
+        {
+          "architecture": "SCMP_ARCH_X86_64",
+          "subArchitectures": [
+            "SCMP_ARCH_X86",
+            "SCMP_ARCH_X32"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_AARCH64",
+          "subArchitectures": [
+            "SCMP_ARCH_ARM"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_PPC64LE",
+          "subArchitectures": [
+            "SCMP_ARCH_PPC64",
+            "SCMP_ARCH_PPC"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_S390X",
+          "subArchitectures": [
+            "SCMP_ARCH_S390"
+          ]
+        }
       ],
       "syscalls": [
         {
@@ -3032,6 +3054,7 @@ data:
             "setuid",
             "sigaltstack",
             "socket",
+            "stat",
             "statfs",
             "tgkill",
             "uname",
@@ -3085,12 +3108,34 @@ data:
   security-profiles-operator.json: |
     {
       "defaultAction": "SCMP_ACT_ERRNO",
-      "architectures": [
-        "SCMP_ARCH_X86_64",
-        "SCMP_ARCH_X86",
-        "SCMP_ARCH_X32",
-        "SCMP_ARCH_AARCH64"
-      ],
+        "archMap": [
+            {
+                "architecture": "SCMP_ARCH_X86_64",
+                "subArchitectures": [
+                    "SCMP_ARCH_X86",
+                    "SCMP_ARCH_X32"
+                ]
+            },
+            {
+                "architecture": "SCMP_ARCH_AARCH64",
+                "subArchitectures": [
+                    "SCMP_ARCH_ARM"
+                ]
+            },
+            {
+            "architecture": "SCMP_ARCH_PPC64LE",
+                "subArchitectures": [
+                    "SCMP_ARCH_PPC64",
+                    "SCMP_ARCH_PPC"
+                ]
+            },
+            {
+                "architecture": "SCMP_ARCH_S390X",
+                "subArchitectures": [
+                    "SCMP_ARCH_S390"
+                ]
+            }
+        ],
       "syscalls": [
         {
           "names": [
@@ -3156,6 +3201,7 @@ data:
             "setuid",
             "sigaltstack",
             "socket",
+            "stat",
             "statfs",
             "tgkill",
             "uname",

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -2985,11 +2985,33 @@ data:
   bpf-recorder.json: |
     {
       "defaultAction": "SCMP_ACT_ERRNO",
-      "architectures": [
-        "SCMP_ARCH_X86_64",
-        "SCMP_ARCH_X86",
-        "SCMP_ARCH_X32",
-        "SCMP_ARCH_AARCH64"
+      "archMap": [
+        {
+          "architecture": "SCMP_ARCH_X86_64",
+          "subArchitectures": [
+            "SCMP_ARCH_X86",
+            "SCMP_ARCH_X32"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_AARCH64",
+          "subArchitectures": [
+            "SCMP_ARCH_ARM"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_PPC64LE",
+          "subArchitectures": [
+            "SCMP_ARCH_PPC64",
+            "SCMP_ARCH_PPC"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_S390X",
+          "subArchitectures": [
+            "SCMP_ARCH_S390"
+          ]
+        }
       ],
       "syscalls": [
         {
@@ -3063,6 +3085,7 @@ data:
             "setuid",
             "sigaltstack",
             "socket",
+            "stat",
             "statfs",
             "tgkill",
             "uname",
@@ -3116,12 +3139,34 @@ data:
   security-profiles-operator.json: |
     {
       "defaultAction": "SCMP_ACT_ERRNO",
-      "architectures": [
-        "SCMP_ARCH_X86_64",
-        "SCMP_ARCH_X86",
-        "SCMP_ARCH_X32",
-        "SCMP_ARCH_AARCH64"
-      ],
+        "archMap": [
+            {
+                "architecture": "SCMP_ARCH_X86_64",
+                "subArchitectures": [
+                    "SCMP_ARCH_X86",
+                    "SCMP_ARCH_X32"
+                ]
+            },
+            {
+                "architecture": "SCMP_ARCH_AARCH64",
+                "subArchitectures": [
+                    "SCMP_ARCH_ARM"
+                ]
+            },
+            {
+            "architecture": "SCMP_ARCH_PPC64LE",
+                "subArchitectures": [
+                    "SCMP_ARCH_PPC64",
+                    "SCMP_ARCH_PPC"
+                ]
+            },
+            {
+                "architecture": "SCMP_ARCH_S390X",
+                "subArchitectures": [
+                    "SCMP_ARCH_S390"
+                ]
+            }
+        ],
       "syscalls": [
         {
           "names": [
@@ -3187,6 +3232,7 @@ data:
             "setuid",
             "sigaltstack",
             "socket",
+            "stat",
             "statfs",
             "tgkill",
             "uname",

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2972,11 +2972,33 @@ data:
   bpf-recorder.json: |
     {
       "defaultAction": "SCMP_ACT_ERRNO",
-      "architectures": [
-        "SCMP_ARCH_X86_64",
-        "SCMP_ARCH_X86",
-        "SCMP_ARCH_X32",
-        "SCMP_ARCH_AARCH64"
+      "archMap": [
+        {
+          "architecture": "SCMP_ARCH_X86_64",
+          "subArchitectures": [
+            "SCMP_ARCH_X86",
+            "SCMP_ARCH_X32"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_AARCH64",
+          "subArchitectures": [
+            "SCMP_ARCH_ARM"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_PPC64LE",
+          "subArchitectures": [
+            "SCMP_ARCH_PPC64",
+            "SCMP_ARCH_PPC"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_S390X",
+          "subArchitectures": [
+            "SCMP_ARCH_S390"
+          ]
+        }
       ],
       "syscalls": [
         {
@@ -3050,6 +3072,7 @@ data:
             "setuid",
             "sigaltstack",
             "socket",
+            "stat",
             "statfs",
             "tgkill",
             "uname",
@@ -3103,12 +3126,34 @@ data:
   security-profiles-operator.json: |
     {
       "defaultAction": "SCMP_ACT_ERRNO",
-      "architectures": [
-        "SCMP_ARCH_X86_64",
-        "SCMP_ARCH_X86",
-        "SCMP_ARCH_X32",
-        "SCMP_ARCH_AARCH64"
-      ],
+        "archMap": [
+            {
+                "architecture": "SCMP_ARCH_X86_64",
+                "subArchitectures": [
+                    "SCMP_ARCH_X86",
+                    "SCMP_ARCH_X32"
+                ]
+            },
+            {
+                "architecture": "SCMP_ARCH_AARCH64",
+                "subArchitectures": [
+                    "SCMP_ARCH_ARM"
+                ]
+            },
+            {
+            "architecture": "SCMP_ARCH_PPC64LE",
+                "subArchitectures": [
+                    "SCMP_ARCH_PPC64",
+                    "SCMP_ARCH_PPC"
+                ]
+            },
+            {
+                "architecture": "SCMP_ARCH_S390X",
+                "subArchitectures": [
+                    "SCMP_ARCH_S390"
+                ]
+            }
+        ],
       "syscalls": [
         {
           "names": [
@@ -3174,6 +3219,7 @@ data:
             "setuid",
             "sigaltstack",
             "socket",
+            "stat",
             "statfs",
             "tgkill",
             "uname",

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -2943,11 +2943,33 @@ data:
   bpf-recorder.json: |
     {
       "defaultAction": "SCMP_ACT_ERRNO",
-      "architectures": [
-        "SCMP_ARCH_X86_64",
-        "SCMP_ARCH_X86",
-        "SCMP_ARCH_X32",
-        "SCMP_ARCH_AARCH64"
+      "archMap": [
+        {
+          "architecture": "SCMP_ARCH_X86_64",
+          "subArchitectures": [
+            "SCMP_ARCH_X86",
+            "SCMP_ARCH_X32"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_AARCH64",
+          "subArchitectures": [
+            "SCMP_ARCH_ARM"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_PPC64LE",
+          "subArchitectures": [
+            "SCMP_ARCH_PPC64",
+            "SCMP_ARCH_PPC"
+          ]
+        },
+        {
+          "architecture": "SCMP_ARCH_S390X",
+          "subArchitectures": [
+            "SCMP_ARCH_S390"
+          ]
+        }
       ],
       "syscalls": [
         {
@@ -3021,6 +3043,7 @@ data:
             "setuid",
             "sigaltstack",
             "socket",
+            "stat",
             "statfs",
             "tgkill",
             "uname",
@@ -3074,12 +3097,34 @@ data:
   security-profiles-operator.json: |
     {
       "defaultAction": "SCMP_ACT_ERRNO",
-      "architectures": [
-        "SCMP_ARCH_X86_64",
-        "SCMP_ARCH_X86",
-        "SCMP_ARCH_X32",
-        "SCMP_ARCH_AARCH64"
-      ],
+        "archMap": [
+            {
+                "architecture": "SCMP_ARCH_X86_64",
+                "subArchitectures": [
+                    "SCMP_ARCH_X86",
+                    "SCMP_ARCH_X32"
+                ]
+            },
+            {
+                "architecture": "SCMP_ARCH_AARCH64",
+                "subArchitectures": [
+                    "SCMP_ARCH_ARM"
+                ]
+            },
+            {
+            "architecture": "SCMP_ARCH_PPC64LE",
+                "subArchitectures": [
+                    "SCMP_ARCH_PPC64",
+                    "SCMP_ARCH_PPC"
+                ]
+            },
+            {
+                "architecture": "SCMP_ARCH_S390X",
+                "subArchitectures": [
+                    "SCMP_ARCH_S390"
+                ]
+            }
+        ],
       "syscalls": [
         {
           "names": [
@@ -3145,6 +3190,7 @@ data:
             "setuid",
             "sigaltstack",
             "socket",
+            "stat",
             "statfs",
             "tgkill",
             "uname",

--- a/hack/image-cross.sh
+++ b/hack/image-cross.sh
@@ -22,7 +22,7 @@ REGISTRY=gcr.io/k8s-staging-sp-operator
 IMAGE=$REGISTRY/security-profiles-operator
 TAG=${TAG:-$(git describe --tags --always --dirty)}
 
-ARCHES=(amd64 arm64)
+ARCHES=(amd64 arm64 ppc64le s390x)
 VERSION=v$(cat VERSION)
 TAGS=("$TAG" "$VERSION" latest)
 

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
@@ -781,24 +781,6 @@ func (b *BpfRecorder) findBtfPath() (string, error) {
 	return file.Name(), nil
 }
 
-func toStringInt8(array [65]int8) string {
-	var buf [65]byte
-	for i, b := range array {
-		buf[i] = byte(b)
-	}
-
-	return toStringByte(buf[:])
-}
-
-func toStringByte(array []byte) string {
-	str := string(array)
-	if i := strings.Index(str, "\x00"); i != -1 {
-		str = str[:i]
-	}
-
-	return str
-}
-
 func (b *BpfRecorder) processEvents(events chan []byte) {
 	b.logger.Info("Processing bpf events")
 	defer b.logger.Info("Stopped processing bpf events")

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_util_default.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_util_default.go
@@ -1,0 +1,53 @@
+//go:build linux && !no_bpf && !ppc64le && !s390x
+// +build linux,!no_bpf,!ppc64le,!s390x
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bpfrecorder
+
+import (
+	"strings"
+	"syscall"
+)
+
+// UnameMachineToString converts uname.Machine to a string for amd64.
+func UnameMachineToString(uname *syscall.Utsname) string {
+	return toStringInt8(uname.Machine)
+}
+
+// UnameReleaseToString converts uname.Release to a string for amd64.
+func UnameReleaseToString(uname *syscall.Utsname) string {
+	return toStringInt8(uname.Release)
+}
+
+func toStringInt8(array [65]int8) string {
+	var buf [65]byte
+	for i, b := range array {
+		buf[i] = byte(b)
+	}
+
+	return toStringByte(buf[:])
+}
+
+func toStringByte(array []byte) string {
+	str := string(array)
+	if i := strings.Index(str, "\x00"); i != -1 {
+		str = str[:i]
+	}
+
+	return str
+}

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_util_linux_ppc64le.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_util_linux_ppc64le.go
@@ -1,0 +1,44 @@
+//go:build ppc64le && linux
+// +build ppc64le,linux
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bpfrecorder
+
+import "syscall"
+
+// UnameMachineToString converts uname.Machine to a string for s390x/ppc64le.
+func UnameMachineToString(uname *syscall.Utsname) string {
+	return toStringUint8P(uname.Machine)
+}
+
+// UnameReleaseToString converts uname.Release to a string for s390x/ppc64le.
+func UnameReleaseToString(uname *syscall.Utsname) string {
+	return toStringUint8P(uname.Release)
+}
+
+// Helper function to convert [65]uint8 to string.
+func toStringUint8P(array [65]uint8) string {
+	n := 0
+	for i, v := range array {
+		if v == 0 {
+			n = i
+			break
+		}
+	}
+	return string(array[:n])
+}

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_util_linux_s390x.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_util_linux_s390x.go
@@ -1,0 +1,47 @@
+//go:build s390x && linux
+// +build s390x,linux
+
+/*
+Copyright 2024 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bpfrecorder
+
+import (
+	"strings"
+	"syscall"
+)
+
+// UnameMachineToString converts uname.Machine to a string for s390x/ppc64le.
+func UnameMachineToString(uname *syscall.Utsname) string {
+	return toStringUint8Z(uname.Machine)
+}
+
+// UnameReleaseToString converts uname.Release to a string for s390x/ppc64le.
+func UnameReleaseToString(uname *syscall.Utsname) string {
+	return toStringUint8Z(uname.Release)
+}
+
+// Helper function to convert [65]uint8 to string.
+func toStringUint8Z(array [65]uint8) string {
+	n := 0
+	for i, v := range array {
+		if v == 0 {
+			n = i
+			break
+		}
+	}
+	return string(array[:n])
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -341,6 +341,8 @@ func (e *e2e) deployOperator(manifest string) {
 	e.waitForSpod()
 	e.waitInOperatorNSFor("condition=initialized", "pod", "-l", "name=spod")
 	e.waitInOperatorNSFor("condition=ready", "pod", "-l", "name=spod")
+	// Execute the kubectl command to fetch logs from SPOD pods
+	e.kubectl("logs", "-l", "spod-labels")
 	// Wait for spod to be available
 	for {
 		if res, err := command.New(


### PR DESCRIPTION
#### What type of PR is this? 
/kind feature

#### What this PR does / why we need it:
This PR enables the Security Profiles Operator for the ppc64le architecture, providing support for managing seccomp and SELinux profiles. The changes have been tested and verified using logenricher to ensure functionality and compliance.

#### Which issue(s) this PR fixes: https://issues.redhat.com/browse/MULTIARCH-4654

#### Does this PR have test?
N/A

#### Special notes for your reviewer:
- Tested for compatibility with seccomp and SELinux profiles on the ppc64le architecture.
- Verified functionality using logenricher.

#### Does this PR introduce a user-facing change?

```release-note
Enabled the Security Profiles Operator for `ppc64le` architecture with support for seccomp and SELinux profile management.
```