### PR TITLE
Fix the injection of the request UID for JSON Log enricher in case of kubectl node debug

### DIFF
--- a/internal/pkg/manager/spod/bindata/webhook_test.go
+++ b/internal/pkg/manager/spod/bindata/webhook_test.go
@@ -226,5 +226,5 @@ func TestWebhook_getWebhookConfig(t *testing.T) {
 	require.Len(t, webhookConfig.Webhooks, 2)
 
 	webhookConfig = getWebhookConfig(true)
-	require.Len(t, webhookConfig.Webhooks, 3)
+	require.Len(t, webhookConfig.Webhooks, 4)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
When a user initiated a node debugging session using `kubectl debug node/<node-name>`, the `requestUID` – essential for tracking the end-user – was not injected into the debug pod's environment by JSON log enricher webhook. This made it difficult to attribute activity in node-debug pods back to the originating user. 

Other cases like `kubectl exec` and `kubectl debug pod` are working, the issue is only with node debugging pod.

To address this, a recent client-side change ([kubernetes/kubernetes#131791](https://github.com/kubernetes/kubernetes/pull/131791)) introduced `app.kubernetes.io/managed-by: "kubectl-debug"` label for these node debugging pods. While this is a step forward, not all Kubernetes API clients (like `oc debug` for OpenShift) utilize this specific label.

This PR introduces a capability: **users can now configure a custom label in the webhook configuration to identify node debugging pods**. This ensures that the requestUID is reliably injected, regardless of the client used to initiate the node debug session. If the custom label is not added it will use  `app.kubernetes.io/managed-by: "kubectl-debug"` .

**Note** that this change has no impact on the exec into a container or pod debug using ephemeral containers.

The execmetadata webhook will now distinguish between different node debug pod types and inject the `SPO_EXEC_REQUEST_UID` environment variable accordingly.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
Manual tests as kubectl having the node debug pod label is not released.

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Adds support for kubectl node debugging for JSON Log enricher
```
