### PR TITLE
Add a delay and check to ensure that SPOD patch is rolled out

### DIFF
--- a/hacking.md
+++ b/hacking.md
@@ -185,7 +185,7 @@ OpenShift cluster's configuration file, and you need to be successfully logged i
 
 For convenience, the `Makefile` contains a target called `deploy-openshift-dev` which
 deploys SPO in an OpenShift cluster with the appropriate defaults (SELinux is on by default)
-and the appropriate settings (no cert-manager needed). It should be noted that `deploy-openshit-dev`
+and the appropriate settings (no cert-manager needed). It should be noted that `deploy-openshift-dev`
 will not enable eBPF and app-armor capabilities (APPARMOR_ENABLED=0, BPF_ENABLED=0).
 
 If you modify the code and need to push the images to the cluster again, use the


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This PR fixes an intermittent failure in the e2e tests for seccomp-profile.

This was observed in https://github.com/kubernetes-sigs/security-profiles-operator/actions/runs/16961101889/job/48074161956?pr=2958
```
2025-08-14T09:28:28.0405670Z Found Kubernetes object spod spod
2025-08-14T09:28:28.1700531Z securityprofilesoperatordaemon.security-profiles-operator.x-k8s.io/spod patched
2025-08-14T09:28:28.3930140Z daemon set "spod" successfully rolled out
2025-08-14T09:28:28.6896880Z securityprofilesoperatordaemon.security-profiles-operator.x-k8s.io/spod condition met
```

The issue occurred because a test assumed the SPOD object's changes had been applied to the DaemonSet before the SPO controller had time to execute. The controller, which takes a moment or two to run (Many a time less than a second), is responsible for modifying the DaemonSet. This timing discrepancy caused the rollout status check to fail because it ran before the changes were complete.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
Yes, the successful multiple runs of the e2etest.
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
