### PR TITLE
Resolves JSON Enricher issues on Ubuntu

### DIFF
--- a/hack/ci/e2e-ubuntu.sh
+++ b/hack/ci/e2e-ubuntu.sh
@@ -17,7 +17,7 @@ set -euo pipefail
 
 export E2E_CLUSTER_TYPE=vanilla
 export E2E_TEST_LOG_ENRICHER=true
-export E2E_TEST_JSON_ENRICHER=false
+export E2E_TEST_JSON_ENRICHER=true
 export E2E_TEST_SECCOMP=false
 export E2E_TEST_FLAKY_TESTS_ONLY=${E2E_TEST_FLAKY_TESTS_ONLY:-false}
 

--- a/internal/pkg/daemon/enricher/jsonenricher.go
+++ b/internal/pkg/daemon/enricher/jsonenricher.go
@@ -285,10 +285,7 @@ func (e *JsonEnricher) Run(ctx context.Context, runErr chan<- error) {
 			}
 		}
 
-		if logBucket.ContainerInfo == nil {
-			logBucket.ContainerInfo = e.fetchContainerInfo(ctx, auditLine.ProcessID, nodeName)
-		}
-
+		// Capture proc/pid/(cmdLine/environ) early; these files are ephemeral on some OS (e.g., Ubuntu).
 		if logBucket.ProcessInfo == nil {
 			uid, gid, err := auditsource.GetUidGid(line)
 			if err != nil {
@@ -298,6 +295,10 @@ func (e *JsonEnricher) Run(ctx context.Context, runErr chan<- error) {
 
 			logBucket.ProcessInfo = e.fetchProcessInfo(auditLine.ProcessID,
 				auditLine.Executable, uid, gid)
+		}
+
+		if logBucket.ContainerInfo == nil {
+			logBucket.ContainerInfo = e.fetchContainerInfo(ctx, auditLine.ProcessID, nodeName)
 		}
 
 		logBucket.SyscallIds.LoadOrStore(auditLine.SystemCallID, struct{}{})

--- a/internal/pkg/daemon/enricher/process_test.go
+++ b/internal/pkg/daemon/enricher/process_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package enricher
+
+import "testing"
+
+func Test_extractSPORequestUID(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		input string
+	}
+
+	tests := []struct {
+		name      string
+		args      args
+		want      string
+		foundWant bool
+	}{
+		{
+			name:      "Basic test with cmdline having SPO_EXEC_REQUEST_UID",
+			args:      args{input: "env SPO_EXEC_REQUEST_UID=dbbf5fca-c955-4922-99d2-27a50212071c ls"},
+			want:      "dbbf5fca-c955-4922-99d2-27a50212071c",
+			foundWant: true,
+		},
+		{
+			name:      "Test with no value",
+			args:      args{input: "ls"},
+			want:      "",
+			foundWant: false,
+		},
+		{
+			name:      "Test with other env values",
+			args:      args{input: "env INVALID=dbbf5fca-c955-4922-99d2-27a50212071c ls"},
+			want:      "",
+			foundWant: false,
+		},
+		{
+			name:      "Test with process values",
+			args:      args{input: "nginx: master process nginx -g daemon off;"},
+			want:      "",
+			foundWant: false,
+		},
+		{
+			name:      "Test with no data",
+			args:      args{input: ""},
+			want:      "",
+			foundWant: false,
+		},
+		{
+			name:      "Test with blank data",
+			args:      args{input: "env SPO_EXEC_REQUEST_UID= ls"},
+			want:      "",
+			foundWant: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, got1 := extractSPORequestUID(tt.args.input)
+
+			if got != tt.want {
+				t.Errorf("extractSPORequestUID() got = %v, want %v", got, tt.want)
+			}
+
+			if got1 != tt.foundWant {
+				t.Errorf("extractSPORequestUID() got1 = %v, want %v", got1, tt.foundWant)
+			}
+		})
+	}
+}

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -640,6 +640,11 @@ semodule -i /opt/spo-profiles/selinuxrecording.cil
 							Privileged:             &falsely,
 							RunAsUser:              &userRoot,
 							RunAsGroup:             &userRoot,
+							Capabilities: &corev1.Capabilities{
+								Add: []corev1.Capability{
+									"SYS_PTRACE", // Needed for /proc/PID/environ access on some systems (ex: Ubuntu)
+								},
+							},
 							SELinuxOptions: &corev1.SELinuxOptions{
 								// TODO(pjbgf): Use a more restricted selinux type
 								Type: "spc_t",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
##### Problem
The JSON Enricher, recently introduced, exhibited intermittent issues on Ubuntu platforms. Specifically, the SPO_EXEC_REQUEST_UID environment variable, expected in the env file from the execmetadata webhook, was occasionally (and inconsistently) found embedded within the process's command line arguments instead. This made consistent reproduction and debugging challenging.

Additionally, the initial feature development lacked comprehensive end-to-end (e2e) test coverage on Ubuntu, limiting the scope of our test suite for this component.

##### Solution
Added SYS_PTRACE Capability:
The SYS_PTRACE capability has been added to the jsonenricher container's security context. This ensures necessary permissions for accessing /proc/PID/environ. On RHEL this permission was not needed, but was required on Ubuntu.

Improve RequestUID Extraction: A fix has been implemented to robustly extract the SPO_EXEC_REQUEST_UID. This solution now accounts for the scenario where the UID might be present in the command line arguments rather than solely relying on the env file. This change includes dedicated unit tests to cover this edge case.

Expanded E2E Test Coverage: E2E testing for the JSON Enricher has been enabled on the Ubuntu environment.
These tests specifically verify the correct extraction and enrichment of the requestUID.

A "sleep" command is now used within the e2e tests as a user process. The JSON Enricher's output is then validated to ensure the "sleep" command is correctly identified and present in the audit data.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
Yes, Part of the PR
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
Initially Ubuntu was a challenge. I was able to setup those tests to run locally now. While developing the feature the vagrant and virtualbox configuration was a challenge on Mac. Now I have setup on a AMD GCP VM and was able to fix these issues.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
