### PR TITLE
BPF Recorder: load bpf program on startup to win race with container startup

### DIFF
--- a/examples/apparmorprofile-sleep-crun.yaml
+++ b/examples/apparmorprofile-sleep-crun.yaml
@@ -16,7 +16,6 @@ spec:
         - mknod
         - setgid
         - setpcap
-        - setuid
         - sys_admin
     executable:
       allowedExecutables:
@@ -25,13 +24,11 @@ spec:
         - /lib/ld-musl-x86_64.so.1
     filesystem:
       readOnlyPaths:
-        - /etc/group
         - /etc/passwd
         - /proc/@{pid}/cgroup
         - /proc/@{pid}/mounts
         - /proc/@{pid}/setgroups
         - /proc/@{pid}/task/@{tid}/attr/apparmor/current
-        - /proc/@{pid}/task/@{tid}/fd/**
         - /proc/@{pid}/uid_map
         - /proc/sys/kernel/cap_last_cap
         - /run/**

--- a/internal/pkg/cli/recorder/impl.go
+++ b/internal/pkg/cli/recorder/impl.go
@@ -43,7 +43,8 @@ type defaultImpl struct{}
 //counterfeiter:generate . impl
 type impl interface {
 	LoadBpfRecorder(*bpfrecorder.BpfRecorder) error
-	UnloadBpfRecorder(*bpfrecorder.BpfRecorder)
+	StartBpfRecording(*bpfrecorder.BpfRecorder) error
+	StopBpfRecording(*bpfrecorder.BpfRecorder) error
 	BPFLSMEnabled() bool
 	CommandRun(*command.Command) (uint32, error)
 	CommandWait(*command.Command) error
@@ -62,11 +63,15 @@ type impl interface {
 }
 
 func (*defaultImpl) LoadBpfRecorder(b *bpfrecorder.BpfRecorder) error {
-	return b.Load(true)
+	return b.Load()
 }
 
-func (*defaultImpl) UnloadBpfRecorder(b *bpfrecorder.BpfRecorder) {
-	b.Unload()
+func (*defaultImpl) StartBpfRecording(b *bpfrecorder.BpfRecorder) error {
+	return b.StartRecording()
+}
+
+func (*defaultImpl) StopBpfRecording(b *bpfrecorder.BpfRecorder) error {
+	return b.StopRecording()
 }
 
 func (*defaultImpl) BPFLSMEnabled() bool {

--- a/internal/pkg/cli/recorder/recorder.go
+++ b/internal/pkg/cli/recorder/recorder.go
@@ -96,7 +96,15 @@ func (r *Recorder) Run() error {
 	if err := r.LoadBpfRecorder(r.bpfRecorder); err != nil {
 		return fmt.Errorf("load: %w", err)
 	}
-	defer r.UnloadBpfRecorder(r.bpfRecorder)
+	if err := r.StartBpfRecording(r.bpfRecorder); err != nil {
+		return fmt.Errorf("record: %w", err)
+	}
+	defer func(r *Recorder, recorder *bpfrecorder.BpfRecorder) {
+		err := r.StopBpfRecording(recorder)
+		if err != nil {
+			log.Println(fmt.Errorf("stop BPF recording: %w", err))
+		}
+	}(r, r.bpfRecorder)
 
 	var mntns uint32
 	if r.options.noProcStart {

--- a/internal/pkg/cli/recorder/recorderfakes/fake_impl.go
+++ b/internal/pkg/cli/recorder/recorderfakes/fake_impl.go
@@ -190,6 +190,28 @@ type FakeImpl struct {
 	printObjReturnsOnCall map[int]struct {
 		result1 error
 	}
+	StartBpfRecordingStub        func(*bpfrecorder.BpfRecorder) error
+	startBpfRecordingMutex       sync.RWMutex
+	startBpfRecordingArgsForCall []struct {
+		arg1 *bpfrecorder.BpfRecorder
+	}
+	startBpfRecordingReturns struct {
+		result1 error
+	}
+	startBpfRecordingReturnsOnCall map[int]struct {
+		result1 error
+	}
+	StopBpfRecordingStub        func(*bpfrecorder.BpfRecorder) error
+	stopBpfRecordingMutex       sync.RWMutex
+	stopBpfRecordingArgsForCall []struct {
+		arg1 *bpfrecorder.BpfRecorder
+	}
+	stopBpfRecordingReturns struct {
+		result1 error
+	}
+	stopBpfRecordingReturnsOnCall map[int]struct {
+		result1 error
+	}
 	SyscallsGetValueStub        func(*bpfrecorder.BpfRecorder, uint32) ([]byte, error)
 	syscallsGetValueMutex       sync.RWMutex
 	syscallsGetValueArgsForCall []struct {
@@ -214,11 +236,6 @@ type FakeImpl struct {
 	}
 	syscallsIteratorReturnsOnCall map[int]struct {
 		result1 *libbpfgo.BPFMapIterator
-	}
-	UnloadBpfRecorderStub        func(*bpfrecorder.BpfRecorder)
-	unloadBpfRecorderMutex       sync.RWMutex
-	unloadBpfRecorderArgsForCall []struct {
-		arg1 *bpfrecorder.BpfRecorder
 	}
 	WaitForPidExitStub        func(*bpfrecorder.BpfRecorder, context.Context, uint32) error
 	waitForPidExitMutex       sync.RWMutex
@@ -1017,6 +1034,128 @@ func (fake *FakeImpl) PrintObjReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeImpl) StartBpfRecording(arg1 *bpfrecorder.BpfRecorder) error {
+	fake.startBpfRecordingMutex.Lock()
+	ret, specificReturn := fake.startBpfRecordingReturnsOnCall[len(fake.startBpfRecordingArgsForCall)]
+	fake.startBpfRecordingArgsForCall = append(fake.startBpfRecordingArgsForCall, struct {
+		arg1 *bpfrecorder.BpfRecorder
+	}{arg1})
+	stub := fake.StartBpfRecordingStub
+	fakeReturns := fake.startBpfRecordingReturns
+	fake.recordInvocation("StartBpfRecording", []interface{}{arg1})
+	fake.startBpfRecordingMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) StartBpfRecordingCallCount() int {
+	fake.startBpfRecordingMutex.RLock()
+	defer fake.startBpfRecordingMutex.RUnlock()
+	return len(fake.startBpfRecordingArgsForCall)
+}
+
+func (fake *FakeImpl) StartBpfRecordingCalls(stub func(*bpfrecorder.BpfRecorder) error) {
+	fake.startBpfRecordingMutex.Lock()
+	defer fake.startBpfRecordingMutex.Unlock()
+	fake.StartBpfRecordingStub = stub
+}
+
+func (fake *FakeImpl) StartBpfRecordingArgsForCall(i int) *bpfrecorder.BpfRecorder {
+	fake.startBpfRecordingMutex.RLock()
+	defer fake.startBpfRecordingMutex.RUnlock()
+	argsForCall := fake.startBpfRecordingArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImpl) StartBpfRecordingReturns(result1 error) {
+	fake.startBpfRecordingMutex.Lock()
+	defer fake.startBpfRecordingMutex.Unlock()
+	fake.StartBpfRecordingStub = nil
+	fake.startBpfRecordingReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) StartBpfRecordingReturnsOnCall(i int, result1 error) {
+	fake.startBpfRecordingMutex.Lock()
+	defer fake.startBpfRecordingMutex.Unlock()
+	fake.StartBpfRecordingStub = nil
+	if fake.startBpfRecordingReturnsOnCall == nil {
+		fake.startBpfRecordingReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.startBpfRecordingReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) StopBpfRecording(arg1 *bpfrecorder.BpfRecorder) error {
+	fake.stopBpfRecordingMutex.Lock()
+	ret, specificReturn := fake.stopBpfRecordingReturnsOnCall[len(fake.stopBpfRecordingArgsForCall)]
+	fake.stopBpfRecordingArgsForCall = append(fake.stopBpfRecordingArgsForCall, struct {
+		arg1 *bpfrecorder.BpfRecorder
+	}{arg1})
+	stub := fake.StopBpfRecordingStub
+	fakeReturns := fake.stopBpfRecordingReturns
+	fake.recordInvocation("StopBpfRecording", []interface{}{arg1})
+	fake.stopBpfRecordingMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) StopBpfRecordingCallCount() int {
+	fake.stopBpfRecordingMutex.RLock()
+	defer fake.stopBpfRecordingMutex.RUnlock()
+	return len(fake.stopBpfRecordingArgsForCall)
+}
+
+func (fake *FakeImpl) StopBpfRecordingCalls(stub func(*bpfrecorder.BpfRecorder) error) {
+	fake.stopBpfRecordingMutex.Lock()
+	defer fake.stopBpfRecordingMutex.Unlock()
+	fake.StopBpfRecordingStub = stub
+}
+
+func (fake *FakeImpl) StopBpfRecordingArgsForCall(i int) *bpfrecorder.BpfRecorder {
+	fake.stopBpfRecordingMutex.RLock()
+	defer fake.stopBpfRecordingMutex.RUnlock()
+	argsForCall := fake.stopBpfRecordingArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImpl) StopBpfRecordingReturns(result1 error) {
+	fake.stopBpfRecordingMutex.Lock()
+	defer fake.stopBpfRecordingMutex.Unlock()
+	fake.StopBpfRecordingStub = nil
+	fake.stopBpfRecordingReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) StopBpfRecordingReturnsOnCall(i int, result1 error) {
+	fake.stopBpfRecordingMutex.Lock()
+	defer fake.stopBpfRecordingMutex.Unlock()
+	fake.StopBpfRecordingStub = nil
+	if fake.stopBpfRecordingReturnsOnCall == nil {
+		fake.stopBpfRecordingReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.stopBpfRecordingReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeImpl) SyscallsGetValue(arg1 *bpfrecorder.BpfRecorder, arg2 uint32) ([]byte, error) {
 	fake.syscallsGetValueMutex.Lock()
 	ret, specificReturn := fake.syscallsGetValueReturnsOnCall[len(fake.syscallsGetValueArgsForCall)]
@@ -1143,38 +1282,6 @@ func (fake *FakeImpl) SyscallsIteratorReturnsOnCall(i int, result1 *libbpfgo.BPF
 	}{result1}
 }
 
-func (fake *FakeImpl) UnloadBpfRecorder(arg1 *bpfrecorder.BpfRecorder) {
-	fake.unloadBpfRecorderMutex.Lock()
-	fake.unloadBpfRecorderArgsForCall = append(fake.unloadBpfRecorderArgsForCall, struct {
-		arg1 *bpfrecorder.BpfRecorder
-	}{arg1})
-	stub := fake.UnloadBpfRecorderStub
-	fake.recordInvocation("UnloadBpfRecorder", []interface{}{arg1})
-	fake.unloadBpfRecorderMutex.Unlock()
-	if stub != nil {
-		fake.UnloadBpfRecorderStub(arg1)
-	}
-}
-
-func (fake *FakeImpl) UnloadBpfRecorderCallCount() int {
-	fake.unloadBpfRecorderMutex.RLock()
-	defer fake.unloadBpfRecorderMutex.RUnlock()
-	return len(fake.unloadBpfRecorderArgsForCall)
-}
-
-func (fake *FakeImpl) UnloadBpfRecorderCalls(stub func(*bpfrecorder.BpfRecorder)) {
-	fake.unloadBpfRecorderMutex.Lock()
-	defer fake.unloadBpfRecorderMutex.Unlock()
-	fake.UnloadBpfRecorderStub = stub
-}
-
-func (fake *FakeImpl) UnloadBpfRecorderArgsForCall(i int) *bpfrecorder.BpfRecorder {
-	fake.unloadBpfRecorderMutex.RLock()
-	defer fake.unloadBpfRecorderMutex.RUnlock()
-	argsForCall := fake.unloadBpfRecorderArgsForCall[i]
-	return argsForCall.arg1
-}
-
 func (fake *FakeImpl) WaitForPidExit(arg1 *bpfrecorder.BpfRecorder, arg2 context.Context, arg3 uint32) error {
 	fake.waitForPidExitMutex.Lock()
 	ret, specificReturn := fake.waitForPidExitReturnsOnCall[len(fake.waitForPidExitArgsForCall)]
@@ -1267,12 +1374,14 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.notifyMutex.RUnlock()
 	fake.printObjMutex.RLock()
 	defer fake.printObjMutex.RUnlock()
+	fake.startBpfRecordingMutex.RLock()
+	defer fake.startBpfRecordingMutex.RUnlock()
+	fake.stopBpfRecordingMutex.RLock()
+	defer fake.stopBpfRecordingMutex.RUnlock()
 	fake.syscallsGetValueMutex.RLock()
 	defer fake.syscallsGetValueMutex.RUnlock()
 	fake.syscallsIteratorMutex.RLock()
 	defer fake.syscallsIteratorMutex.RUnlock()
-	fake.unloadBpfRecorderMutex.RLock()
-	defer fake.unloadBpfRecorderMutex.RUnlock()
 	fake.waitForPidExitMutex.RLock()
 	defer fake.waitForPidExitMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/internal/pkg/daemon/bpfrecorder/bpf_program_collection.go
+++ b/internal/pkg/daemon/bpfrecorder/bpf_program_collection.go
@@ -1,0 +1,88 @@
+//go:build linux && !no_bpf
+// +build linux,!no_bpf
+
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bpfrecorder
+
+import (
+	"fmt"
+
+	bpf "github.com/aquasecurity/libbpfgo"
+	"github.com/go-logr/logr"
+)
+
+type bpfProgram struct {
+	name string
+	prog *bpf.BPFProg
+	link *bpf.BPFLink
+}
+
+// This struct holds a set of bpf programs so that they be quickly attached and detached.
+// We want to minimize the time that takes because it races with container startup,
+// and we want to make sure that we catch the entire container lifecycle.
+type bpfProgramCollection struct {
+	logger   logr.Logger
+	programs []bpfProgram
+}
+
+func newProgramCollection(
+	r *BpfRecorder,
+	logger logr.Logger,
+	module *bpf.Module,
+	programNames []string,
+) (*bpfProgramCollection, error) {
+	programs := make([]bpfProgram, len(programNames))
+	for i, name := range programNames {
+		prog, err := r.GetProgram(module, name)
+		if err != nil {
+			return nil, fmt.Errorf("get bpf program %s: %w", name, err)
+		}
+		programs[i] = bpfProgram{
+			name: name,
+			prog: prog,
+			link: nil,
+		}
+	}
+	return &bpfProgramCollection{
+		logger:   logger,
+		programs: programs,
+	}, nil
+}
+
+func (b *bpfProgramCollection) attachAll(r *BpfRecorder) error {
+	var err error
+	for i := range b.programs {
+		b.programs[i].link, err = r.AttachGeneric(b.programs[i].prog)
+		if err != nil {
+			return fmt.Errorf("attach bpf program %s: %w", b.programs[i].name, err)
+		}
+		b.logger.Info("attached bpf program", "name", b.programs[i].name)
+	}
+	return err
+}
+
+func (b *bpfProgramCollection) detachAll(r *BpfRecorder) error {
+	for i := range b.programs {
+		if err := r.DestroyLink(b.programs[i].link); err != nil {
+			return fmt.Errorf("detach bpf program %s: %w", b.programs[i].name, err)
+		}
+		b.programs[i].link = nil
+		b.logger.Info("detached bpf program", "name", b.programs[i].name)
+	}
+	return nil
+}

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
@@ -86,10 +86,11 @@ type BpfRecorder struct {
 	nodeName                string
 	clientset               *kubernetes.Clientset
 	excludeMountNamespace   uint32
-	loadUnloadMutex         sync.RWMutex
+	attachUnattachMutex     sync.RWMutex
 	metricsClient           apimetrics.Metrics_BpfIncClient
 	programName             string
 	module                  *bpf.Module
+	bpfPrograms             *bpfProgramCollection
 
 	AppArmor *AppArmorRecorder
 	Seccomp  *SeccompRecorder
@@ -127,7 +128,7 @@ func New(programName string, logger logr.Logger, recordSeccomp, recordAppArmor b
 		),
 		mntnsToContainerIDMap:   bimap.New[uint32, string](),
 		containerIDToProfileMap: bimap.New[string, string](),
-		loadUnloadMutex:         sync.RWMutex{},
+		attachUnattachMutex:     sync.RWMutex{},
 		programName:             programName,
 		AppArmor:                appArmor,
 		Seccomp:                 seccomp,
@@ -209,11 +210,19 @@ func (b *BpfRecorder) Run() error {
 	}
 	b.logger.Info("Got system mount namespace: " + strconv.FormatUint(uint64(b.excludeMountNamespace), 10))
 
-	b.logger.Info("Doing BPF load/unload self-test")
-	if err := b.Load(false); err != nil {
-		return fmt.Errorf("load self-test: %w", err)
+	b.logger.Info("Loading BPF program")
+	if err := b.Load(); err != nil {
+		return fmt.Errorf("bpf load: %w", err)
 	}
-	b.Unload()
+
+	b.logger.Info("Doing BPF start/stop self-test...")
+	if err := b.StartRecording(); err != nil {
+		return fmt.Errorf("StartRecording self-test: %w", err)
+	}
+	if err := b.StopRecording(); err != nil {
+		return fmt.Errorf("StopRecording self-test: %w", err)
+	}
+	b.logger.Info("BPF start/stop self-test successful.")
 
 	b.logger.Info("Starting GRPC API server")
 	grpcServer := grpc.NewServer(
@@ -272,9 +281,8 @@ func (b *BpfRecorder) Start(
 ) (*api.EmptyResponse, error) {
 	if b.startRequests == 0 {
 		b.logger.Info("Starting bpf recorder")
-		//nolint:contextcheck // no context intended here
-		if err := b.Load(true); err != nil {
-			return nil, fmt.Errorf("load bpf: %w", err)
+		if err := b.StartRecording(); err != nil {
+			return nil, fmt.Errorf("start recording: %w", err)
 		}
 	} else {
 		b.logger.Info("bpf recorder already running")
@@ -295,7 +303,9 @@ func (b *BpfRecorder) Stop(
 	atomic.AddInt64(&b.startRequests, -1)
 	if b.startRequests == 0 {
 		b.logger.Info("Stopping bpf recorder")
-		b.Unload()
+		if err := b.StopRecording(); err != nil {
+			return nil, fmt.Errorf("start recording: %w", err)
+		}
 	} else {
 		b.logger.Info("Not stopping because another recording is in progress")
 	}
@@ -318,9 +328,9 @@ func (b *BpfRecorder) SyscallsForProfile(
 	if err != nil {
 		return nil, err
 	}
-	b.loadUnloadMutex.RLock()
+	b.attachUnattachMutex.RLock()
 	syscalls, err := b.Seccomp.PopSyscalls(b, mntns)
-	b.loadUnloadMutex.RUnlock()
+	b.attachUnattachMutex.RUnlock()
 	if err != nil {
 		b.logger.Error(err, "Failed to get syscalls for mntns", "mntns", mntns)
 		return nil, err
@@ -353,9 +363,9 @@ func (b *BpfRecorder) ApparmorForProfile(
 	if err != nil {
 		return nil, err
 	}
-	b.loadUnloadMutex.RLock()
+	b.attachUnattachMutex.RLock()
 	apparmor := b.AppArmor.GetAppArmorProcessed(mntns)
-	b.loadUnloadMutex.RUnlock()
+	b.attachUnattachMutex.RUnlock()
 	return &api.ApparmorResponse{
 		Files: &api.ApparmorResponse_Files{
 			AllowedExecutables: apparmor.FileProcessed.AllowedExecutables,
@@ -421,11 +431,15 @@ var baseHooks = []string{
 	"sched_process_exit",
 }
 
-// Load prestarts the bpf recorder.
-func (b *BpfRecorder) Load(startEventProcessor bool) (err error) {
+// Load loads the BPF code, does relocations, and gets references to the programs we want to attach.
+// We try to front load as much work as possible so that starting a recording is quick.
+// Recorder start races with container initialization, so we can't spend too much time then.
+//
+// Unloading is currently done implicitly on process exit.
+func (b *BpfRecorder) Load() (err error) {
 	var module *bpf.Module
 
-	b.logger.Info("Loading bpf module")
+	b.logger.Info("Loading bpf module...")
 	b.btfPath, err = b.findBtfPath()
 	if err != nil {
 		return fmt.Errorf("find btf: %w", err)
@@ -450,6 +464,26 @@ func (b *BpfRecorder) Load(startEventProcessor bool) (err error) {
 		return fmt.Errorf("load bpf module: %w", err)
 	}
 	b.module = module
+	programs, err := newProgramCollection(b, b.logger, module, baseHooks)
+	if err != nil {
+		return err
+	}
+	b.bpfPrograms = programs
+	if b.AppArmor != nil {
+		if err := b.AppArmor.Load(b); err != nil {
+			// Only log an error here, if Apparmor cannot be loaded. This is because it is
+			// enabled by default, and there are Linux distributions which either do not
+			// support Apparmor or BPF LSM is not yet available.
+			//
+			// see also https://github.com/kubernetes-sigs/security-profiles-operator/issues/2384
+			b.logger.Error(err, "load AppArmor bpf hooks")
+		}
+	}
+	if b.Seccomp != nil {
+		if err := b.Seccomp.Load(b); err != nil {
+			return err
+		}
+	}
 
 	if b.programName != "" {
 		programName := []byte(filepath.Base(b.programName))
@@ -480,28 +514,7 @@ func (b *BpfRecorder) Load(startEventProcessor bool) (err error) {
 		if err := b.UpdateValue(excludeMntns, b.excludeMountNamespace, []byte{excludeMntnsEnabled}); err != nil {
 			return fmt.Errorf("updating exclude_mntns map failed: %w", err)
 		}
-	}
-
-	b.logger.Info("Attach all bpf programs")
-	for _, hook := range baseHooks {
-		if err := b.attachBpfProgram(hook); err != nil {
-			return fmt.Errorf("attach bpf program: %w", err)
-		}
-	}
-	if b.AppArmor != nil {
-		if err := b.AppArmor.Load(b); err != nil {
-			// Only log an error here, if Apparmor cannot be loaded. This is because it is
-			// enabled by default, and there are Linux distributions which either do not
-			// support Apparmor or BPF LSM is not yet available.
-			//
-			// see also https://github.com/kubernetes-sigs/security-profiles-operator/issues/2384
-			b.logger.Error(err, "Loading bpf program")
-		}
-	}
-	if b.Seccomp != nil {
-		if err := b.Seccomp.Load(b); err != nil {
-			return err
-		}
+		b.logger.Info("Excluding mount namespace", "mntns", b.excludeMountNamespace)
 	}
 
 	const timeout = 300
@@ -516,23 +529,65 @@ func (b *BpfRecorder) Load(startEventProcessor bool) (err error) {
 	}
 	b.PollRingBuffer(ringbuf, timeout)
 
-	if startEventProcessor {
-		go b.processEvents(events)
-	}
+	go b.processEvents(events)
 
 	b.logger.Info("BPF module successfully loaded.")
 	return nil
 }
 
-func (b *BpfRecorder) attachBpfProgram(name string) error {
-	program, err := b.GetProgram(b.module, name)
-	if err != nil {
-		return fmt.Errorf("get %s bpf program: %w", name, err)
+func (b *BpfRecorder) StartRecording() (err error) {
+	b.attachUnattachMutex.Lock()
+	defer b.attachUnattachMutex.Unlock()
+	b.logger.Info("Start BPF recording: Attaching all programs...")
+
+	if b.bpfPrograms == nil {
+		return ErrStartBeforeLoad
 	}
-	if _, err := b.AttachGeneric(program); err != nil {
-		return fmt.Errorf("attach %s bpf program: %w", name, err)
+
+	if err := b.bpfPrograms.attachAll(b); err != nil {
+		return fmt.Errorf("attach base hooks: %w", err)
 	}
-	b.logger.Info("Attached bpf program " + name + ".")
+	if b.AppArmor != nil {
+		if err := b.AppArmor.StartRecording(b); err != nil {
+			// Only log an error here, if Apparmor cannot be loaded. This is because it is
+			// enabled by default, and there are Linux distributions which either do not
+			// support Apparmor or BPF LSM is not yet available.
+			//
+			// see also https://github.com/kubernetes-sigs/security-profiles-operator/issues/2384
+			b.logger.Error(err, "attach AppArmor bpf hooks")
+		}
+	}
+	if b.Seccomp != nil {
+		if err := b.Seccomp.StartRecording(b); err != nil {
+			return err
+		}
+	}
+	b.logger.Info("Recording started.")
+
+	return nil
+}
+
+func (b *BpfRecorder) StopRecording() error {
+	b.attachUnattachMutex.Lock()
+	defer b.attachUnattachMutex.Unlock()
+	b.logger.Info("Stop BPF recording: Detaching all programs...")
+
+	if err := b.bpfPrograms.detachAll(b); err != nil {
+		return fmt.Errorf("detach base hooks: %w", err)
+	}
+	if b.Seccomp != nil {
+		if err := b.Seccomp.StopRecording(b); err != nil {
+			return err
+		}
+	}
+	if b.AppArmor != nil {
+		if err := b.AppArmor.StopRecording(b); err != nil {
+			return err
+		}
+	}
+	b.logger.Info("Recording stopped.")
+
+	// XXX: It may be useful to clear out all existing maps here.
 	return nil
 }
 
@@ -878,23 +933,6 @@ func (b *BpfRecorder) findProfileForContainerID(id string) (string, error) {
 	}
 
 	return "", fmt.Errorf("container ID not found: %s", id)
-}
-
-// Unload can be used to reset the bpf recorder.
-func (b *BpfRecorder) Unload() {
-	b.logger.Info("Unloading bpf module")
-	b.loadUnloadMutex.Lock()
-	b.CloseModule(b.module)
-
-	if b.Seccomp != nil {
-		b.Seccomp.Unload()
-	}
-	if b.AppArmor != nil {
-		b.AppArmor.Unload()
-	}
-
-	os.RemoveAll(b.btfPath)
-	b.loadUnloadMutex.Unlock()
 }
 
 // When running outside of Kubernetes as spoc, we have the use case of waiting for a specific PID to exit.

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorderfakes/fake_impl.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorderfakes/fake_impl.go
@@ -62,6 +62,28 @@ type FakeImpl struct {
 	bPFLoadObjectReturnsOnCall map[int]struct {
 		result1 error
 	}
+	BPFMapIteratorStub        func(*libbpfgo.BPFMap) *libbpfgo.BPFMapIterator
+	bPFMapIteratorMutex       sync.RWMutex
+	bPFMapIteratorArgsForCall []struct {
+		arg1 *libbpfgo.BPFMap
+	}
+	bPFMapIteratorReturns struct {
+		result1 *libbpfgo.BPFMapIterator
+	}
+	bPFMapIteratorReturnsOnCall map[int]struct {
+		result1 *libbpfgo.BPFMapIterator
+	}
+	BPFMapIteratorNextStub        func(*libbpfgo.BPFMapIterator) bool
+	bPFMapIteratorNextMutex       sync.RWMutex
+	bPFMapIteratorNextArgsForCall []struct {
+		arg1 *libbpfgo.BPFMapIterator
+	}
+	bPFMapIteratorNextReturns struct {
+		result1 bool
+	}
+	bPFMapIteratorNextReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	BpfIncClientStub        func(api_metrics.MetricsClient) (api_metrics.Metrics_BpfIncClient, error)
 	bpfIncClientMutex       sync.RWMutex
 	bpfIncClientArgsForCall []struct {
@@ -140,6 +162,17 @@ type FakeImpl struct {
 		result1 error
 	}
 	deleteKey64ReturnsOnCall map[int]struct {
+		result1 error
+	}
+	DestroyLinkStub        func(*libbpfgo.BPFLink) error
+	destroyLinkMutex       sync.RWMutex
+	destroyLinkArgsForCall []struct {
+		arg1 *libbpfgo.BPFLink
+	}
+	destroyLinkReturns struct {
+		result1 error
+	}
+	destroyLinkReturnsOnCall map[int]struct {
 		result1 error
 	}
 	DialMetricsStub        func() (*grpc.ClientConn, context.CancelFunc, error)
@@ -639,6 +672,128 @@ func (fake *FakeImpl) BPFLoadObjectReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
+func (fake *FakeImpl) BPFMapIterator(arg1 *libbpfgo.BPFMap) *libbpfgo.BPFMapIterator {
+	fake.bPFMapIteratorMutex.Lock()
+	ret, specificReturn := fake.bPFMapIteratorReturnsOnCall[len(fake.bPFMapIteratorArgsForCall)]
+	fake.bPFMapIteratorArgsForCall = append(fake.bPFMapIteratorArgsForCall, struct {
+		arg1 *libbpfgo.BPFMap
+	}{arg1})
+	stub := fake.BPFMapIteratorStub
+	fakeReturns := fake.bPFMapIteratorReturns
+	fake.recordInvocation("BPFMapIterator", []interface{}{arg1})
+	fake.bPFMapIteratorMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) BPFMapIteratorCallCount() int {
+	fake.bPFMapIteratorMutex.RLock()
+	defer fake.bPFMapIteratorMutex.RUnlock()
+	return len(fake.bPFMapIteratorArgsForCall)
+}
+
+func (fake *FakeImpl) BPFMapIteratorCalls(stub func(*libbpfgo.BPFMap) *libbpfgo.BPFMapIterator) {
+	fake.bPFMapIteratorMutex.Lock()
+	defer fake.bPFMapIteratorMutex.Unlock()
+	fake.BPFMapIteratorStub = stub
+}
+
+func (fake *FakeImpl) BPFMapIteratorArgsForCall(i int) *libbpfgo.BPFMap {
+	fake.bPFMapIteratorMutex.RLock()
+	defer fake.bPFMapIteratorMutex.RUnlock()
+	argsForCall := fake.bPFMapIteratorArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImpl) BPFMapIteratorReturns(result1 *libbpfgo.BPFMapIterator) {
+	fake.bPFMapIteratorMutex.Lock()
+	defer fake.bPFMapIteratorMutex.Unlock()
+	fake.BPFMapIteratorStub = nil
+	fake.bPFMapIteratorReturns = struct {
+		result1 *libbpfgo.BPFMapIterator
+	}{result1}
+}
+
+func (fake *FakeImpl) BPFMapIteratorReturnsOnCall(i int, result1 *libbpfgo.BPFMapIterator) {
+	fake.bPFMapIteratorMutex.Lock()
+	defer fake.bPFMapIteratorMutex.Unlock()
+	fake.BPFMapIteratorStub = nil
+	if fake.bPFMapIteratorReturnsOnCall == nil {
+		fake.bPFMapIteratorReturnsOnCall = make(map[int]struct {
+			result1 *libbpfgo.BPFMapIterator
+		})
+	}
+	fake.bPFMapIteratorReturnsOnCall[i] = struct {
+		result1 *libbpfgo.BPFMapIterator
+	}{result1}
+}
+
+func (fake *FakeImpl) BPFMapIteratorNext(arg1 *libbpfgo.BPFMapIterator) bool {
+	fake.bPFMapIteratorNextMutex.Lock()
+	ret, specificReturn := fake.bPFMapIteratorNextReturnsOnCall[len(fake.bPFMapIteratorNextArgsForCall)]
+	fake.bPFMapIteratorNextArgsForCall = append(fake.bPFMapIteratorNextArgsForCall, struct {
+		arg1 *libbpfgo.BPFMapIterator
+	}{arg1})
+	stub := fake.BPFMapIteratorNextStub
+	fakeReturns := fake.bPFMapIteratorNextReturns
+	fake.recordInvocation("BPFMapIteratorNext", []interface{}{arg1})
+	fake.bPFMapIteratorNextMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) BPFMapIteratorNextCallCount() int {
+	fake.bPFMapIteratorNextMutex.RLock()
+	defer fake.bPFMapIteratorNextMutex.RUnlock()
+	return len(fake.bPFMapIteratorNextArgsForCall)
+}
+
+func (fake *FakeImpl) BPFMapIteratorNextCalls(stub func(*libbpfgo.BPFMapIterator) bool) {
+	fake.bPFMapIteratorNextMutex.Lock()
+	defer fake.bPFMapIteratorNextMutex.Unlock()
+	fake.BPFMapIteratorNextStub = stub
+}
+
+func (fake *FakeImpl) BPFMapIteratorNextArgsForCall(i int) *libbpfgo.BPFMapIterator {
+	fake.bPFMapIteratorNextMutex.RLock()
+	defer fake.bPFMapIteratorNextMutex.RUnlock()
+	argsForCall := fake.bPFMapIteratorNextArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImpl) BPFMapIteratorNextReturns(result1 bool) {
+	fake.bPFMapIteratorNextMutex.Lock()
+	defer fake.bPFMapIteratorNextMutex.Unlock()
+	fake.BPFMapIteratorNextStub = nil
+	fake.bPFMapIteratorNextReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeImpl) BPFMapIteratorNextReturnsOnCall(i int, result1 bool) {
+	fake.bPFMapIteratorNextMutex.Lock()
+	defer fake.bPFMapIteratorNextMutex.Unlock()
+	fake.BPFMapIteratorNextStub = nil
+	if fake.bPFMapIteratorNextReturnsOnCall == nil {
+		fake.bPFMapIteratorNextReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.bPFMapIteratorNextReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
+}
+
 func (fake *FakeImpl) BpfIncClient(arg1 api_metrics.MetricsClient) (api_metrics.Metrics_BpfIncClient, error) {
 	fake.bpfIncClientMutex.Lock()
 	ret, specificReturn := fake.bpfIncClientReturnsOnCall[len(fake.bpfIncClientArgsForCall)]
@@ -1044,6 +1199,67 @@ func (fake *FakeImpl) DeleteKey64ReturnsOnCall(i int, result1 error) {
 		})
 	}
 	fake.deleteKey64ReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) DestroyLink(arg1 *libbpfgo.BPFLink) error {
+	fake.destroyLinkMutex.Lock()
+	ret, specificReturn := fake.destroyLinkReturnsOnCall[len(fake.destroyLinkArgsForCall)]
+	fake.destroyLinkArgsForCall = append(fake.destroyLinkArgsForCall, struct {
+		arg1 *libbpfgo.BPFLink
+	}{arg1})
+	stub := fake.DestroyLinkStub
+	fakeReturns := fake.destroyLinkReturns
+	fake.recordInvocation("DestroyLink", []interface{}{arg1})
+	fake.destroyLinkMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) DestroyLinkCallCount() int {
+	fake.destroyLinkMutex.RLock()
+	defer fake.destroyLinkMutex.RUnlock()
+	return len(fake.destroyLinkArgsForCall)
+}
+
+func (fake *FakeImpl) DestroyLinkCalls(stub func(*libbpfgo.BPFLink) error) {
+	fake.destroyLinkMutex.Lock()
+	defer fake.destroyLinkMutex.Unlock()
+	fake.DestroyLinkStub = stub
+}
+
+func (fake *FakeImpl) DestroyLinkArgsForCall(i int) *libbpfgo.BPFLink {
+	fake.destroyLinkMutex.RLock()
+	defer fake.destroyLinkMutex.RUnlock()
+	argsForCall := fake.destroyLinkArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImpl) DestroyLinkReturns(result1 error) {
+	fake.destroyLinkMutex.Lock()
+	defer fake.destroyLinkMutex.Unlock()
+	fake.DestroyLinkStub = nil
+	fake.destroyLinkReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) DestroyLinkReturnsOnCall(i int, result1 error) {
+	fake.destroyLinkMutex.Lock()
+	defer fake.destroyLinkMutex.Unlock()
+	fake.DestroyLinkStub = nil
+	if fake.destroyLinkReturnsOnCall == nil {
+		fake.destroyLinkReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.destroyLinkReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -2861,6 +3077,10 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.attachGenericMutex.RUnlock()
 	fake.bPFLoadObjectMutex.RLock()
 	defer fake.bPFLoadObjectMutex.RUnlock()
+	fake.bPFMapIteratorMutex.RLock()
+	defer fake.bPFMapIteratorMutex.RUnlock()
+	fake.bPFMapIteratorNextMutex.RLock()
+	defer fake.bPFMapIteratorNextMutex.RUnlock()
 	fake.bpfIncClientMutex.RLock()
 	defer fake.bpfIncClientMutex.RUnlock()
 	fake.chownMutex.RLock()
@@ -2875,6 +3095,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.deleteKeyMutex.RUnlock()
 	fake.deleteKey64Mutex.RLock()
 	defer fake.deleteKey64Mutex.RUnlock()
+	fake.destroyLinkMutex.RLock()
+	defer fake.destroyLinkMutex.RUnlock()
 	fake.dialMetricsMutex.RLock()
 	defer fake.dialMetricsMutex.RUnlock()
 	fake.getMapMutex.RLock()

--- a/internal/pkg/daemon/bpfrecorder/impl.go
+++ b/internal/pkg/daemon/bpfrecorder/impl.go
@@ -56,9 +56,12 @@ type impl interface {
 	Listen(string, string) (net.Listener, error)
 	Serve(*grpc.Server, net.Listener) error
 	NewModuleFromBufferArgs(*bpf.NewModuleArgs) (*bpf.Module, error)
+	BPFMapIterator(*bpf.BPFMap) *bpf.BPFMapIterator
+	BPFMapIteratorNext(*bpf.BPFMapIterator) bool
 	BPFLoadObject(*bpf.Module) error
 	GetProgram(*bpf.Module, string) (*bpf.BPFProg, error)
 	AttachGeneric(*bpf.BPFProg) (*bpf.BPFLink, error)
+	DestroyLink(*bpf.BPFLink) error
 	GetMap(*bpf.Module, string) (*bpf.BPFMap, error)
 	InitRingBuf(*bpf.Module, string, chan []byte) (*bpf.RingBuffer, error)
 	Stat(string) (os.FileInfo, error)
@@ -116,6 +119,14 @@ func (d *defaultImpl) NewModuleFromBufferArgs(args *bpf.NewModuleArgs) (*bpf.Mod
 	return bpf.NewModuleFromBufferArgs(*args)
 }
 
+func (*defaultImpl) BPFMapIterator(m *bpf.BPFMap) *bpf.BPFMapIterator {
+	return m.Iterator()
+}
+
+func (*defaultImpl) BPFMapIteratorNext(it *bpf.BPFMapIterator) bool {
+	return it.Next()
+}
+
 func (d *defaultImpl) BPFLoadObject(module *bpf.Module) error {
 	return module.BPFLoadObject()
 }
@@ -126,6 +137,10 @@ func (d *defaultImpl) GetProgram(module *bpf.Module, progName string) (*bpf.BPFP
 
 func (d *defaultImpl) AttachGeneric(prog *bpf.BPFProg) (*bpf.BPFLink, error) {
 	return prog.AttachGeneric()
+}
+
+func (d *defaultImpl) DestroyLink(link *bpf.BPFLink) error {
+	return link.Destroy()
 }
 
 func (d *defaultImpl) GetMap(module *bpf.Module, mapName string) (*bpf.BPFMap, error) {

--- a/internal/pkg/daemon/bpfrecorder/vars.go
+++ b/internal/pkg/daemon/bpfrecorder/vars.go
@@ -20,3 +20,5 @@ import "errors"
 
 // ErrNotFound is the GRPC error if no recorded profile found.
 var ErrNotFound = errors.New("no recorded profile found")
+
+var ErrStartBeforeLoad = errors.New("BPF module must be loaded before a recording can be started")


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind flake

#### What this PR does / why we need it:

This commit makes it so that the BPF program is loaded (and relocated) on profile recorder startup. When we then want to start the recording, we only need to attach the programs. This fixes the flakiness in #2667 and #2668 where program loading is taking so long that we miss container startup.


#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?


```release-note
NONE
```
