### PR TITLE
Fix profile install/uninstall path

### DIFF
--- a/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
@@ -95,6 +95,10 @@ func (a *aaProfileManager) CustomResourceTypeName() string {
 	return customResourceTypeName
 }
 
+func profileFilename(profileName string) string {
+	return strings.Trim(strings.ReplaceAll(profileName, "/", "."), ".")
+}
+
 func loadProfile(logger logr.Logger, name, content string) (bool, error) {
 	mount := hostop.NewMountHostOp(
 		hostop.WithLogger(logger),
@@ -104,8 +108,10 @@ func loadProfile(logger logr.Logger, name, content string) (bool, error) {
 
 	err := mount.Do(func() error {
 		// AppArmor convention: A profile for /bin/foo is typically named `bin.foo`.
-		name := strings.Trim(strings.ReplaceAll(name, "/", "."), ".")
-		path := filepath.Join(targetProfileDir, name)
+		path := filepath.Join(
+			targetProfileDir,
+			profileFilename(name),
+		)
 		if err := os.WriteFile(path, []byte(content), 0o644); err != nil { //nolint // file permissions are fine
 			return fmt.Errorf("writing policy file: %w", err)
 		}
@@ -152,7 +158,7 @@ func removeProfile(logger logr.Logger, profileName string) error {
 			return err
 		}
 
-		return os.Remove(filepath.Join(targetProfileDir, profileName))
+		return os.Remove(filepath.Join(targetProfileDir, profileFilename(profileName)))
 	})
 
 	return err


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes a bug where the AppArmor profile manager would calculate different filepaths for installing/uninstalling, thus not properly uninstalling the profile.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Will be transitively tested in a forthcoming PR.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fix a bug where AppArmor profiles with a name containing `/` or `.` weren't deleted properly.
```
