### PR TITLE
#2857: Add Request UID to JSON log enricher to correlate container and API Server Audit log

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -75,6 +75,7 @@ import (
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/util"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/version"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/webhooks/binding"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/webhooks/execmetadata"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/webhooks/recording"
 )
 
@@ -811,6 +812,7 @@ func runWebhook(ctx *cli.Context, info *version.Info) error {
 	hookserver := mgr.GetWebhookServer()
 	binding.RegisterWebhook(hookserver, mgr.GetScheme(), mgr.GetClient())
 	recording.RegisterWebhook(hookserver, mgr.GetScheme(), mgr.GetEventRecorderFor("recording-webhook"), mgr.GetClient())
+	execmetadata.RegisterWebhook(hookserver)
 
 	sigHandler := ctrl.SetupSignalHandler()
 

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	golang.org/x/mod v0.25.0
 	golang.org/x/net v0.41.0
 	golang.org/x/sync v0.15.0
+	gomodules.xyz/jsonpatch/v2 v2.4.0
 	google.golang.org/grpc v1.73.0
 	google.golang.org/grpc/cmd/protoc-gen-go-grpc v1.5.1
 	google.golang.org/protobuf v1.36.6
@@ -268,7 +269,6 @@ require (
 	golang.org/x/text v0.26.0 // indirect
 	golang.org/x/time v0.12.0 // indirect
 	golang.org/x/tools v0.34.0 // indirect
-	gomodules.xyz/jsonpatch/v2 v2.4.0 // indirect
 	google.golang.org/api v0.237.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20250519155744-55703ea1f237 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250603155806-513f23925822 // indirect

--- a/internal/pkg/daemon/enricher/enricher.go
+++ b/internal/pkg/daemon/enricher/enricher.go
@@ -70,7 +70,7 @@ type Enricher struct {
 // New returns a new Enricher instance.
 func New(logger logr.Logger) *Enricher {
 	return &Enricher{
-		impl:   &defaultImpl{},
+		impl:   newDefaultImpl(),
 		source: auditsource.NewAuditdSource(logger),
 		logger: logger,
 		containerIDCache: ttlcache.New(

--- a/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
+++ b/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
@@ -121,6 +121,19 @@ type FakeImpl struct {
 		result2 context.CancelFunc
 		result3 error
 	}
+	EnvForPidStub        func(int) (map[string]string, error)
+	envForPidMutex       sync.RWMutex
+	envForPidArgsForCall []struct {
+		arg1 int
+	}
+	envForPidReturns struct {
+		result1 map[string]string
+		result2 error
+	}
+	envForPidReturnsOnCall map[int]struct {
+		result1 map[string]string
+		result2 error
+	}
 	FlushBacklogStub        func(*ttlcache.Cache[string, []*types.AuditLine], string)
 	flushBacklogMutex       sync.RWMutex
 	flushBacklogArgsForCall []struct {
@@ -735,6 +748,70 @@ func (fake *FakeImpl) DialReturnsOnCall(i int, result1 *grpc.ClientConn, result2
 		result2 context.CancelFunc
 		result3 error
 	}{result1, result2, result3}
+}
+
+func (fake *FakeImpl) EnvForPid(arg1 int) (map[string]string, error) {
+	fake.envForPidMutex.Lock()
+	ret, specificReturn := fake.envForPidReturnsOnCall[len(fake.envForPidArgsForCall)]
+	fake.envForPidArgsForCall = append(fake.envForPidArgsForCall, struct {
+		arg1 int
+	}{arg1})
+	stub := fake.EnvForPidStub
+	fakeReturns := fake.envForPidReturns
+	fake.recordInvocation("EnvForPid", []interface{}{arg1})
+	fake.envForPidMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) EnvForPidCallCount() int {
+	fake.envForPidMutex.RLock()
+	defer fake.envForPidMutex.RUnlock()
+	return len(fake.envForPidArgsForCall)
+}
+
+func (fake *FakeImpl) EnvForPidCalls(stub func(int) (map[string]string, error)) {
+	fake.envForPidMutex.Lock()
+	defer fake.envForPidMutex.Unlock()
+	fake.EnvForPidStub = stub
+}
+
+func (fake *FakeImpl) EnvForPidArgsForCall(i int) int {
+	fake.envForPidMutex.RLock()
+	defer fake.envForPidMutex.RUnlock()
+	argsForCall := fake.envForPidArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeImpl) EnvForPidReturns(result1 map[string]string, result2 error) {
+	fake.envForPidMutex.Lock()
+	defer fake.envForPidMutex.Unlock()
+	fake.EnvForPidStub = nil
+	fake.envForPidReturns = struct {
+		result1 map[string]string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) EnvForPidReturnsOnCall(i int, result1 map[string]string, result2 error) {
+	fake.envForPidMutex.Lock()
+	defer fake.envForPidMutex.Unlock()
+	fake.EnvForPidStub = nil
+	if fake.envForPidReturnsOnCall == nil {
+		fake.envForPidReturnsOnCall = make(map[int]struct {
+			result1 map[string]string
+			result2 error
+		})
+	}
+	fake.envForPidReturnsOnCall[i] = struct {
+		result1 map[string]string
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeImpl) FlushBacklog(arg1 *ttlcache.Cache[string, []*types.AuditLine], arg2 string) {
@@ -1755,6 +1832,8 @@ func (fake *FakeImpl) Invocations() map[string][][]interface{} {
 	defer fake.containerIDForPIDMutex.RUnlock()
 	fake.dialMutex.RLock()
 	defer fake.dialMutex.RUnlock()
+	fake.envForPidMutex.RLock()
+	defer fake.envForPidMutex.RUnlock()
 	fake.flushBacklogMutex.RLock()
 	defer fake.flushBacklogMutex.RUnlock()
 	fake.getFromBacklogMutex.RLock()

--- a/internal/pkg/daemon/enricher/impl_test.go
+++ b/internal/pkg/daemon/enricher/impl_test.go
@@ -1,0 +1,140 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package enricher
+
+import (
+	"testing"
+	"testing/fstest"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestDefaultImpl_EnvForPid(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		prepare func() *fstest.MapFS
+		assert  func(env map[string]string, retErr error)
+	}{
+		{
+			// Test the best case
+			prepare: func() *fstest.MapFS {
+				return &fstest.MapFS{
+					"proc/1234/environ": {Data: []byte("hello=world")},
+				}
+			},
+			assert: func(env map[string]string, retErr error) {
+				require.NoError(t, retErr)
+				require.Equal(t, "world", env["hello"])
+			},
+		},
+		{
+			// Test key with empty value
+			prepare: func() *fstest.MapFS {
+				return &fstest.MapFS{
+					"proc/1234/environ": {Data: []byte("hello=")},
+				}
+			},
+			assert: func(env map[string]string, retErr error) {
+				require.NoError(t, retErr)
+				require.Len(t, env, 1)
+			},
+		},
+		{
+			// Test keys with no equals sign
+			prepare: func() *fstest.MapFS {
+				return &fstest.MapFS{
+					"proc/1234/environ": {Data: []byte("hello")},
+				}
+			},
+			assert: func(env map[string]string, retErr error) {
+				require.NoError(t, retErr)
+				require.Empty(t, env)
+			},
+		},
+		{
+			// Test empty lines
+			prepare: func() *fstest.MapFS {
+				return &fstest.MapFS{
+					"proc/1234/environ": {Data: []byte("hello=world\x00\x00\x00test1=test2")},
+				}
+			},
+			assert: func(env map[string]string, retErr error) {
+				require.NoError(t, retErr)
+				require.Equal(t, "world", env["hello"])
+				require.Equal(t, "test2", env["test1"])
+				require.Len(t, env, 2)
+			},
+		},
+		{
+			// Test incorrect file
+			prepare: func() *fstest.MapFS {
+				return &fstest.MapFS{
+					"proc/unknown/environ": {Data: []byte("hello=world")},
+				}
+			},
+			assert: func(env map[string]string, retErr error) {
+				require.Error(t, retErr)
+			},
+		},
+	} {
+		testImpl := defaultImpl{
+			fsys: tc.prepare(),
+		}
+		env, err := testImpl.EnvForPid(1234)
+		tc.assert(env, err)
+	}
+}
+
+func TestDefaultImpl_CmdlineForPID(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		prepare func() *fstest.MapFS
+		assert  func(cmd string, retErr error)
+	}{
+		{
+			// Test the best case
+			prepare: func() *fstest.MapFS {
+				return &fstest.MapFS{
+					"proc/1234/cmdline": {Data: []byte("/sh")},
+				}
+			},
+			assert: func(cmd string, retErr error) {
+				require.NoError(t, retErr)
+				require.Equal(t, "/sh", cmd)
+			},
+		},
+		{
+			// Test incorrect file
+			prepare: func() *fstest.MapFS {
+				return &fstest.MapFS{
+					"proc/unknown/environ": {Data: []byte("/sh")},
+				}
+			},
+			assert: func(cmd string, retErr error) {
+				require.Error(t, retErr)
+			},
+		},
+	} {
+		testImpl := defaultImpl{
+			fsys: tc.prepare(),
+		}
+		cmd, err := testImpl.CmdlineForPID(1234)
+		tc.assert(cmd, err)
+	}
+}

--- a/internal/pkg/daemon/enricher/process.go
+++ b/internal/pkg/daemon/enricher/process.go
@@ -36,6 +36,10 @@ var (
 	ErrCmdlineNotFound = errors.New("cmdline empty or not found for the process")
 )
 
+const (
+	requestIdEnv = "SPO_EXEC_REQUEST_UID"
+)
+
 func GetProcessInfo(
 	pid int, executable string, uid, gid uint32,
 	processCache *ttlcache.Cache[int, *types.ProcessInfo],
@@ -76,7 +80,17 @@ func populateProcessCache(
 
 	cmdLine, err := impl.CmdlineForPID(pid)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to get cmdline for pid %d: %w", pid, err)
+	}
+
+	env, err := impl.EnvForPid(pid)
+	if err != nil {
+		return fmt.Errorf("failed to get env for pid %d: %w", pid, err)
+	}
+
+	reqId, ok := env[requestIdEnv]
+	if ok {
+		procInfo.ExecRequestId = &reqId
 	}
 
 	procInfo.CmdLine = cmdLine

--- a/internal/pkg/daemon/enricher/types/types.go
+++ b/internal/pkg/daemon/enricher/types/types.go
@@ -16,7 +16,9 @@ limitations under the License.
 
 package types
 
-import "sync"
+import (
+	"sync"
+)
 
 const (
 	AuditTypeSeccomp  = "seccomp"
@@ -62,13 +64,13 @@ type ContainerInfo struct {
 }
 
 type ProcessInfo struct {
-	Pid        int
-	CmdLine    string
-	Uid        uint32
-	Gid        uint32
-	Executable string
+	Pid           int
+	CmdLine       string
+	Uid           uint32
+	Gid           uint32
+	Executable    string
+	ExecRequestId *string
 }
-
 type LogBucket struct {
 	SyscallIds    sync.Map
 	ContainerInfo *ContainerInfo

--- a/internal/pkg/manager/spod/bindata/webhook.go
+++ b/internal/pkg/manager/spod/bindata/webhook.go
@@ -39,10 +39,9 @@ import (
 var (
 	replicas                int32 = 3
 	defaultMode             int32 = 420
-	failurePolicy                 = admissionregv1.Fail
+	failurePolicyFail             = admissionregv1.Fail
+	failurePolicyIgnore           = admissionregv1.Ignore
 	caBundle                      = []byte("Cg==")
-	bindingPath                   = "/mutate-v1-pod-binding"
-	recordingPath                 = "/mutate-v1-pod-recording"
 	sideEffects                   = admissionregv1.SideEffectClassNone
 	admissionReviewVersions       = []string{"v1beta1"}
 	rules                         = []admissionregv1.RuleWithOperations{
@@ -54,6 +53,18 @@ var (
 				APIGroups:   []string{""},
 				APIVersions: []string{"v1"},
 				Resources:   []string{"pods"},
+			},
+		},
+	}
+	rulesExec = []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{
+				"*",
+			},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{""},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"pods/exec"},
 			},
 		},
 	}
@@ -86,6 +97,18 @@ const (
 	webhookServerCert  = "webhook-server-cert"
 )
 
+type webhook struct {
+	index int
+	name  string
+	path  string
+}
+
+var (
+	binding      = webhook{0, "binding.spo.io", "/mutate-v1-pod-binding"}
+	recording    = webhook{1, "recording.spo.io", "/mutate-v1-pod-recording"}
+	execMetadata = webhook{2, "execmetadata.spo.io", "/mutate-v1-exec-metadata"}
+)
+
 type Webhook struct {
 	log        logr.Logger
 	deployment *appsv1.Deployment
@@ -102,6 +125,7 @@ func GetWebhook(
 	caInjectType CAInjectType,
 	tolerations []corev1.Toleration,
 	imagePullSecrets []corev1.LocalObjectReference,
+	execMetadataWebhookEnabled bool,
 ) *Webhook {
 	deployment := webhookDeployment.DeepCopy()
 	deployment.Namespace = namespace
@@ -118,10 +142,14 @@ func GetWebhook(
 	ctr.Image = image
 	ctr.ImagePullPolicy = pullPolicy
 
-	cfg := webhookConfig.DeepCopy()
+	cfg := getWebhookConfig(execMetadataWebhookEnabled).DeepCopy()
 	cfg.Namespace = namespace
-	cfg.Webhooks[0].ClientConfig.Service.Namespace = namespace
-	cfg.Webhooks[1].ClientConfig.Service.Namespace = namespace
+	cfg.Webhooks[binding.index].ClientConfig.Service.Namespace = namespace
+	cfg.Webhooks[recording.index].ClientConfig.Service.Namespace = namespace
+
+	if execMetadataWebhookEnabled {
+		cfg.Webhooks[execMetadata.index].ClientConfig.Service.Namespace = namespace
+	}
 
 	service := webhookService.DeepCopy()
 	service.Namespace = namespace
@@ -211,6 +239,10 @@ func (w *Webhook) NeedsUpdate(ctx context.Context, c client.Client) (bool, error
 	}
 
 	if len(existingWebHook.Webhooks) != len(w.config.Webhooks) {
+		w.log.V(1).Info("updating webhook configuration",
+			"len(existingWebHook)", len(existingWebHook.Webhooks),
+			"len(config)", len(w.config.Webhooks))
+
 		return true, nil
 	}
 
@@ -224,7 +256,11 @@ func (w *Webhook) NeedsUpdate(ctx context.Context, c client.Client) (bool, error
 				continue
 			}
 
-			if webhookNeedsUpdate(&ew, &cw) {
+			if w.webhookNeedsUpdate(&ew, j) {
+				w.log.V(1).Info("updating webhook configuration",
+					"configName", cw.Name,
+					"existingName", ew.Name)
+
 				return true, nil
 			}
 		}
@@ -234,46 +270,95 @@ func (w *Webhook) NeedsUpdate(ctx context.Context, c client.Client) (bool, error
 }
 
 // only compare the settings that are tunable in spod now.
-func webhookNeedsUpdate(existing, configured *admissionregv1.MutatingWebhook) bool {
+func (w *Webhook) webhookNeedsUpdate(existing *admissionregv1.MutatingWebhook, index int) bool {
+	configured := w.config.Webhooks[index]
+
+	// comparing pointers, not values
 	if existing.FailurePolicy == nil && configured.FailurePolicy != nil ||
 		existing.FailurePolicy != nil && configured.FailurePolicy == nil {
-		// comparing pointers, not values
+		w.log.V(1).Info("updating webhook configuration",
+			"existing FailurePolicy", existing.FailurePolicy,
+			"configured FailurePolicy", configured.FailurePolicy)
+
 		return true
 	}
 
+	// comparing values this time
 	if existing.FailurePolicy != nil &&
 		configured.FailurePolicy != nil &&
 		*existing.FailurePolicy != *configured.FailurePolicy {
-		// comparing values this time
+		w.log.V(1).Info("updating webhook configuration",
+			"existing FailurePolicy", existing.FailurePolicy,
+			"configured FailurePolicy", configured.FailurePolicy)
+
 		return true
 	}
 
-	if existing.NamespaceSelector == nil && configured.NamespaceSelector != nil ||
-		existing.NamespaceSelector != nil && configured.NamespaceSelector == nil {
-		// comparing pointers, not values
+	// Both nil and empty object selector are equal
+	// Some platform set the Namespace selector as empty when nil is configured
+	if existing.NamespaceSelector != nil && configured.NamespaceSelector == nil {
+		if existing.NamespaceSelector.Size() > 0 {
+			w.log.V(1).Info("updating webhook configuration",
+				"existing ObjectSelector", existing.ObjectSelector,
+				"configured ObjectSelector", configured.ObjectSelector)
+
+			return true
+		}
+	}
+
+	// comparing pointers, not values
+	if existing.NamespaceSelector == nil && configured.NamespaceSelector != nil {
+		w.log.V(1).Info("updating webhook configuration",
+			"existing NamespaceSelector", existing.NamespaceSelector,
+			"configured NamespaceSelector", configured.NamespaceSelector)
+
 		return true
 	}
 
+	// Only compare managed labels, all others are out of scope
 	if existing.NamespaceSelector != nil && configured.NamespaceSelector != nil {
-		// Only compare managed labels, all others are out of scope
 		for _, label := range []string{EnableBindingLabel, EnableRecordingLabel} {
 			if namespaceSelectorUnequalForLabel(label, existing.NamespaceSelector, configured.NamespaceSelector) {
+				w.log.V(1).Info("updating webhook configuration",
+					"existing NamespaceSelector", existing.NamespaceSelector,
+					"configured NamespaceSelector", configured.NamespaceSelector)
+
 				return true
 			}
 		}
 	}
 
-	if existing.ObjectSelector == nil && configured.ObjectSelector != nil ||
-		existing.ObjectSelector != nil && configured.ObjectSelector == nil {
-		// comparing pointers, not values
+	// Both nil and empty object selector are equal
+	if existing.ObjectSelector != nil && configured.ObjectSelector == nil {
+		if existing.ObjectSelector.Size() > 0 {
+			w.log.V(1).Info("updating webhook configuration",
+				"existing ObjectSelector", existing.ObjectSelector,
+				"configured ObjectSelector", configured.ObjectSelector)
+
+			return true
+		}
+	}
+
+	// comparing pointers, not values
+	if existing.ObjectSelector == nil && configured.ObjectSelector != nil {
+		w.log.V(1).Info("updating webhook configuration",
+			"existing ObjectSelector", existing.ObjectSelector,
+			"configured ObjectSelector", configured.ObjectSelector)
+
 		return true
 	}
 
 	if existing.ObjectSelector != nil &&
 		configured.ObjectSelector != nil &&
 		!reflect.DeepEqual(*existing.ObjectSelector, *configured.ObjectSelector) {
+		w.log.V(1).Info("updating webhook configuration",
+			"existing ObjectSelector", existing.ObjectSelector,
+			"configured ObjectSelector", configured.ObjectSelector)
+
 		return true
 	}
+
+	w.log.V(1).Info("webbhook does not need update")
 
 	return false
 }
@@ -330,6 +415,82 @@ func (w *Webhook) objectMap() map[string]client.Object {
 		"deployment": w.deployment,
 		"config":     w.config,
 		"service":    w.service,
+	}
+}
+
+// getWebhookConfig returns the webhooks in the order binding, recording and execMetadata.
+func getWebhookConfig(execMetadataWebhookEnabled bool) *admissionregv1.MutatingWebhookConfiguration {
+	webhooks := []admissionregv1.MutatingWebhook{
+		{
+			Name:           binding.name,
+			FailurePolicy:  &failurePolicyFail,
+			SideEffects:    &sideEffects,
+			Rules:          rules,
+			ObjectSelector: &objectSelector,
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      EnableBindingLabel,
+						Operator: metav1.LabelSelectorOpExists,
+					},
+				},
+			},
+			ClientConfig: admissionregv1.WebhookClientConfig{
+				CABundle: caBundle,
+				Service: &admissionregv1.ServiceReference{
+					Name: serviceName,
+					Path: &binding.path,
+				},
+			},
+			AdmissionReviewVersions: admissionReviewVersions,
+		},
+		{
+			Name:           recording.name,
+			FailurePolicy:  &failurePolicyFail,
+			SideEffects:    &sideEffects,
+			Rules:          rules,
+			ObjectSelector: &objectSelector,
+			NamespaceSelector: &metav1.LabelSelector{
+				MatchExpressions: []metav1.LabelSelectorRequirement{
+					{
+						Key:      EnableRecordingLabel,
+						Operator: metav1.LabelSelectorOpExists,
+					},
+				},
+			},
+			ClientConfig: admissionregv1.WebhookClientConfig{
+				CABundle: caBundle,
+				Service: &admissionregv1.ServiceReference{
+					Name: serviceName,
+					Path: &recording.path,
+				},
+			},
+			AdmissionReviewVersions: admissionReviewVersions,
+		},
+	}
+
+	if execMetadataWebhookEnabled {
+		webhooks = append(webhooks, admissionregv1.MutatingWebhook{
+			Name:          execMetadata.name,
+			FailurePolicy: &failurePolicyIgnore,
+			SideEffects:   &sideEffects,
+			Rules:         rulesExec,
+			ClientConfig: admissionregv1.WebhookClientConfig{
+				CABundle: caBundle,
+				Service: &admissionregv1.ServiceReference{
+					Name: serviceName,
+					Path: &execMetadata.path,
+				},
+			},
+			AdmissionReviewVersions: admissionReviewVersions,
+		})
+	}
+
+	return &admissionregv1.MutatingWebhookConfiguration{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: webhookConfigName,
+		},
+		Webhooks: webhooks,
 	}
 }
 
@@ -429,60 +590,6 @@ var webhookDeployment = &appsv1.Deployment{
 					},
 				},
 			},
-		},
-	},
-}
-
-var webhookConfig = &admissionregv1.MutatingWebhookConfiguration{
-	ObjectMeta: metav1.ObjectMeta{
-		Name: webhookConfigName,
-	},
-	Webhooks: []admissionregv1.MutatingWebhook{
-		{
-			Name:           "binding.spo.io",
-			FailurePolicy:  &failurePolicy,
-			SideEffects:    &sideEffects,
-			Rules:          rules,
-			ObjectSelector: &objectSelector,
-			NamespaceSelector: &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{
-						Key:      EnableBindingLabel,
-						Operator: metav1.LabelSelectorOpExists,
-					},
-				},
-			},
-			ClientConfig: admissionregv1.WebhookClientConfig{
-				CABundle: caBundle,
-				Service: &admissionregv1.ServiceReference{
-					Name: serviceName,
-					Path: &bindingPath,
-				},
-			},
-			AdmissionReviewVersions: admissionReviewVersions,
-		},
-		{
-			Name:           "recording.spo.io",
-			FailurePolicy:  &failurePolicy,
-			SideEffects:    &sideEffects,
-			Rules:          rules,
-			ObjectSelector: &objectSelector,
-			NamespaceSelector: &metav1.LabelSelector{
-				MatchExpressions: []metav1.LabelSelectorRequirement{
-					{
-						Key:      EnableRecordingLabel,
-						Operator: metav1.LabelSelectorOpExists,
-					},
-				},
-			},
-			ClientConfig: admissionregv1.WebhookClientConfig{
-				CABundle: caBundle,
-				Service: &admissionregv1.ServiceReference{
-					Name: serviceName,
-					Path: &recordingPath,
-				},
-			},
-			AdmissionReviewVersions: admissionReviewVersions,
 		},
 	},
 }

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -181,9 +181,7 @@ func (r *ReconcileSPOd) Reconcile(ctx context.Context, req reconcile.Request) (r
 	}
 
 	configuredSPOd := r.getConfiguredSPOd(spod, image, pullPolicy, caInjectType)
-
-	webhook := bindata.GetWebhook(r.log, r.namespace, spod.Spec.WebhookOpts, image,
-		pullPolicy, caInjectType, spod.Spec.Tolerations, spod.Spec.ImagePullSecrets)
+	webhook := r.getConfiguredWebook(spod, image, pullPolicy, caInjectType)
 	metricsService := bindata.GetMetricsService(r.namespace, caInjectType)
 	serviceMonitor := bindata.ServiceMonitor(caInjectType)
 
@@ -795,6 +793,17 @@ func (r *ReconcileSPOd) getConfiguredJsonEnricher(cfg *spodv1alpha1.SecurityProf
 			)
 		}
 	}
+}
+
+// getConfiguredWebook gets a fully configured webhook instance from a desired
+// configuration and the reference base SPOd.
+func (r *ReconcileSPOd) getConfiguredWebook(cfg *spodv1alpha1.SecurityProfilesOperatorDaemon,
+	image string, pullPolicy corev1.PullPolicy, caInjectType bindata.CAInjectType,
+) *bindata.Webhook {
+	webhook := bindata.GetWebhook(r.log, r.namespace, cfg.Spec.WebhookOpts, image,
+		pullPolicy, caInjectType, cfg.Spec.Tolerations, cfg.Spec.ImagePullSecrets, isJsonEnricherEnabled(cfg))
+
+	return webhook
 }
 
 func isLogEnricherEnabled(cfg *spodv1alpha1.SecurityProfilesOperatorDaemon) bool {

--- a/internal/pkg/webhooks/execmetadata/execmetadata.go
+++ b/internal/pkg/webhooks/execmetadata/execmetadata.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package execmetadata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"slices"
+
+	"github.com/go-logr/logr"
+	"gomodules.xyz/jsonpatch/v2"
+	corev1 "k8s.io/api/core/v1"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+const (
+	ExecRequestUid = "SPO_EXEC_REQUEST_UID"
+)
+
+type Handler struct {
+	log logr.Logger
+}
+
+// Ensure ExecMetadataHandler implements admission.Handler at compile time.
+var _ admission.Handler = (*Handler)(nil)
+
+//nolint:gocritic
+func (p Handler) Handle(_ context.Context, req admission.Request) admission.Response {
+	p.log.V(1).Info("Executing execmetadata webhook")
+
+	execObject := corev1.PodExecOptions{}
+
+	if err := json.Unmarshal(req.Object.Raw, &execObject); err != nil {
+		p.log.Error(err, "unmarshal pod exec request")
+
+		return admission.Allowed("pod exec request unmodified")
+	}
+
+	p.log.V(1).Info("execObject before mutate", "execObject", execObject)
+
+	execObject.Command = removeRegexMatches(execObject.Command,
+		ExecRequestUid+"=.*")
+
+	execObject.Command = slices.Insert(execObject.Command, 0, "env",
+		fmt.Sprintf("%s=%s", ExecRequestUid, req.UID))
+
+	p.log.V(1).Info("execObject after mutate", "execObject", execObject)
+
+	jsonPathOps := []jsonpatch.JsonPatchOperation{
+		{
+			Operation: "add",
+			Path:      "/command",
+			Value:     execObject.Command,
+		},
+	}
+
+	resp := admission.Patched("UID added to execmetadata", jsonPathOps...)
+
+	// The RequestUid will be used to correlate the log from container and API server
+	resp.AuditAnnotations = map[string]string{
+		ExecRequestUid: string(req.UID),
+	}
+
+	p.log.V(1).Info("response sent", "resp", resp)
+
+	return resp
+}
+
+func removeRegexMatches(slice []string, pattern string) []string {
+	re := regexp.MustCompile(pattern)
+
+	var result []string
+
+	for _, s := range slice {
+		if !re.MatchString(s) {
+			result = append(result, s)
+		}
+	}
+
+	return result
+}
+
+func RegisterWebhook(server webhook.Server) {
+	server.Register(
+		"/mutate-v1-exec-metadata",
+		&webhook.Admission{
+			Handler: &Handler{
+				log: logf.Log.WithName("execmetadata"),
+			},
+		},
+	)
+}

--- a/internal/pkg/webhooks/execmetadata/execmetadata_test.go
+++ b/internal/pkg/webhooks/execmetadata/execmetadata_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package execmetadata
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+)
+
+func getAdmRequest(t *testing.T, execOpts *corev1.PodExecOptions) admissionv1.AdmissionRequest {
+	t.Helper()
+
+	return admissionv1.AdmissionRequest{
+		Object: runtime.RawExtension{
+			Raw: func() []byte {
+				b, err := json.Marshal(execOpts.DeepCopy())
+				require.NoError(t, err)
+
+				return b
+			}(),
+		},
+	}
+}
+
+func TestHandlePodExecWithContainer(t *testing.T) {
+	t.Parallel()
+
+	testExecCall := &corev1.PodExecOptions{
+		Container: "test",
+		Command:   []string{"echo", "hello"},
+		Stdin:     true,
+		Stdout:    true,
+		Stderr:    true,
+		TTY:       true,
+	}
+
+	handler := Handler{logr.Discard()}
+	resp := handler.Handle(t.Context(), admission.Request{
+		AdmissionRequest: getAdmRequest(t, testExecCall),
+	})
+
+	if !strings.Contains(resp.Patches[0].Json(), ExecRequestUid) {
+		t.Errorf("Expected the response to contain " + ExecRequestUid)
+	}
+}
+
+func TestHandlePodExecWithoutContainer(t *testing.T) {
+	t.Parallel()
+
+	testExecCall := &corev1.PodExecOptions{
+		Command: []string{"echo", "hello"},
+		Stdin:   true,
+		Stdout:  true,
+		Stderr:  true,
+		TTY:     true,
+	}
+
+	handler := Handler{logr.Discard()}
+	resp := handler.Handle(t.Context(), admission.Request{
+		AdmissionRequest: getAdmRequest(t, testExecCall),
+	})
+
+	if !strings.Contains(resp.Patches[0].Json(), ExecRequestUid) {
+		t.Errorf("Expected the response to contain " + ExecRequestUid)
+	}
+}
+
+func TestHandlePodExecMulUid(t *testing.T) {
+	t.Parallel()
+
+	testExecCall := &corev1.PodExecOptions{
+		Command: []string{
+			ExecRequestUid + "=overwriteid",
+		},
+		Stdin:  true,
+		Stdout: true,
+		Stderr: true,
+		TTY:    true,
+	}
+
+	handler := Handler{logr.Discard()}
+	resp := handler.Handle(t.Context(), admission.Request{
+		AdmissionRequest: getAdmRequest(t, testExecCall),
+	})
+
+	if !strings.Contains(resp.Patches[0].Json(), ExecRequestUid) {
+		t.Errorf("Expected the response to contain " + ExecRequestUid)
+	}
+
+	if strings.Count(resp.Patches[0].Json(), ExecRequestUid) > 1 {
+		t.Errorf("Expected only one environment variable" + ExecRequestUid)
+	}
+
+	if strings.Count(resp.Patches[0].Json(), "overwriteid") > 1 {
+		t.Errorf("Expected overwriteid to be revomed")
+	}
+
+	require.Contains(t, resp.AuditAnnotations, ExecRequestUid)
+}

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -793,6 +793,10 @@ func (e *e2e) enableJsonEnricherInSpod() {
 	time.Sleep(defaultWaitTime)
 	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
 
+	e.kubectlOperatorNS("get", "pods")
+
+	e.logf("Done waiting for the rollout restart")
+
 	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultLogEnricherOpTimeout)
 }
 

--- a/test/tc_log_enricher_test.go
+++ b/test/tc_log_enricher_test.go
@@ -96,6 +96,10 @@ spec:
 		time.Sleep(5 * time.Second)
 	}
 
+	// Make sure that Exec webhook is not enabled unless JSON Log Enricher is used
+	envOutput := e.kubectl("exec", "-it", podName, "--", "env")
+	e.NotContains(envOutput, "SPO_EXEC_REQUEST_UID")
+
 	// wait for at least one component of the expected logs to appear
 	e.waitForEnricherLogs(since, regexp.MustCompile(`(?m)"syscallName"="listen"`))
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR addresses an issue with JSON Log Enricher: the inability to correlate in logs generated from `kubectl exec` sessions with the API Server Audit Logs. This information is required to find the end-user who executed a command on the pod/container.

**Problem**
Kubernetes, by default, does not pass user authentication details and request details (request UID) from the API server into the container's environment when a user runs `kubectl exec`. This means JSON logs for exec sessions lack context about who initiated the command. When there are multiple users doing `kubectl exec` requests and the audit log for the API Server is enabled, its not possible to correlate the server side audit log and the container audit log.

**Solution**
This PR introduces a mutating admission webhook designed to inject the request ID directly into the environment variables of containers targeted by `kubectl exec` requests. Sufficient checks are placed to ensure that the user cannot override them. The request ID is also added as a Audit annotation of the API server audit log.

**How it Works**

When a user initiates an `kubectl exec` command, the request is intercepted by the new mutating webhook (execmetadata.spo.io).
The webhook adds environment variable (EXEC_REQUEST_UID) to the exec command. This environment variables is then available to the process running inside the container (e.g., JSON Log Enricher), accessible via /proc/pid/environ.
JSON Log Enricher is updated to read and incorporate this injected request ID into the log lines.

#### Which issue(s) this PR fixes:
Fixes #2857 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
Yes. Added e2e and unit tests
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
Initial PR was raised to inject the User information. Since there are concerns of PII now only the request UID is injected. Also made the webhook optional.
@haircommander / @ccojocar Sorry for the change in the title. It was required to provide clarity on exact change.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add Request UID to JSON log enricher to correlate container and API Server Audit log
```
