### PR TITLE
Point to URL of Fedora 39

### DIFF
--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -71,6 +71,12 @@ dependencies:
     - path: hack/ci/Vagrantfile-fedora
       match: fedora
 
+  - name: e2e-fedora-image-url
+    version: 39-1.5
+    refPaths:
+      - path: hack/ci/Vagrantfile-fedora
+        match: vm.box_url
+
   - name: e2e-ubuntu
     version: ubuntu2204
     refPaths:

--- a/hack/ci/Vagrantfile-fedora
+++ b/hack/ci/Vagrantfile-fedora
@@ -4,15 +4,18 @@
 # Vagrant box for testing
 Vagrant.configure("2") do |config|
   config.vm.box = "fedora/39-cloud-base"
+  config.vm.box_url = "override-by-provider"
   memory = 8192
   cpus = 4
 
-  config.vm.provider :virtualbox do |v|
+  config.vm.provider :virtualbox do |v, override|
+    override.vm.box_url = "https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-39-1.5.x86_64.vagrant-virtualbox.box"
     v.memory = memory
     v.cpus = cpus
   end
 
-  config.vm.provider :libvirt do |v|
+  config.vm.provider :libvirt do |v, override|
+    override.vm.box_url = "https://archives.fedoraproject.org/pub/archive/fedora/linux/releases/39/Cloud/x86_64/images/Fedora-Cloud-Base-Vagrant-39-1.5.x86_64.vagrant-libvirt.box"
     v.memory = memory
     v.cpus = cpus
   end

--- a/hack/ci/install-kubernetes.sh
+++ b/hack/ci/install-kubernetes.sh
@@ -20,6 +20,7 @@ IP=$(ip route get 1.2.3.4 | cut -d ' ' -f7 | tr -d '[:space:]')
 swapoff -a
 modprobe br_netfilter
 sysctl -w net.ipv4.ip_forward=1
+echo "Number of CPUs: $(nproc)"
 kubeadm init --apiserver-cert-extra-sans="$IP"
 
 # Setup kubectl


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
Fedora tests are failing as the image is archived: https://dl.fedoraproject.org/pub/fedora/linux/releases/39/README


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
This is similar to https://github.com/containerd/containerd/issues/12124
I added ncpu as that fails in fedora 41. For some weird reason ncpu becomes 1 in Fedora 41 and fails while kubeadm preflight checks are done. Hence used Fedora 39
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
