### PR TITLE
Extract all cert-manager resources in static manifests

### DIFF
--- a/deploy/overlays/webhook/kustomization.yaml
+++ b/deploy/overlays/webhook/kustomization.yaml
@@ -15,9 +15,11 @@ patches:
 - path: deployment.yaml
 
 resources:
+- webhook_issuer.yaml
 - webhook_cert.yaml
 - webhook_deployment.yaml
 - webhook_service.yaml
+- metrics_cert.yaml
 - ../cluster
 
 images:

--- a/deploy/overlays/webhook/metrics_cert.yaml
+++ b/deploy/overlays/webhook/metrics_cert.yaml
@@ -1,0 +1,20 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: metrics-cert
+  namespace: security-profiles-operator
+  labels:
+    app: security-profiles-operator
+spec:
+  dnsNames:
+  - metrics.security-profiles-operator
+  - metrics.security-profiles-operator.svc
+  - metrics.security-profiles-operator.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert
+  subject:
+    organizations:
+    - security-profiles-operator

--- a/deploy/overlays/webhook/webhook_issuer.yaml
+++ b/deploy/overlays/webhook/webhook_issuer.yaml
@@ -1,0 +1,10 @@
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: selfsigned-issuer
+  namespace: security-profiles-operator
+  labels:
+    app: security-profiles-operator
+spec:
+  selfSigned: {}

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3289,6 +3289,26 @@ kind: Certificate
 metadata:
   labels:
     app: security-profiles-operator
+  name: metrics-cert
+  namespace: security-profiles-operator
+spec:
+  dnsNames:
+  - metrics.security-profiles-operator
+  - metrics.security-profiles-operator.svc
+  - metrics.security-profiles-operator.svc.cluster.local
+  issuerRef:
+    kind: Issuer
+    name: selfsigned-issuer
+  secretName: metrics-server-cert
+  subject:
+    organizations:
+    - security-profiles-operator
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  labels:
+    app: security-profiles-operator
   name: webhook-cert
   namespace: security-profiles-operator
 spec:
@@ -3299,6 +3319,16 @@ spec:
     kind: Issuer
     name: selfsigned-issuer
   secretName: webhook-server-cert
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  labels:
+    app: security-profiles-operator
+  name: selfsigned-issuer
+  namespace: security-profiles-operator
+spec:
+  selfSigned: {}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind cleanup

#### What this PR does / why we need it:

Extract all resources created for cert-manager in static manifests in the static webhook deployment.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

None

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
N/A

```
