### PR TITLE
Add webhook options only for openshift deployments to handle node debugging label

### DIFF
--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -2115,6 +2115,11 @@ spec:
                 description: Verbosity specifies the logging verbosity of the daemon.
                 type: integer
               webhookOptions:
+                default:
+                - name: nodedebuggingpod.spo.io
+                  objectSelector:
+                    matchLabels:
+                      debug.openshift.io/managed-by: oc-debug
                 description: |-
                   WebhookOpts set custom namespace selectors and failure mode for
                   SPO's webhooks

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -1806,6 +1806,11 @@ spec:
                 description: Verbosity specifies the logging verbosity of the daemon.
                 type: integer
               webhookOptions:
+                default:
+                - name: nodedebuggingpod.spo.io
+                  objectSelector:
+                    matchLabels:
+                      debug.openshift.io/managed-by: oc-debug
                 description: |-
                   WebhookOpts set custom namespace selectors and failure mode for
                   SPO's webhooks

--- a/deploy/overlays/openshift-dev/kustomization.yaml
+++ b/deploy/overlays/openshift-dev/kustomization.yaml
@@ -12,11 +12,22 @@ images:
   newTag: latest
 resources:
 - ../cluster
-
 patches:
+- patch: |-
+    - op: replace
+      path: "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/webhookOptions/default"
+      value:
+        - name: nodedebuggingpod.spo.io
+          objectSelector:
+            matchLabels:
+              debug.openshift.io/managed-by: "oc-debug"
+  target:
+    kind: CustomResourceDefinition
+    name: securityprofilesoperatordaemons.security-profiles-operator.x-k8s.io
 - patch: |-
     - op: add
       path:  "/metadata/labels/openshift.io~1cluster-monitoring"
       value: "true"
   target:
     kind: Namespace
+

--- a/deploy/overlays/openshift-downstream/kustomization.yaml
+++ b/deploy/overlays/openshift-downstream/kustomization.yaml
@@ -10,6 +10,17 @@ sortOptions:
 resources:
 - ../cluster
 patches:
+- patch: |-
+    - op: replace
+      path: "/spec/versions/0/schema/openAPIV3Schema/properties/spec/properties/webhookOptions/default"
+      value:
+        - name: nodedebuggingpod.spo.io
+          objectSelector:
+            matchLabels:
+              debug.openshift.io/managed-by: "oc-debug"
+  target:
+    kind: CustomResourceDefinition
+    name: securityprofilesoperatordaemons.security-profiles-operator.x-k8s.io
 - path: service_discovery_rules.yaml
   target:
     kind: ClusterRole


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind feature
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
This pull request is essential for OpenShift deployments as it enables the configuration of the `nodedebuggingpod` webhook. It adds the required webhook options to ensure that the nodedebuggingpod webhook can correctly function in openshift. 
This is necessary because of a change introduced in PR https://github.com/openshift/oc/pull/2074, which added the label `debug.openshift.io/managed-by=oc-debug` for the oc debug node command. By setting this label, the `nodedebuggingpod` webhook will be able to identify the correct pods and inject the SPO_EXEC_REQUEST_UID environment variable.
The webhook configuration tells nodedebuggingpod webhook the label to look for to set SPO_EXEC_REQUEST_UID. 

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
Manually tested with openshift:
```
oc describe po ip-10-0-91-131ec2internal-debug-jh8gs               ✔  admin 󱃾  19:13:22
Name:                 ip-10-0-91-131ec2internal-debug-jh8gs
Namespace:            default
Priority:             1000000000
Priority Class Name:  openshift-user-critical
Service Account:      default
Node:                 ip-10-0-91-131.ec2.internal/10.0.91.131
Start Time:           Mon, 18 Aug 2025 19:12:44 +0530
Labels:               debug.openshift.io/managed-by=oc-debug
```
and futher we can see the label injected by the webook:
```
      HOST:                  /host
      SPO_EXEC_REQUEST_UID:  67119dfa-2df7-45a8-a435-3d7e00ab5197
    Mounts:
      /host from host (rw)
```

After the release into the downstream OpenShift, the plan is to have a automated test.

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
My thinking is that openshift-dev.yaml and openshift-downstream.yaml is generated code and hence used a patch method instead of directly editing the yaml.
Red Hat Internal Jira reference: https://issues.redhat.com/browse/OCPNODE-3465

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
