### PR TITLE
Process backlog before the new audit log to maintain ordering

### DIFF
--- a/internal/pkg/daemon/enricher/enricher_test.go
+++ b/internal/pkg/daemon/enricher/enricher_test.go
@@ -281,13 +281,9 @@ func TestRun(t *testing.T) {
 				require.Equal(t, 0, mock.GetFromBacklogCallCount())
 
 				lineChan <- &tail.Line{
-					Text: avcLine,
+					Text: seccompLine,
 					Time: time.Now(),
 				}
-
-				// the other line shouldn't hit the backlog, so there
-				// should be still only one write to backlog
-				require.Equal(t, 1, mock.AddToBacklogCallCount())
 
 				// add something to the mock backlog
 				mock.GetFromBacklogReturns(
@@ -306,6 +302,10 @@ func TestRun(t *testing.T) {
 					},
 				)
 
+				// the other line shouldn't hit the backlog, so there
+				// should be still only one write to backlog
+				require.Equal(t, 1, mock.AddToBacklogCallCount())
+
 				for mock.GetFromBacklogCallCount() != 1 {
 					// Make sure the backlog was read from when the avcs
 					// were dispatched
@@ -316,6 +316,14 @@ func TestRun(t *testing.T) {
 					// that it was not empty and the mock entry was
 					// actually processed
 				}
+
+				for mock.SendMetricCallCount() != 2 {
+				}
+				_, firstSysCall := mock.SendMetricArgsForCall(0)
+				require.NotNil(t, firstSysCall.GetSelinuxReq())
+				_, secondSysCall := mock.SendMetricArgsForCall(1)
+				require.NotNil(t, secondSysCall.GetSeccompReq())
+
 				require.NoError(t, err)
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR addresses an issue where audit log messages could be processed out of order.

**Problem:**

- Audit logs arriving before container information was available were added to a backlog.
- The backlog was processed *after* the audit log message for which container info was available, leading to incorrect log message ordering.

**Fix:**

- The backlog is now **cleared** before processing any new audit log line for which container info was available.
- Removed an unnecessary loop variable and nil check in the backlog processing logic.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
Yes, Unit test is added to ensure ordering is checked
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
