### PR TITLE
AppArmor recorder: improve generalization of random sequences

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
@@ -317,12 +317,15 @@ func ReplaceVarianceInFilePath(filePath string) string {
 	pathWithCid := regexp.MustCompile(`/var/lib/containers/storage/overlay/\w+/`)
 	filePath = pathWithCid.ReplaceAllString(filePath, "/var/lib/containers/storage/overlay/*/")
 
+	uuid := regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+	filePath = uuid.ReplaceAllString(filePath, "*")
+
+	hash := regexp.MustCompile(`[0-9a-fA-F]{32,}`)
+	filePath = hash.ReplaceAllString(filePath, "*")
+
 	// Assume that long digit sequences are random, replace them with a placeholder
 	digitSequence := regexp.MustCompile(`\d{6,}`)
-	// Beware: This is not a regex. `[0-9]*` would mean "a digit followed by arbitrary characters"
-	// AppArmor syntax doesn't have regex quantifiers. So we approximate with
-	// "a digit followed by arbitrary characters followed by a digit".
-	filePath = digitSequence.ReplaceAllString(filePath, "[0-9]*[0-9]")
+	filePath = digitSequence.ReplaceAllString(filePath, "*")
 
 	return filePath
 }

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
@@ -65,8 +65,8 @@ func TestReplaceVarianceInFilePath(t *testing.T) {
 		},
 		{
 			name: "generalize hashes",
-			path: "/var/lib/kubelet/plugins/kubernetes.io/csi/pd.csi.storage.gke.io/3c5928afbbefea1b0acf34b9acd866d2bcb3d6b6955d4e1fe095a97d487bcb45/globalmountroblem-detector.db",
-			want: "/var/lib/kubelet/plugins/kubernetes.io/csi/pd.csi.storage.gke.io/*/globalmountroblem-detector.db",
+			path: "/tmp/3c5928afbbefea1b0acf34b9acd866d2bcb3d6b6955d4e1fe095a97d487bcb45/foo",
+			want: "/tmp/*/foo",
 		},
 	}
 

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor_test.go
@@ -56,12 +56,17 @@ func TestReplaceVarianceInFilePath(t *testing.T) {
 		{
 			name: "generalize os.MkdirTemp() directories",
 			path: "/tmp/kubelet-detect-safe-umount1404256428",
-			want: "/tmp/kubelet-detect-safe-umount[0-9]*[0-9]",
+			want: "/tmp/kubelet-detect-safe-umount*",
 		},
 		{
-			name: "generalize os.MkdirTemp() directories",
-			path: "/tmp/kubelet-detect-safe-umount1404256428/test",
-			want: "/tmp/kubelet-detect-safe-umount[0-9]*[0-9]/test",
+			name: "generalize uuids",
+			path: "/var/lib/kubelet/pods/00112233-4455-6677-8899-aabbccddeeff/",
+			want: "/var/lib/kubelet/pods/*/",
+		},
+		{
+			name: "generalize hashes",
+			path: "/var/lib/kubelet/plugins/kubernetes.io/csi/pd.csi.storage.gke.io/3c5928afbbefea1b0acf34b9acd866d2bcb3d6b6955d4e1fe095a97d487bcb45/globalmountroblem-detector.db",
+			want: "/var/lib/kubelet/plugins/kubernetes.io/csi/pd.csi.storage.gke.io/*/globalmountroblem-detector.db",
 		},
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->
/kind feature


#### What this PR does / why we need it:

This PR adds more generalizations to the AppArmor recorder, for example so that UUIDs in the file path as replaced with `*`.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->
Yes.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
