### PR TITLE
Add Ephemeral Container Statuses for enricher usage

### DIFF
--- a/internal/pkg/daemon/enricher/container.go
+++ b/internal/pkg/daemon/enricher/container.go
@@ -19,6 +19,7 @@ package enricher
 import (
 	"errors"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -118,8 +119,8 @@ func populateCacheEntryForContainer(
 	infoCache *ttlcache.Cache[string, *types.ContainerInfo], logger logr.Logger,
 ) {
 	eg.Go(func() (errorToRetry error) {
-		//nolint:gocritic // This is what we expect and want
-		statuses := append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...)
+		statuses := slices.Concat(pod.Status.InitContainerStatuses,
+			pod.Status.ContainerStatuses, pod.Status.EphemeralContainerStatuses)
 
 		for c := range statuses {
 			containerStatus := statuses[c]

--- a/internal/pkg/daemon/enricher/container_test.go
+++ b/internal/pkg/daemon/enricher/container_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package enricher
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/jellydator/ttlcache/v3"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/errgroup"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/enricher/types"
+)
+
+func Test_populateCacheEntryForContainer(t *testing.T) {
+	t.Parallel()
+
+	falsely, truly := false, true
+
+	type args struct {
+		pod *v1.Pod
+	}
+
+	tests := []struct {
+		name        string
+		args        args
+		want        int
+		expectError bool
+	}{
+		{
+			name:        "Empty containerID test",
+			want:        1,
+			expectError: true,
+			args: args{
+				pod: &v1.Pod{
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:         "no-container-id",
+								Ready:        false,
+								Image:        "nginx",
+								ContainerID:  "",
+								Started:      &falsely,
+								RestartCount: 0,
+								State: v1.ContainerState{
+									Waiting: &v1.ContainerStateWaiting{
+										Reason: "ContainerCreating",
+									},
+								},
+							},
+						},
+						EphemeralContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:         "debug-container",
+								Ready:        true,
+								Image:        "busybox",
+								ContainerID:  "cri-o://4066a8e6f5e212076950d00c0cdeb9672e6b58c87bd31085720a8564e01ee021",
+								Started:      &truly,
+								RestartCount: 0,
+								State: v1.ContainerState{
+									Running: &v1.ContainerStateRunning{
+										StartedAt: metav1.Time{
+											Time: time.Now(),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "pod info fetch",
+			want: 2,
+			args: args{
+				pod: &v1.Pod{
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:         "my-container",
+								Ready:        true,
+								Image:        "nginx",
+								ContainerID:  "cri-o://a7afc479dcef795780f76309b93f6087602f92e60cc352e01e89d596530d3bf3",
+								Started:      &truly,
+								RestartCount: 0,
+								State: v1.ContainerState{
+									Running: &v1.ContainerStateRunning{
+										StartedAt: metav1.Time{
+											Time: time.Now(),
+										},
+									},
+								},
+							},
+						},
+						EphemeralContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:         "debug-container",
+								Ready:        true,
+								Image:        "busybox",
+								ContainerID:  "cri-o://4066a8e6f5e212076950d00c0cdeb9672e6b58c87bd31085720a8564e01ee021",
+								Started:      &truly,
+								RestartCount: 0,
+								State: v1.ContainerState{
+									Running: &v1.ContainerStateRunning{
+										StartedAt: metav1.Time{
+											Time: time.Now(),
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name:        "Without EphemeralContainerStatuses",
+			want:        1,
+			expectError: false,
+			args: args{
+				pod: &v1.Pod{
+					Status: v1.PodStatus{
+						ContainerStatuses: []v1.ContainerStatus{
+							{
+								Name:         "no-container-id",
+								Ready:        false,
+								Image:        "nginx",
+								ContainerID:  "cri-o://4066a8e6f5e212076950d00c0cdeb9672e6b58c87bd31085720a8564e01ee021",
+								Started:      &falsely,
+								RestartCount: 0,
+								State: v1.ContainerState{
+									Waiting: &v1.ContainerStateWaiting{
+										Reason: "ContainerCreating",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			eg, _ := errgroup.WithContext(t.Context())
+
+			infoCache := ttlcache.New(
+				ttlcache.WithTTL[string, *types.ContainerInfo](defaultCacheTimeout),
+				ttlcache.WithCapacity[string, *types.ContainerInfo](maxCacheItems),
+			)
+
+			populateCacheEntryForContainer(t.Context(), tt.args.pod, eg, infoCache, logr.Discard())
+
+			err := eg.Wait()
+
+			if !tt.expectError {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+			}
+
+			if infoCache.Len() != tt.want {
+				t.Errorf("populateCacheEntryForContainer() = %d, want %d", infoCache.Len(), tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR resolves an issue where the log enrichers (both standard and JSON) failed to capture resource information for containers started via kubectl debug.

Previously, enrichers only considered init and regular container statuses, overlooking ephemeral containers. This led to missing resource details for these ephemeral containers in the generated logs.

This change extends the log enrichers to include ephemeral container statuses, ensuring that resource information is captured for kubectl debug sessions. Unit tests have been added to validate this fix.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
Yes, Unit tests
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
