### PR TITLE
Minor refactor to audit log parsing and unit tests

### DIFF
--- a/internal/pkg/daemon/common/common.go
+++ b/internal/pkg/daemon/common/common.go
@@ -30,13 +30,11 @@ import (
 // GetSPODName returns the name of the SPOD instance we're currently running
 // on.
 func GetSPODName() string {
-	name := os.Getenv(config.SPOdNameEnvKey)
-	if name == "" {
-		// Return the default spod name
-		return config.SPOdName
+	if name := os.Getenv(config.SPOdNameEnvKey); name != "" {
+		return name
 	}
 
-	return name
+	return config.SPOdName
 }
 
 // GetSPOD returns the SPOD instance we're currently running on.

--- a/internal/pkg/daemon/common/common_test.go
+++ b/internal/pkg/daemon/common/common_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2021 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
+)
+
+func Test_GetSPODNameNonDefault(t *testing.T) {
+	t.Setenv(config.SPOdNameEnvKey, "customSPODName")
+
+	require.Equal(t, "customSPODName", GetSPODName())
+}
+
+func Test_GetSPODNameDefault(t *testing.T) {
+	t.Setenv(config.SPOdNameEnvKey, "")
+
+	require.Equal(t, config.SPOdName, GetSPODName())
+}

--- a/internal/pkg/daemon/enricher/audit.go
+++ b/internal/pkg/daemon/enricher/audit.go
@@ -85,25 +85,25 @@ func extractSeccompLine(logLine string) *types.AuditLine {
 		return nil
 	}
 
-	line := types.AuditLine{}
-	line.AuditType = types.AuditTypeSeccomp
-	line.TimestampID = captures[2]
-	line.Executable = captures[4]
-
-	if v, err := strconv.Atoi(captures[3]); err == nil {
-		line.ProcessID = v
+	line := types.AuditLine{
+		AuditType:   types.AuditTypeSeccomp,
+		TimestampID: captures[2],
+		Executable:  captures[4],
 	}
 
-	const (
-		base    = 10
-		bitSize = 32
-	)
+	extractProcessId(&line, captures[3])
 
-	if v, err := strconv.ParseInt(captures[5], base, bitSize); err == nil {
-		line.SystemCallID = int32(v)
+	if syscallID, err := strconv.ParseInt(captures[5], 10, 32); err == nil {
+		line.SystemCallID = int32(syscallID)
 	}
 
 	return &line
+}
+
+func extractProcessId(line *types.AuditLine, capturedProcessID string) {
+	if pid, err := strconv.Atoi(capturedProcessID); err == nil {
+		line.ProcessID = pid
+	}
 }
 
 func extractSelinuxLine(logLine string) *types.AuditLine {
@@ -112,14 +112,13 @@ func extractSelinuxLine(logLine string) *types.AuditLine {
 		return nil
 	}
 
-	line := types.AuditLine{}
-	line.AuditType = types.AuditTypeSelinux
-	line.TimestampID = captures[1]
-	line.Perm = captures[2]
-
-	if v, err := strconv.Atoi(captures[3]); err == nil {
-		line.ProcessID = v
+	line := types.AuditLine{
+		AuditType:   types.AuditTypeSelinux,
+		TimestampID: captures[1],
+		Perm:        captures[2],
 	}
+
+	extractProcessId(&line, captures[3])
 
 	line.Scontext = captures[4]
 	line.Tcontext = captures[5]
@@ -134,18 +133,17 @@ func extractApparmorLine(logLine string) *types.AuditLine {
 		return nil
 	}
 
-	line := types.AuditLine{}
-	line.AuditType = types.AuditTypeApparmor
-	line.TimestampID = captures[2]
-	line.Apparmor = captures[3]
-	line.Operation = captures[4]
-	line.Profile = captures[5]
-	line.Name = captures[6]
-	line.Executable = captures[8]
-
-	if v, err := strconv.Atoi(captures[7]); err == nil {
-		line.ProcessID = v
+	line := types.AuditLine{
+		AuditType:   types.AuditTypeApparmor,
+		TimestampID: captures[2],
+		Apparmor:    captures[3],
+		Operation:   captures[4],
+		Profile:     captures[5],
+		Name:        captures[6],
+		Executable:  captures[8],
 	}
+
+	extractProcessId(&line, captures[7])
 
 	if len(captures) > minAppArmorCapturesExpected {
 		line.ExtraInfo = strings.ReplaceAll(captures[9], "\"", "'")

--- a/internal/pkg/daemon/enricher/audit_test.go
+++ b/internal/pkg/daemon/enricher/audit_test.go
@@ -52,6 +52,12 @@ func Test_isAuditLine(t *testing.T) {
 			true,
 		},
 		{
+			"Should identify type=SECCOMP log lines from user activity inside the container",
+			//nolint:lll // no need to wrap
+			`type=SECCOMP msg=audit(1744780616.598:836036): auid=4294967295 uid=0 gid=0 ses=4294967295 subj=system_u:system_r:container_t:s0:c83,c152 pid=72503 comm="sh" exe="/bin/dash" sig=0 arch=c000003e syscall=56 compat=0 ip=0x7fe2ff5017be code=0x7ffc0000AUID="unset" UID="root" GID="root" ARCH=x86_64 SYSCALL=clone`,
+			true,
+		},
+		{
 			"Should ignore unsupported log types",
 			//nolint:lll // no need to wrap
 			`audit: type=1016 audit(1611996299.149:466250): auid=4294967295 uid=0 gid=0 ses=4294967295 pid=615549 comm="sh" exe="/bin/busybox" sig=0 arch=c000003e syscall=1 compat=0 ip=0x7f61a81c5923 code=0x7ffc0000`,


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
- Minor refactor to audit log parsing and unit tests: Created the audit struct with all the fields.
- Adds a test for handling the syscall by doing exec

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
Yes
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
