### PR TITLE
Fix the logging at the given verbosity

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -283,7 +283,8 @@ func initialize(ctx *cli.Context) error {
 }
 
 func initLogging(ctx *cli.Context) error {
-	ctrl.SetLogger(textlogger.NewLogger(textlogger.NewConfig()))
+	logConfig := textlogger.NewConfig()
+	ctrl.SetLogger(textlogger.NewLogger(logConfig))
 
 	set := flag.NewFlagSet("logging", flag.ContinueOnError)
 	klog.InitFlags(set)
@@ -294,6 +295,9 @@ func initLogging(ctx *cli.Context) error {
 	}
 
 	ctrl.SetLogger(ctrl.Log.V(int(level)))
+	if err := logConfig.Verbosity().Set(fmt.Sprintf("%d", level)); err != nil {
+		return fmt.Errorf("setting the verbosity flag to level %d : %w", level, err)
+	}
 	ctrl.Log.Info(fmt.Sprintf("Set logging verbosity to %d", level))
 
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Sets the configured verbosity to the logr.
Currently logging with verbosity:
```
e.logger.V(config.VerboseLevel).Info("Got line: " + line)
```
does not produce any log in the output when configured as described here https://github.com/kubernetes-sigs/security-profiles-operator/blob/main/installation-usage.md#set-logging-verbosity

The fix addresses this issue by setting the verbosity given by the user. The default logging level is not changed.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

```
