### PR TITLE
Fix Linux release version parsing

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
@@ -720,7 +720,9 @@ func (b *BpfRecorder) findBtfPath() (string, error) {
 
 	arch, version, err := b.Uname()
 	if err != nil {
-		return "", fmt.Errorf("uname syscall failed: %w", err)
+		b.logger.Error(err, "failed to get kernel version, continuing without BTF...")
+
+		return "", nil
 	}
 
 	btfArch, ok := btfOsVersion[arch]

--- a/internal/pkg/daemon/enricher/auditsource/bpf.go
+++ b/internal/pkg/daemon/enricher/auditsource/bpf.go
@@ -32,10 +32,12 @@ import (
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/util"
 )
 
-func BpfSupported() error {
+func BpfSupported(logger logr.Logger) error {
 	_, version, err := util.Uname()
 	if err != nil {
-		return fmt.Errorf("uname failed: %w", err)
+		logger.Error(err, "failed to get kernel version to check BPF support, continuing anyway...")
+
+		return nil
 	}
 
 	minVersion := semver.Version{Major: 5, Minor: 19}
@@ -52,7 +54,7 @@ type BpfSource struct {
 }
 
 func NewBpfSource(logger logr.Logger) (*BpfSource, error) {
-	if err := BpfSupported(); err != nil {
+	if err := BpfSupported(logger); err != nil {
 		return nil, err
 	}
 

--- a/internal/pkg/util/uname.go
+++ b/internal/pkg/util/uname.go
@@ -20,12 +20,18 @@ package util
 
 import (
 	"fmt"
+	"strings"
 	"syscall"
 
 	"github.com/blang/semver/v4"
 
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/bpfrecorder/types"
 )
+
+func normalizeRelease(release string) string {
+	// Work around kernels with empty build metadata, e.g. `6.6.93+`.
+	return strings.TrimSuffix(release, "+")
+}
 
 func Uname() (types.Arch, *semver.Version, error) {
 	uname := syscall.Utsname{}
@@ -35,6 +41,7 @@ func Uname() (types.Arch, *semver.Version, error) {
 
 	arch := types.Arch(unameMachineToString(&uname))
 	release := unameReleaseToString(&uname)
+	release = normalizeRelease(release)
 
 	version, err := semver.Parse(release)
 	if err != nil {

--- a/internal/pkg/util/uname_test.go
+++ b/internal/pkg/util/uname_test.go
@@ -33,3 +33,11 @@ func TestUname(t *testing.T) {
 	require.True(t, version.GT(semver.Version{Major: 0, Minor: 0, Patch: 0}))
 	require.NotEmpty(t, arch)
 }
+
+func TestNormalize(t *testing.T) {
+	t.Parallel()
+
+	require.Equal(t, "6.6.93", normalizeRelease("6.6.93"))
+	require.Equal(t, "6.6.93", normalizeRelease("6.6.93+"))
+	require.Equal(t, "6.6.93+extra", normalizeRelease("6.6.93+extra"))
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR fixes `uname` version parsing for releases with empty build tags, and also stops us from failing hard if we hit a version we cannot parse.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
