### PR TITLE
Allow individual controllers of manager to be turn on/off

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -384,18 +384,23 @@ func runManager(ctx *cli.Context, info *version.Info) error {
 	}
 
 	enabledControllers := []controller.Controller{}
+
 	if ctx.Bool(nodeStatusControllerFlag) {
 		enabledControllers = append(enabledControllers, nodestatus.NewController())
 	}
+
 	if ctx.Bool(spodControllerFlag) {
 		enabledControllers = append(enabledControllers, spod.NewController())
 	}
+
 	if ctx.Bool(workloadAnnotatorFlag) {
 		enabledControllers = append(enabledControllers, workloadannotator.NewController())
 	}
+
 	if ctx.Bool(recordingMergerFlag) {
 		enabledControllers = append(enabledControllers, recordingmerger.NewController())
 	}
+
 	setupLog.Info("enabled controllers", "controllers", enabledControllers)
 
 	if err := setupEnabledControllers(

--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -78,10 +78,10 @@ import (
 const (
 	spocCmd                  string = "spoc"
 	jsonFlag                 string = "json"
+	nodeStatusControllerFlag string = "with-nodestatus-controller"
 	spodControllerFlag       string = "with-spod-controller"
 	workloadAnnotatorFlag    string = "with-workload-annotator"
 	recordingMergerFlag      string = "with-recording-merger"
-	nodeStatusControllerFlag string = "with-nodestatus-controller"
 	recordingFlag            string = "with-recording"
 	selinuxFlag              string = "with-selinux"
 	apparmorFlag             string = "with-apparmor"
@@ -117,6 +117,11 @@ func main() {
 					Aliases: []string{"w"},
 					Value:   true,
 					Usage:   "the webhook k8s resources are managed by the operator(default true)",
+				},
+				&cli.BoolFlag{
+					Name:  nodeStatusControllerFlag,
+					Value: true,
+					Usage: "Enable the node status controller.",
 				},
 				&cli.BoolFlag{
 					Name:  spodControllerFlag,
@@ -379,6 +384,9 @@ func runManager(ctx *cli.Context, info *version.Info) error {
 	}
 
 	enabledControllers := []controller.Controller{}
+	if ctx.Bool(nodeStatusControllerFlag) {
+		enabledControllers = append(enabledControllers, nodestatus.NewController())
+	}
 	if ctx.Bool(spodControllerFlag) {
 		enabledControllers = append(enabledControllers, spod.NewController())
 	}
@@ -387,9 +395,6 @@ func runManager(ctx *cli.Context, info *version.Info) error {
 	}
 	if ctx.Bool(recordingMergerFlag) {
 		enabledControllers = append(enabledControllers, recordingmerger.NewController())
-	}
-	if ctx.Bool(nodeStatusControllerFlag) {
-		enabledControllers = append(enabledControllers, nodestatus.NewController())
 	}
 	setupLog.Info("enabled controllers", "controllers", enabledControllers)
 


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

So that controllers that are not needed for certain clusters can be turned off. E.g. recordingmerger can be turned off if a cluster doesn't use the recording feature.

#### Does this PR have test?

Covered by existing tests.

#### Does this PR introduce a user-facing change?

```release-note
Users can turn off the controllers by explicitly setting the flags to false.
```