### PR TITLE
fix apparmor profile for spod

### DIFF
--- a/deploy/base/profiles/bpfrecorder-apparmor.yaml
+++ b/deploy/base/profiles/bpfrecorder-apparmor.yaml
@@ -23,21 +23,15 @@ spec:
       - /proc/sys/net/core/somaxconn
       - /sys/devices/kprobe/type
       - /sys/devices/system/cpu/online
-      - /sys/fs/bpf/**
+      - /sys/fs/bpf/
       - /sys/kernel/btf/vmlinux
-      - /sys/kernel/debug/tracing/events/raw_syscalls/sys_enter/id
-      - /sys/kernel/debug/tracing/events/sched/sched_process_exec/id
-      - /sys/kernel/debug/tracing/events/sched/sched_process_exit/id
-      - /sys/kernel/debug/tracing/events/syscalls/sys_enter_execve/id
-      - /sys/kernel/debug/tracing/events/syscalls/sys_enter_getgid/id
-      - /sys/kernel/debug/tracing/events/syscalls/sys_enter_prctl/id
-      - /sys/kernel/debug/tracing/events/syscalls/sys_enter_socket/id
-      - /sys/kernel/debug/tracing/events/syscalls/sys_exit_clone/id
+      - /sys/kernel/debug/tracing/events/**/id
       - /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
       - /sys/kernel/security/lsm
       - /var/run/secrets/kubernetes.io/serviceaccount/**
       - /var/run/secrets/kubernetes.io/serviceaccount/**
       readWritePaths:
+      - "ptrace (read),\n# ugly template injection hack"
       - /var/run/grpc/bpf-recorder.sock
     network:
       allowedProtocols:

--- a/deploy/base/profiles/spo-apparmor.yaml
+++ b/deploy/base/profiles/spo-apparmor.yaml
@@ -9,13 +9,16 @@ spec:
   abstract:
     capability:
       allowedCapabilities:
+      - dac_override
       - dac_read_search
       - sys_admin
+      - sys_chroot
     executable:
       allowedExecutables:
       - /security-profiles-operator
     filesystem:
       readOnlyPaths:
+      - /  # workaround for apparmor bug
       - /proc/@{pid}/maps
       - /proc/sys/net/core/somaxconn
       - /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
@@ -25,7 +28,12 @@ spec:
       - /var/run/secrets/kubernetes.io/serviceaccount/**
       - /var/run/secrets/metrics/**
       - /var/run/secrets/metrics/**
+      - /sys/module/apparmor/parameters/enabled
+      writeOnlyPaths:
+      - /etc/apparmor.d/**
+      - /tmp/aa_profile_bin_*
       readWritePaths:
+      - "ptrace (read),  # ugly template injection hack"
       - /var/run/grpc/metrics.sock
     network:
       allowedProtocols:

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -802,21 +802,15 @@ data:
           - /proc/sys/net/core/somaxconn
           - /sys/devices/kprobe/type
           - /sys/devices/system/cpu/online
-          - /sys/fs/bpf/**
+          - /sys/fs/bpf/
           - /sys/kernel/btf/vmlinux
-          - /sys/kernel/debug/tracing/events/raw_syscalls/sys_enter/id
-          - /sys/kernel/debug/tracing/events/sched/sched_process_exec/id
-          - /sys/kernel/debug/tracing/events/sched/sched_process_exit/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_execve/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_getgid/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_prctl/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_socket/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_exit_clone/id
+          - /sys/kernel/debug/tracing/events/**/id
           - /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
           - /sys/kernel/security/lsm
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           readWritePaths:
+          - "ptrace (read),\n# ugly template injection hack"
           - /var/run/grpc/bpf-recorder.sock
         network:
           allowedProtocols:
@@ -984,13 +978,16 @@ data:
       abstract:
         capability:
           allowedCapabilities:
+          - dac_override
           - dac_read_search
           - sys_admin
+          - sys_chroot
         executable:
           allowedExecutables:
           - /security-profiles-operator
         filesystem:
           readOnlyPaths:
+          - /  # workaround for apparmor bug
           - /proc/@{pid}/maps
           - /proc/sys/net/core/somaxconn
           - /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
@@ -1000,7 +997,12 @@ data:
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           - /var/run/secrets/metrics/**
           - /var/run/secrets/metrics/**
+          - /sys/module/apparmor/parameters/enabled
+          writeOnlyPaths:
+          - /etc/apparmor.d/**
+          - /tmp/aa_profile_bin_*
           readWritePaths:
+          - "ptrace (read),  # ugly template injection hack"
           - /var/run/grpc/metrics.sock
         network:
           allowedProtocols:

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -3085,21 +3085,15 @@ data:
           - /proc/sys/net/core/somaxconn
           - /sys/devices/kprobe/type
           - /sys/devices/system/cpu/online
-          - /sys/fs/bpf/**
+          - /sys/fs/bpf/
           - /sys/kernel/btf/vmlinux
-          - /sys/kernel/debug/tracing/events/raw_syscalls/sys_enter/id
-          - /sys/kernel/debug/tracing/events/sched/sched_process_exec/id
-          - /sys/kernel/debug/tracing/events/sched/sched_process_exit/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_execve/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_getgid/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_prctl/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_socket/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_exit_clone/id
+          - /sys/kernel/debug/tracing/events/**/id
           - /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
           - /sys/kernel/security/lsm
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           readWritePaths:
+          - "ptrace (read),\n# ugly template injection hack"
           - /var/run/grpc/bpf-recorder.sock
         network:
           allowedProtocols:
@@ -3267,13 +3261,16 @@ data:
       abstract:
         capability:
           allowedCapabilities:
+          - dac_override
           - dac_read_search
           - sys_admin
+          - sys_chroot
         executable:
           allowedExecutables:
           - /security-profiles-operator
         filesystem:
           readOnlyPaths:
+          - /  # workaround for apparmor bug
           - /proc/@{pid}/maps
           - /proc/sys/net/core/somaxconn
           - /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
@@ -3283,7 +3280,12 @@ data:
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           - /var/run/secrets/metrics/**
           - /var/run/secrets/metrics/**
+          - /sys/module/apparmor/parameters/enabled
+          writeOnlyPaths:
+          - /etc/apparmor.d/**
+          - /tmp/aa_profile_bin_*
           readWritePaths:
+          - "ptrace (read),  # ugly template injection hack"
           - /var/run/grpc/metrics.sock
         network:
           allowedProtocols:

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3067,21 +3067,15 @@ data:
           - /proc/sys/net/core/somaxconn
           - /sys/devices/kprobe/type
           - /sys/devices/system/cpu/online
-          - /sys/fs/bpf/**
+          - /sys/fs/bpf/
           - /sys/kernel/btf/vmlinux
-          - /sys/kernel/debug/tracing/events/raw_syscalls/sys_enter/id
-          - /sys/kernel/debug/tracing/events/sched/sched_process_exec/id
-          - /sys/kernel/debug/tracing/events/sched/sched_process_exit/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_execve/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_getgid/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_prctl/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_socket/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_exit_clone/id
+          - /sys/kernel/debug/tracing/events/**/id
           - /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
           - /sys/kernel/security/lsm
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           readWritePaths:
+          - "ptrace (read),\n# ugly template injection hack"
           - /var/run/grpc/bpf-recorder.sock
         network:
           allowedProtocols:
@@ -3249,13 +3243,16 @@ data:
       abstract:
         capability:
           allowedCapabilities:
+          - dac_override
           - dac_read_search
           - sys_admin
+          - sys_chroot
         executable:
           allowedExecutables:
           - /security-profiles-operator
         filesystem:
           readOnlyPaths:
+          - /  # workaround for apparmor bug
           - /proc/@{pid}/maps
           - /proc/sys/net/core/somaxconn
           - /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
@@ -3265,7 +3262,12 @@ data:
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           - /var/run/secrets/metrics/**
           - /var/run/secrets/metrics/**
+          - /sys/module/apparmor/parameters/enabled
+          writeOnlyPaths:
+          - /etc/apparmor.d/**
+          - /tmp/aa_profile_bin_*
           readWritePaths:
+          - "ptrace (read),  # ugly template injection hack"
           - /var/run/grpc/metrics.sock
         network:
           allowedProtocols:

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -3098,21 +3098,15 @@ data:
           - /proc/sys/net/core/somaxconn
           - /sys/devices/kprobe/type
           - /sys/devices/system/cpu/online
-          - /sys/fs/bpf/**
+          - /sys/fs/bpf/
           - /sys/kernel/btf/vmlinux
-          - /sys/kernel/debug/tracing/events/raw_syscalls/sys_enter/id
-          - /sys/kernel/debug/tracing/events/sched/sched_process_exec/id
-          - /sys/kernel/debug/tracing/events/sched/sched_process_exit/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_execve/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_getgid/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_prctl/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_socket/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_exit_clone/id
+          - /sys/kernel/debug/tracing/events/**/id
           - /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
           - /sys/kernel/security/lsm
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           readWritePaths:
+          - "ptrace (read),\n# ugly template injection hack"
           - /var/run/grpc/bpf-recorder.sock
         network:
           allowedProtocols:
@@ -3280,13 +3274,16 @@ data:
       abstract:
         capability:
           allowedCapabilities:
+          - dac_override
           - dac_read_search
           - sys_admin
+          - sys_chroot
         executable:
           allowedExecutables:
           - /security-profiles-operator
         filesystem:
           readOnlyPaths:
+          - /  # workaround for apparmor bug
           - /proc/@{pid}/maps
           - /proc/sys/net/core/somaxconn
           - /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
@@ -3296,7 +3293,12 @@ data:
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           - /var/run/secrets/metrics/**
           - /var/run/secrets/metrics/**
+          - /sys/module/apparmor/parameters/enabled
+          writeOnlyPaths:
+          - /etc/apparmor.d/**
+          - /tmp/aa_profile_bin_*
           readWritePaths:
+          - "ptrace (read),  # ugly template injection hack"
           - /var/run/grpc/metrics.sock
         network:
           allowedProtocols:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3085,21 +3085,15 @@ data:
           - /proc/sys/net/core/somaxconn
           - /sys/devices/kprobe/type
           - /sys/devices/system/cpu/online
-          - /sys/fs/bpf/**
+          - /sys/fs/bpf/
           - /sys/kernel/btf/vmlinux
-          - /sys/kernel/debug/tracing/events/raw_syscalls/sys_enter/id
-          - /sys/kernel/debug/tracing/events/sched/sched_process_exec/id
-          - /sys/kernel/debug/tracing/events/sched/sched_process_exit/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_execve/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_getgid/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_prctl/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_socket/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_exit_clone/id
+          - /sys/kernel/debug/tracing/events/**/id
           - /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
           - /sys/kernel/security/lsm
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           readWritePaths:
+          - "ptrace (read),\n# ugly template injection hack"
           - /var/run/grpc/bpf-recorder.sock
         network:
           allowedProtocols:
@@ -3267,13 +3261,16 @@ data:
       abstract:
         capability:
           allowedCapabilities:
+          - dac_override
           - dac_read_search
           - sys_admin
+          - sys_chroot
         executable:
           allowedExecutables:
           - /security-profiles-operator
         filesystem:
           readOnlyPaths:
+          - /  # workaround for apparmor bug
           - /proc/@{pid}/maps
           - /proc/sys/net/core/somaxconn
           - /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
@@ -3283,7 +3280,12 @@ data:
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           - /var/run/secrets/metrics/**
           - /var/run/secrets/metrics/**
+          - /sys/module/apparmor/parameters/enabled
+          writeOnlyPaths:
+          - /etc/apparmor.d/**
+          - /tmp/aa_profile_bin_*
           readWritePaths:
+          - "ptrace (read),  # ugly template injection hack"
           - /var/run/grpc/metrics.sock
         network:
           allowedProtocols:

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3056,21 +3056,15 @@ data:
           - /proc/sys/net/core/somaxconn
           - /sys/devices/kprobe/type
           - /sys/devices/system/cpu/online
-          - /sys/fs/bpf/**
+          - /sys/fs/bpf/
           - /sys/kernel/btf/vmlinux
-          - /sys/kernel/debug/tracing/events/raw_syscalls/sys_enter/id
-          - /sys/kernel/debug/tracing/events/sched/sched_process_exec/id
-          - /sys/kernel/debug/tracing/events/sched/sched_process_exit/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_execve/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_getgid/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_prctl/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_enter_socket/id
-          - /sys/kernel/debug/tracing/events/syscalls/sys_exit_clone/id
+          - /sys/kernel/debug/tracing/events/**/id
           - /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
           - /sys/kernel/security/lsm
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           readWritePaths:
+          - "ptrace (read),\n# ugly template injection hack"
           - /var/run/grpc/bpf-recorder.sock
         network:
           allowedProtocols:
@@ -3238,13 +3232,16 @@ data:
       abstract:
         capability:
           allowedCapabilities:
+          - dac_override
           - dac_read_search
           - sys_admin
+          - sys_chroot
         executable:
           allowedExecutables:
           - /security-profiles-operator
         filesystem:
           readOnlyPaths:
+          - /  # workaround for apparmor bug
           - /proc/@{pid}/maps
           - /proc/sys/net/core/somaxconn
           - /sys/kernel/mm/transparent_hugepage/hpage_pmd_size
@@ -3254,7 +3251,12 @@ data:
           - /var/run/secrets/kubernetes.io/serviceaccount/**
           - /var/run/secrets/metrics/**
           - /var/run/secrets/metrics/**
+          - /sys/module/apparmor/parameters/enabled
+          writeOnlyPaths:
+          - /etc/apparmor.d/**
+          - /tmp/aa_profile_bin_*
           readWritePaths:
+          - "ptrace (read),  # ugly template injection hack"
           - /var/run/grpc/metrics.sock
         network:
           allowedProtocols:


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

This PR fixes the apparmor profile for the bpf recorder itself so that recording works again after #2646. The template injection hack is not meant to be a permanent solution, but a temporary stopgap to make things work without reverts.

Most of the missing permissions were found looking at `journalctl`, but for `/` AppArmor did not emit any DENIED messages despite actually denying permissions. This is a bit worrying in general, but what to do.


#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
