### PR TITLE
bpf-recorder needs /sys/kernel/tracing/events/raw_syscalls/sys_enter/id

### DIFF
--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -53,6 +53,7 @@ const (
 	SelinuxdDBPath                                   = SelinuxdPrivateDir + "/selinuxd.db"
 	sysKernelDebugPath                               = "/sys/kernel/debug"
 	sysKernelSecurityPath                            = "/sys/kernel/security"
+	sysKernelTracingPath                             = "/sys/kernel/tracing"
 	InitContainerIDNonRootenabler                    = 0
 	InitContainerIDSelinuxSharedPoliciesCopier       = 1
 	ContainerIDDaemon                                = 0
@@ -557,6 +558,11 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 								ReadOnly:  true,
 							},
 							{
+								Name:      "sys-kernel-tracing-volume",
+								MountPath: sysKernelTracingPath,
+								ReadOnly:  true,
+							},
+							{
 								Name:      "host-etc-osrelease-volume",
 								MountPath: etcOSReleasePath,
 							},
@@ -732,6 +738,15 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 						VolumeSource: corev1.VolumeSource{
 							HostPath: &corev1.HostPathVolumeSource{
 								Path: sysKernelSecurityPath,
+								Type: &hostPathDirectory,
+							},
+						},
+					},
+					{
+						Name: "sys-kernel-tracing-volume",
+						VolumeSource: corev1.VolumeSource{
+							HostPath: &corev1.HostPathVolumeSource{
+								Path: sysKernelTracingPath,
 								Type: &hostPathDirectory,
 							},
 						},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind bug

#### What this PR does / why we need it:

spod crashes when using the eBPF based recorder, because the container cannot access /sys/kernel/tracing/events/raw_syscalls/sys_enter/id:

I0122 08:11:14.334147 9234 bpfrecorder.go:517] "Excluding mount namespace" logger="bpf-recorder" mntns=4026531841
I0122 08:11:14.335822 9234 bpfrecorder.go:534] "BPF module successfully loaded." logger="bpf-recorder"
I0122 08:11:14.335896 9234 bpfrecorder.go:218] "Doing BPF start/stop self-test..." logger="bpf-recorder"
I0122 08:11:14.335967 9234 bpfrecorder.go:541] "Start BPF recording: Attaching all programs..." logger="bpf-recorder"
libbpf: failed to open '/sys/kernel/tracing/events/raw_syscalls/sys_enter/id': No such file or directory
libbpf: failed to determine tracepoint 'raw_syscalls/sys_enter' perf event ID: No such file or directory
libbpf: prog 'sys_enter': failed to create tracepoint 'raw_syscalls/sys_enter' perf event: No such file or directory
I0122 08:11:14.335948 9234 bpfrecorder.go:698] "Processing bpf events" logger="bpf-recorder"
E0122 08:11:14.336538 9234 main.go:240] "running security-profiles-operator" err="StartRecording self-test: attach base hooks: attach bpf program sys_enter: failed to attach program: no such file or directory" logger="setup"

Kernel is:
Linux kworker1 6.12.8-artix1-1 #1 SMP PREEMPT_DYNAMIC Fri, 03 Jan 2025 16:31:28 +0000 x86_64 GNU/Linux

Kubernetes test cluster running on QEMU/KVM:

NAME       STATUS   ROLES           AGE   VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE      KERNEL-VERSION    CONTAINER-RUNTIME
kcoplane   Ready    control-plane   16d   v1.32.0   100.64.1.101   <none>        Artix Linux   6.12.9-artix1-1   cri-o://1.32.0
kworker1   Ready    worker          16d   v1.32.0   100.64.1.102   <none>        Artix Linux   6.12.8-artix1-1   cri-o://1.32.0
kworker2   Ready    worker          16d   v1.32.0   100.64.1.103   <none>        Artix Linux   6.12.8-artix1-1   cri-o://1.32.0

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
