### PR TITLE
can't load security-profiles-operator as dependancy of another operator

### DIFF
--- a/api/selinuxprofile/v1alpha2/rawselinuxprofile_types.go
+++ b/api/selinuxprofile/v1alpha2/rawselinuxprofile_types.go
@@ -69,7 +69,7 @@ func (sp *RawSelinuxProfile) SetImplementationStatus() {
 // GetPolicyName gets the policy module name in the format that
 // we're expecting for parsing.
 func (sp *RawSelinuxProfile) GetPolicyName() string {
-	return sp.GetName() + "_" + sp.GetNamespace()
+	return sp.GetName()
 }
 
 // GetPolicyUsage is the representation of how a pod will call this

--- a/api/selinuxprofile/v1alpha2/selinuxprofile_types.go
+++ b/api/selinuxprofile/v1alpha2/selinuxprofile_types.go
@@ -148,7 +148,7 @@ func (sp *SelinuxProfile) SetImplementationStatus() {
 // GetPolicyName gets the policy module name in the format that
 // we're expecting for parsing.
 func (sp *SelinuxProfile) GetPolicyName() string {
-	return sp.GetName() + "_" + sp.GetNamespace()
+	return sp.GetName()
 }
 
 // GetPolicyUsage is the representation of how a pod will call this

--- a/installation-usage.md
+++ b/installation-usage.md
@@ -1067,10 +1067,10 @@ the resulting CIL policy:
 
 ```shell
 $ kubectl exec -it -c selinuxd spod-fm55x -- sh
-sh-4.4# cat /etc/selinux.d/nginx-secure_nginx-deploy.cil
-(block nginx-secure_nginx-deploy
+sh-4.4# cat /etc/selinux.d/nginx-secure.cil
+(block nginx-secure
 (blockinherit container)
-(allow process nginx-secure_nginx-deploy.process ( tcp_socket ( listen )))
+(allow process nginx-secure.process ( tcp_socket ( listen )))
 (allow process http_cache_port_t ( tcp_socket ( name_bind )))
 (allow process node_t ( tcp_socket ( node_bind )))
 )
@@ -1176,8 +1176,8 @@ kubectl get selinuxprofile
 
 # Output should show the selinux profile.
 
-NAME                              USAGE                                                                STATE
-nginx-recording-nginx-container   nginx-recording-nginx-container_security-profiles-operator.process   partial
+NAME                              USAGE                                     STATE
+nginx-recording-nginx-container   nginx-recording-nginx-container.process   partial
 
 # The content of the profile can be inspected.
 
@@ -1186,7 +1186,7 @@ kubectl get selinuxprofile -o yaml
 
 #### Use SELinux profile
 
-SELinux profiles are referenced based on their `USAGE` type name.
+SELinux profiles are referenced based on their `USAGE` type name, which is `<ProfileName>.process`.
 
 Use this SELinux type in the workload manifest in the `.spec.containers[].securityContext.seLinuxOptions` attribute:
 
@@ -1203,7 +1203,7 @@ spec:
       securityContext:
         seLinuxOptions:
           # NOTE: This uses an appropriate SELinux type
-          type: nginx-recording-nginx-container_security-profiles-operator.process
+          type: nginx-recording-nginx-container.process
 ```
 
 The pod should properly start and run.

--- a/internal/pkg/manager/workloadannotator/workloadannotator.go
+++ b/internal/pkg/manager/workloadannotator/workloadannotator.go
@@ -148,7 +148,7 @@ func (r *PodReconciler) Reconcile(ctx context.Context, req reconcile.Request) (r
 
 	// pod is being created or updated so ensure it is linked to a selinux profile
 	for _, profileIndex := range getSelinuxProfilesFromPod(ctx, r, pod) {
-		profileSuffix := "_" + pod.GetNamespace() + ".process"
+		profileSuffix := ".process"
 		profileName := strings.TrimSuffix(profileIndex, profileSuffix)
 
 		selinuxProfile := &selinuxprofileapi.SelinuxProfile{}
@@ -371,7 +371,7 @@ func isOperatorSelinuxType(ctx context.Context, r *PodReconciler, se *corev1.SEL
 		return false
 	}
 
-	suffix := "_" + ns + ".process"
+	suffix := ".process"
 	selinuxProfileName := strings.TrimSuffix(se.Type, suffix)
 
 	if selinuxProfileName != se.Type {

--- a/internal/pkg/translator/obj2cil.go
+++ b/internal/pkg/translator/obj2cil.go
@@ -79,7 +79,7 @@ func Object2CIL(
 }
 
 func getCILStart(sp *selxv1alpha2.SelinuxProfile) string {
-	return fmt.Sprintf("(block %s_%s\n", sp.GetName(), sp.GetNamespace())
+	return fmt.Sprintf("(block %s\n", sp.GetName())
 }
 
 func getCILInheritline(i string) string {

--- a/internal/pkg/translator/obj2cil_test.go
+++ b/internal/pkg/translator/obj2cil_test.go
@@ -40,8 +40,7 @@ func TestObject2CIL(t *testing.T) {
 			name: "Test errorlogger translation with system inheritance",
 			profile: &selxv1alpha2.SelinuxProfile{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "bar",
+					Name: "foo-bar",
 				},
 				Spec: selxv1alpha2.SelinuxProfileSpec{
 					Inherit: []selxv1alpha2.PolicyRef{
@@ -85,7 +84,7 @@ func TestObject2CIL(t *testing.T) {
 				},
 			},
 			wantMatches: []string{
-				"\\(block foo_bar",
+				"\\(block foo-bar",
 				"\\(blockinherit container\\)",
 				// We match on several lines since we don't care about the order
 				"\\(allow process var_log_t \\( dir \\(.*open.*\\)\\)\\)\n",
@@ -107,8 +106,7 @@ func TestObject2CIL(t *testing.T) {
 			name: "Test translation with @self",
 			profile: &selxv1alpha2.SelinuxProfile{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-selinux-recording-nginx",
-					Namespace: "default",
+					Name: "test-selinux-recording-nginx",
 				},
 				Spec: selxv1alpha2.SelinuxProfileSpec{
 					Inherit: []selxv1alpha2.PolicyRef{
@@ -142,13 +140,13 @@ func TestObject2CIL(t *testing.T) {
 				},
 			},
 			wantMatches: []string{
-				"\\(block test-selinux-recording-nginx_default",
+				"\\(block test-selinux-recording-nginx",
 				"\\(blockinherit container\\)",
 				// We match on several lines since we don't care about the order
 				"\\(allow process http_port_t \\( tcp_socket \\(.*name_bind.*\\)\\)\\)\n",
 				"\\(allow process node_t \\( tcp_socket \\(.*name_bind.*\\)\\)\\)\n",
 				"\\(allow process proc_t \\( filesystem \\(.*associate.*\\)\\)\\)\n",
-				"\\(allow process test-selinux-recording-nginx_default.process \\( tcp_socket " +
+				"\\(allow process test-selinux-recording-nginx.process \\( tcp_socket " +
 					"\\(.*listen.*\\)\\)\\)\n",
 			},
 			inheritsys: []string{
@@ -159,8 +157,7 @@ func TestObject2CIL(t *testing.T) {
 			name: "Test successful inherit reference",
 			profile: &selxv1alpha2.SelinuxProfile{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-selinux-recording-nginx",
-					Namespace: "default",
+					Name: "test-selinux-recording-nginx",
 				},
 				Spec: selxv1alpha2.SelinuxProfileSpec{
 					Inherit: []selxv1alpha2.PolicyRef{
@@ -179,8 +176,8 @@ func TestObject2CIL(t *testing.T) {
 				},
 			},
 			wantMatches: []string{
-				"\\(block test-selinux-recording-nginx_default",
-				"\\(blockinherit foo_default\\)",
+				"\\(block test-selinux-recording-nginx",
+				"\\(blockinherit foo\\)",
 				"\\(allow process http_port_t \\( tcp_socket \\(.*name_bind.*\\)\\)\\)\\n",
 			},
 			doNotMatch: []string{
@@ -189,8 +186,7 @@ func TestObject2CIL(t *testing.T) {
 			inheritobjs: []selxv1alpha2.SelinuxProfileObject{
 				&selxv1alpha2.SelinuxProfile{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      "foo",
-						Namespace: "default",
+						Name: "foo",
 					},
 				},
 			},
@@ -199,8 +195,7 @@ func TestObject2CIL(t *testing.T) {
 			name: "Test errorlogger translation with permissive mode",
 			profile: &selxv1alpha2.SelinuxProfile{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo-permissive",
-					Namespace: "bar",
+					Name: "foo-permissive-bar",
 				},
 				Spec: selxv1alpha2.SelinuxProfileSpec{
 					Permissive: true,
@@ -245,7 +240,7 @@ func TestObject2CIL(t *testing.T) {
 				},
 			},
 			wantMatches: []string{
-				"\\(block foo-permissive_bar",
+				"\\(block foo-permissive-bar",
 				"\\(blockinherit container\\)",
 				"\\(typepermissive process\\)",
 				// We match on several lines since we don't care about the order
@@ -268,8 +263,7 @@ func TestObject2CIL(t *testing.T) {
 			name: "Test translation with another template than container",
 			profile: &selxv1alpha2.SelinuxProfile{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "foo",
-					Namespace: "bar",
+					Name: "foo-bar",
 				},
 				Spec: selxv1alpha2.SelinuxProfileSpec{
 					Inherit: []selxv1alpha2.PolicyRef{
@@ -293,7 +287,7 @@ func TestObject2CIL(t *testing.T) {
 				},
 			},
 			wantMatches: []string{
-				"\\(block foo_bar",
+				"\\(block foo-bar",
 				"\\(blockinherit container\\)",
 				"\\(blockinherit net_container\\)",
 				// We match on several lines since we don't care about the order


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
For #2699
When loaded through OperatorHub as a dependency of another operator, security-profiles-operator is loaded in the namespace of the other operator.  When this happens, any created SelinuxProfile stays in the Pending State.

It appears that the function getDS() is searching for the DaemonSet with a label of "spod". However, the r.client.List() call is returning all DaemonSets in the Namespace and bailing because it found more than one.
    
This commit changes the logic to call Get() instead of GetList().

While trying to verify the above, ran into issues with the move of SelinuxProfile from namespace scoped to cluster scoped (#2745). Recently SelinuxProfile was moved from Namespace scoped to cluster  scoped. Some of the code was still using the Namespace as part of the generation of the "Usage" string. The Namespace was blank, so the usage string just ended in an "\_", something like "policyName_.process". However, workloadannotator was using the application pods namespace and the code to strip the "\_namspace.process" off the usage string to get the actual profile name was failing. So just removed all the logic was appending "_namespace" to the profile name in the Usage since namespace is no longer used.

#### Which issue(s) this PR fixes:
Fixes #2699
Fixes #2745
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
No, but the linked issues describe how to reproduce.
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
The Usage should no longer have an "\_" after the profile name.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
