### PR TITLE
Fix permission denied when loading apparmor profiles

### DIFF
--- a/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
+++ b/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
@@ -347,6 +347,7 @@ data:
           allowedExecutables:
           - /security-profiles-operator
           - /usr/sbin/apparmor_parser
+          - /sbin/apparmor_parser
         filesystem:
           readOnlyPaths:
           - /  # workaround for apparmor bug

--- a/deploy/base/profiles/spo-apparmor.yaml
+++ b/deploy/base/profiles/spo-apparmor.yaml
@@ -18,6 +18,7 @@ spec:
       allowedExecutables:
       - /security-profiles-operator
       - /usr/sbin/apparmor_parser
+      - /sbin/apparmor_parser
     filesystem:
       readOnlyPaths:
       - /  # workaround for apparmor bug

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -1033,6 +1033,7 @@ data:
           allowedExecutables:
           - /security-profiles-operator
           - /usr/sbin/apparmor_parser
+          - /sbin/apparmor_parser
         filesystem:
           readOnlyPaths:
           - /  # workaround for apparmor bug

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -3316,6 +3316,7 @@ data:
           allowedExecutables:
           - /security-profiles-operator
           - /usr/sbin/apparmor_parser
+          - /sbin/apparmor_parser
         filesystem:
           readOnlyPaths:
           - /  # workaround for apparmor bug

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3298,6 +3298,7 @@ data:
           allowedExecutables:
           - /security-profiles-operator
           - /usr/sbin/apparmor_parser
+          - /sbin/apparmor_parser
         filesystem:
           readOnlyPaths:
           - /  # workaround for apparmor bug

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -3329,6 +3329,7 @@ data:
           allowedExecutables:
           - /security-profiles-operator
           - /usr/sbin/apparmor_parser
+          - /sbin/apparmor_parser
         filesystem:
           readOnlyPaths:
           - /  # workaround for apparmor bug

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3316,6 +3316,7 @@ data:
           allowedExecutables:
           - /security-profiles-operator
           - /usr/sbin/apparmor_parser
+          - /sbin/apparmor_parser
         filesystem:
           readOnlyPaths:
           - /  # workaround for apparmor bug

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3287,6 +3287,7 @@ data:
           allowedExecutables:
           - /security-profiles-operator
           - /usr/sbin/apparmor_parser
+          - /sbin/apparmor_parser
         filesystem:
           readOnlyPaths:
           - /  # workaround for apparmor bug


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Allowing spod to exec the apparmor_parser

#### Which issue(s) this PR fixes:

Loading apparmor profiles failed on GCP COS after https://github.com/kubernetes-sigs/security-profiles-operator/pull/2771

It is because both /usr/sbin/apparmor_parser and /sbin/apparmor_parser
can be the location of apparmor parser based on https://github.com/kubernetes-sigs/security-profiles-operator/blob/ed66f8e5eb0fb5bd5138024ef93fb6facbbd40b0/vendor/github.com/pjbgf/go-apparmor/pkg/apparmor/apparmor_linux.go#L177

#### Does this PR have test?

Tested on GKE

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?



```release-note
None
```
