### PR TITLE
2940: optionally enable TLS 1.3 for SPO webhook

### DIFF
--- a/internal/pkg/util/enum.go
+++ b/internal/pkg/util/enum.go
@@ -1,0 +1,63 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"flag"
+	"fmt"
+	"strings"
+)
+
+type EnumValue struct {
+	Enum     []string
+	Default  string
+	selected string
+}
+
+var _ flag.Value = (*EnumValue)(nil)
+
+// NewEnumValue returns a new EnumValue. Returns nil if defaultValue is not found in enum.
+func NewEnumValue(enum []string, defaultValue string) *EnumValue {
+	for _, v := range enum {
+		if v == defaultValue {
+			return &EnumValue{Enum: enum, Default: defaultValue}
+		}
+	}
+
+	return nil
+}
+
+// Set method is used by cli.GenericFlag. But the IDE won't recognize it.
+func (e *EnumValue) Set(value string) error {
+	for _, enum := range e.Enum {
+		if strings.EqualFold(enum, value) {
+			e.selected = enum
+
+			return nil
+		}
+	}
+
+	return fmt.Errorf("allowed values are %s", strings.Join(e.Enum, ", "))
+}
+
+func (e *EnumValue) String() string {
+	if e.selected == "" {
+		return e.Default
+	}
+
+	return e.selected
+}

--- a/internal/pkg/util/enum_test.go
+++ b/internal/pkg/util/enum_test.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"flag"
+	"testing"
+)
+
+func TestEnumValue(t *testing.T) {
+	t.Parallel()
+
+	// Test NewEnumValue
+	enum := NewEnumValue([]string{"1.2", "1.3"}, "1.2")
+	if enum == nil {
+		t.Fatal("NewEnumValue should not return nil for valid input")
+	}
+
+	if enum.Default != "1.2" {
+		t.Errorf("expected default '1.2', got '%s'", enum.Default)
+	}
+
+	// Test invalid constructor
+	if NewEnumValue([]string{"1.2", "1.3"}, "1.1") != nil {
+		t.Error("NewEnumValue should return nil when default not in enum")
+	}
+
+	if NewEnumValue([]string{}, "test") != nil {
+		t.Error("NewEnumValue should return nil for empty enum")
+	}
+
+	// Test String method returns default initially
+	if enum.String() != "1.2" {
+		t.Errorf("expected default '1.2', got '%s'", enum.String())
+	}
+
+	// Test Set method with valid inputs
+	if err := enum.Set("1.3"); err != nil {
+		t.Errorf("Set failed for valid value: %v", err)
+	}
+
+	if enum.String() != "1.3" {
+		t.Errorf("expected '1.3' after Set, got '%s'", enum.String())
+	}
+
+	// Test Set method with invalid inputs
+	if err := enum.Set("1.1"); err == nil {
+		t.Error("Set should fail for invalid value")
+	}
+
+	// Test case-insensitive matching
+	enumCase := NewEnumValue([]string{"Debug", "Info"}, "Info")
+	if err := enumCase.Set("debug"); err != nil {
+		t.Errorf("Set should work case-insensitively: %v", err)
+	}
+
+	if enumCase.String() != "Debug" {
+		t.Errorf("expected canonical case 'Debug', got '%s'", enumCase.String())
+	}
+
+	// Test flag.Value interface
+	var _ flag.Value = enum
+
+	// Test error message format
+	err := enum.Set("invalid")
+
+	expectedMsg := "allowed values are 1.2, 1.3"
+
+	if err.Error() != expectedMsg {
+		t.Errorf("expected error '%s', got '%s'", expectedMsg, err.Error())
+	}
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The PR adds TLS 1.3 as an option for webhook pods running on port 9443. The default is TLS 1.2.

#### Which issue(s) this PR fixes:
Fixes #2940
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #2940

or

None
-->

#### Does this PR have test?
Unit tested

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
It added TLS 1.3 option. But none of the existing webhook flags like [port or static](https://github.com/kubernetes-sigs/security-profiles-operator/blob/main/cmd/security-profiles-operator/main.go#L216) can be configured at the moment. It requires an additional config to be added to SPOD Types. I haven't taken up that as part of the PR.

#### Does this PR introduce a user-facing change?
Yes
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Support for TLS 1.3 in SPO webhooks
```
