### PR TITLE
apparmor recorder: generalize random digit sequences

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
@@ -315,8 +315,16 @@ func replaceVarianceInFilePath(filePath string) string {
 
 	// Replace container ID with any container ID
 	pathWithCid := regexp.MustCompile(`/var/lib/containers/storage/overlay/\w+/`)
+	filePath = pathWithCid.ReplaceAllString(filePath, "/var/lib/containers/storage/overlay/*/")
 
-	return pathWithCid.ReplaceAllString(filePath, "/var/lib/containers/storage/overlay/*/")
+	// Assume that long digit sequences are random, replace them with a placeholder
+	digitSequence := regexp.MustCompile(`\d{6,}`)
+	// Beware: This is not a regex. `[0-9]*` would mean "a digit followed by arbitrary characters"
+	// AppArmor syntax doesn't have regex quantifiers. So we approximate with
+	// "a digit followed by arbitrary characters followed by a digit".
+	filePath = digitSequence.ReplaceAllString(filePath, "[0-9]*[0-9]")
+
+	return filePath
 }
 
 func shouldExcludeFile(filePath string) bool {

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
@@ -159,7 +159,7 @@ func (b *AppArmorRecorder) handleFileEvent(fileEvent *bpfEvent) {
 	defer b.lockRecordedFiles.Unlock()
 
 	fileName := fileDataToString(&fileEvent.Data)
-	fileName = replaceVarianceInFilePath(fileName)
+	fileName = ReplaceVarianceInFilePath(fileName)
 
 	log.Printf("File access: %s, flags=%d pid=%d mntns=%d\n", fileName, fileEvent.Flags, fileEvent.Pid, fileEvent.Mntns)
 
@@ -304,7 +304,7 @@ func (b *AppArmorRecorder) GetAppArmorProcessed(mntns uint32) BpfAppArmorProcess
 	return processed
 }
 
-func replaceVarianceInFilePath(filePath string) string {
+func ReplaceVarianceInFilePath(filePath string) string {
 	// Replace PID value with a apparmor variable.
 	pathWithPid := regexp.MustCompile(`^/proc/\d+/`)
 	filePath = pathWithPid.ReplaceAllString(filePath, "/proc/@{pid}/")

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
@@ -53,6 +53,16 @@ func TestReplaceVarianceInFilePath(t *testing.T) {
 			path: "/var/lib/containers/storage/overlay/8a0a50ee00/merged/dev",
 			want: "/var/lib/containers/storage/overlay/*/merged/dev",
 		},
+		{
+			name: "generalize os.MkdirTemp() directories",
+			path: "/tmp/kubelet-detect-safe-umount1404256428",
+			want: "/tmp/kubelet-detect-safe-umount[0-9]*[0-9]",
+		},
+		{
+			name: "generalize os.MkdirTemp() directories",
+			path: "/tmp/kubelet-detect-safe-umount1404256428/test",
+			want: "/tmp/kubelet-detect-safe-umount[0-9]*[0-9]/test",
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
@@ -69,7 +69,7 @@ func TestReplaceVarianceInFilePath(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := replaceVarianceInFilePath(tc.path)
+			got := ReplaceVarianceInFilePath(tc.path)
 			require.Equal(t, tc.want, got)
 		})
 	}

--- a/test/spoc/e2e_spoc_test.go
+++ b/test/spoc/e2e_spoc_test.go
@@ -92,7 +92,7 @@ func recordAppArmorTest(t *testing.T) {
 		require.Contains(t, *profile.Filesystem.ReadOnlyPaths, readme)
 		require.Contains(t, *profile.Filesystem.WriteOnlyPaths, "/dev/null")
 		require.Contains(t, *profile.Filesystem.WriteOnlyPaths, "/tmp/spoc-test-file")
-		require.Contains(t, *profile.Filesystem.ReadWritePaths, fileToRemove.Name())
+		require.Contains(t, *profile.Filesystem.ReadWritePaths, bpfrecorder.ReplaceVarianceInFilePath(fileToRemove.Name()))
 
 		count := 0
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

This PR makes it so that the AppArmor recorder replaces long digit sequences in file paths with placeholders. This heuristic covers the `os.MkDirTemp` case we've observed during testing. We may need to do more generalizing / fine-tuning here in the future, but let's do that once we have concrete examples.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
The AppArmor recorder is now better at detecting randomness in file paths and replacing it with placeholders.
```
