### PR TITLE
Doc updates for developers of security profiles operator

### DIFF
--- a/hacking.md
+++ b/hacking.md
@@ -16,6 +16,8 @@ There are currently two optional features at build time
 - eBPF based recording
   - This feature requires a rather new `libbpf` which requires a new `libelf`
     version which in turn requires a new `libz` version.
+    - Install the necessary libraries based on your build OS.
+      For example, on Fedora, you'll need to install the RPMs `elfutils-libelf-devel` and `libbpf-devel`
   - disable with `BPF_ENABLED=0`
 - AppArmor
   - This feature requires apparmor headers and development libraries as well as the `go-apparmor` bindings
@@ -35,6 +37,8 @@ for actually deploying the operator, `libseccomp` is not optional and whether
 to build against seccomp is determined automatically based on the build
 platform.
 
+Also make sure you have `clang-tools-extra` installed
+
 To build SPO with all the features simply run:
 ```shell
 make
@@ -43,6 +47,31 @@ To disable features, prefix `make` with environment variables that deselect them
 ```shell
 BPF_ENABLED=0 APPARMOR_ENABLED=0 make
 ```
+
+In most cases you will need a container image. You can build by running:
+```shell
+make image
+```
+
+## Submitting a Pull Request (PR)
+
+Here's the process for contributing your changes:
+
+1.  **Fork and Branch:**
+    * First, create your own copy (a "fork") of the [main repository](https://github.com/kubernetes-sigs/security-profiles-operator) on GitHub.
+    * Then, create a new branch within your forked repository to work on your changes.
+
+2.  **Build and Test:**
+    * Build a container image of your changes. This ensures your code runs in a kubernetes environment (Ex: OpenShift).
+
+3.  **Verify:**
+    * Run the command `make verify`. This command executes automated checks (like code style) to ensure your changes meet the project's standards. Make sure this command passes without any errors.
+
+4.  **PR Description:**
+    * When you create your Pull Request to merge your changes back into the main repository, please provide a clear description.
+    * Specifically, make sure to clearly indicate:
+        * **Type of PR:** What kind of change is this?
+        * **User-facing change:** If your changes will be noticeable to users of the project, briefly explain what those changes are. If not, you can state "NONE"
 
 ## Running unit tests and viewing coverage
 SPO uses the Go's `testing` library augmented with [testify](https://github.com/stretchr/testify)

--- a/hacking.md
+++ b/hacking.md
@@ -71,7 +71,7 @@ Here's the process for contributing your changes:
     * When you create your Pull Request to merge your changes back into the main repository, please provide a clear description.
     * Specifically, make sure to clearly indicate:
         * **Type of PR:** What kind of change is this?
-        * **User-facing change:** If your changes will be noticeable to users of the project, briefly explain what those changes are. If not, you can state "NONE"
+        * **User-facing change:** If your changes will be noticeable to users of the project, briefly explain what those changes are. If not, you must state "NONE"
 
 ## Running unit tests and viewing coverage
 SPO uses the Go's `testing` library augmented with [testify](https://github.com/stretchr/testify)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind documentation
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Updates the hacking doc to help developers of SPO. It specifically calls out `make verify` to make sure that the reviewer gets to see the final code that will pass code style checks.
- The doc change also make sure that required libraries are installed for compiling.
- In most cases its the container image that's required to test and hence updated the doc to mention it

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
