### PR TITLE
Overwrite only some settings in the security context when apparmor is enabled

### DIFF
--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -576,15 +576,14 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 	if cfg.Spec.EnableAppArmor {
 		falsely, truly := false, true
 		var userRoot int64
-		// a more privileged mode is required when apparmor is enabled
+		// A more privileged mode is required when apparmor is enabled.
 		// TODO: review security model and provide a dynamic approach that can be case specific
-		templateSpec.Containers[bindata.ContainerIDDaemon].SecurityContext = &corev1.SecurityContext{
-			AllowPrivilegeEscalation: &truly,
-			Privileged:               &truly,
-			ReadOnlyRootFilesystem:   &falsely,
-			RunAsUser:                &userRoot,
-			RunAsGroup:               &userRoot,
-		}
+		sc := templateSpec.Containers[bindata.ContainerIDDaemon].SecurityContext
+		sc.AllowPrivilegeEscalation = &truly
+		sc.Privileged = &truly
+		sc.ReadOnlyRootFilesystem = &falsely
+		sc.RunAsUser = &userRoot
+		sc.RunAsGroup = &userRoot
 
 		templateSpec.Containers[bindata.ContainerIDDaemon].Args = append(
 			templateSpec.Containers[bindata.ContainerIDDaemon].Args,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

It seems that the daemon container runs without the local seccomp profile in the security
context because is overwritten by the apparmor config.

It should overwrite only some settings in the security context when apparmor is enabled
in order to keep the local seccomp profile in the security context.


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix the daemon container security context to keep the local seccomp profile.
```
