### PR TITLE
Reapply AppArmor profile only for actual changes

### DIFF
--- a/internal/pkg/daemon/apparmorprofile/setup.go
+++ b/internal/pkg/daemon/apparmorprofile/setup.go
@@ -20,6 +20,7 @@ import (
 	"context"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	"sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1alpha1"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/metrics"
@@ -43,5 +44,6 @@ func (r *Reconciler) Setup(
 	return ctrl.NewControllerManagedBy(mgr).
 		Named("apparmorprofile").
 		For(&v1alpha1.AppArmorProfile{}).
+		WithEventFilter(predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{})).
 		Complete(r)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

AppArmor profiles are currently reapplied periodically even nothing is changed. Add an event filter so that it happens only when spec changes or label changes.

#### Does this PR have test?

Manually on a GKE cluster.


