### PR TITLE
Allow seccompprofile controller to be turned off in spod

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -84,6 +84,7 @@ const (
 	workloadAnnotatorFlag    string = "with-workload-annotator"
 	recordingMergerFlag      string = "with-recording-merger"
 	recordingFlag            string = "with-recording"
+	seccompFlag              string = "with-seccomp"
 	selinuxFlag              string = "with-selinux"
 	apparmorFlag             string = "with-apparmor"
 	webhookFlag              string = "webhook"
@@ -150,6 +151,11 @@ func main() {
 				return runDaemon(ctx, info)
 			},
 			Flags: []cli.Flag{
+				&cli.BoolFlag{
+					Name:  seccompFlag,
+					Usage: "Listen for seccomp API resources",
+					Value: true,
+				},
 				&cli.BoolFlag{
 					Name:  selinuxFlag,
 					Usage: "Listen for SELinux API resources",
@@ -466,8 +472,10 @@ func setControllerOptionsForNamespaces(opts *ctrl.Options) {
 }
 
 func getEnabledControllers(ctx *cli.Context) []controller.Controller {
-	controllers := []controller.Controller{
-		seccompprofile.NewController(),
+	controllers := []controller.Controller{}
+
+	if ctx.Bool(seccompFlag) {
+		controllers = append(controllers, seccompprofile.NewController())
 	}
 
 	if ctx.Bool(recordingFlag) {


### PR DESCRIPTION
#### What type of PR is this?

/kind feature


#### What this PR does / why we need it:

Allow seccompprofile controller to be turned off in spo daemonset like other controllers.
The default behavior is still on to match the current default behavior.

#### Does this PR have test?

N/A


#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```

