### PR TITLE
Add missing ppc64le and s390x nix files

### DIFF
--- a/nix/default-bpf-ppc64le.nix
+++ b/nix/default-bpf-ppc64le.nix
@@ -1,0 +1,7 @@
+(import ./nixpkgs.nix {
+  crossSystem = {
+    config = "powerpc64le-unknown-linux-gnu";
+  };
+  overlays = [ (import ./overlay.nix) ];
+}).callPackage ./derivation-bpf.nix
+{ arch = "ppc64le"; }

--- a/nix/default-bpf-s390.nix
+++ b/nix/default-bpf-s390.nix
@@ -1,0 +1,7 @@
+(import ./nixpkgs.nix {
+  crossSystem = {
+    config = "s390x-unknown-linux-musl";
+  };
+  overlays = [ (import ./overlay.nix) ];
+}).callPackage ./derivation-bpf.nix
+{ arch = "s390x"; }

--- a/nix/default-ppc64le.nix
+++ b/nix/default-ppc64le.nix
@@ -1,0 +1,7 @@
+(import ./nixpkgs.nix {
+  crossSystem = {
+    config = "powerpc64le-unknown-linux-gnu";
+  };
+  overlays = [ (import ./overlay.nix) ];
+}).callPackage ./derivation.nix
+{ }

--- a/nix/default-s390x.nix
+++ b/nix/default-s390x.nix
@@ -1,0 +1,7 @@
+(import ./nixpkgs.nix {
+  crossSystem = {
+    config = "s390x-unknown-linux-musl";
+  };
+  overlays = [ (import ./overlay.nix) ];
+}).callPackage ./derivation.nix
+{ }

--- a/nix/default-spoc-ppc64le.nix
+++ b/nix/default-spoc-ppc64le.nix
@@ -1,0 +1,15 @@
+((import ./nixpkgs.nix {
+  crossSystem = {
+    config = "powerpc64le-unknown-linux-gnu";
+  };
+  overlays = [ (import ./overlay.nix) ];
+}).callPackage ./derivation.nix
+  { }).overrideAttrs (x: {
+  buildPhase = ''
+    make build/spoc
+  '';
+
+  installPhase = ''
+    install -Dm755 -t $out build/spoc
+  '';
+})

--- a/nix/default-spoc-s390x.nix
+++ b/nix/default-spoc-s390x.nix
@@ -1,0 +1,15 @@
+((import ./nixpkgs.nix {
+  crossSystem = {
+    config = "s390x-unknown-linux-gnu";
+  };
+  overlays = [ (import ./overlay.nix) ];
+}).callPackage ./derivation.nix
+  { }).overrideAttrs (x: {
+  buildPhase = ''
+    make build/spoc
+  '';
+
+  installPhase = ''
+    install -Dm755 -t $out build/spoc
+  '';
+})


### PR DESCRIPTION


#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Adding the missing nix builders for the new arches.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
