### PR TITLE
Switch to to k8s v1.34 in CI

### DIFF
--- a/.github/workflows/olm_tests.yaml
+++ b/.github/workflows/olm_tests.yaml
@@ -5,7 +5,7 @@ on:
       - main
   pull_request:
 env:
-  KIND_IMG_TAG: v1.32.2
+  KIND_IMG_TAG: v1.34.0
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -42,13 +42,13 @@ dependencies:
       match: cert-manager/cert-manager
 
   - name: kind
-    version: 0.27.0
+    version: 0.30.0
     refPaths:
     - path: test/suite_test.go
       match: kindVersion
 
   - name: kind-image
-    version: 1.32.2
+    version: 1.34.0
     refPaths:
     - path: test/suite_test.go
       match: kindImage
@@ -56,7 +56,7 @@ dependencies:
       match: KIND_IMG_TAG
 
   - name: e2e-kubernetes
-    version: 1.33
+    version: 1.34
     refPaths:
     - path: hack/ci/Vagrantfile-fedora
       match: KUBERNETES_VERSION

--- a/hack/ci/Vagrantfile-debian
+++ b/hack/ci/Vagrantfile-debian
@@ -61,7 +61,7 @@ Vagrant.configure("2") do |config|
       chmod +x "$COSIGN_BINARY"
 
       # Install kubernetes related binaries
-      KUBERNETES_VERSION=v1.33
+      KUBERNETES_VERSION=v1.34
       curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
       echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
       curl -fsSL https://download.opensuse.org/repositories/isv:/cri-o:/prerelease:/main/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg

--- a/hack/ci/Vagrantfile-fedora
+++ b/hack/ci/Vagrantfile-fedora
@@ -40,7 +40,7 @@ Vagrant.configure("2") do |config|
       echo 'export GOPATH="$HOME/go"' >> /etc/profile
       echo 'export GOBIN="$GOPATH/bin"' >> /etc/profile
 
-      KUBERNETES_VERSION=v1.33
+      KUBERNETES_VERSION=v1.34
       cat <<EOF | tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes

--- a/hack/ci/Vagrantfile-ubuntu
+++ b/hack/ci/Vagrantfile-ubuntu
@@ -35,7 +35,7 @@ Vagrant.configure("2") do |config|
         tar xfz - -C /usr/local
 
       # Kubernetes
-      KUBERNETES_VERSION=v1.33
+      KUBERNETES_VERSION=v1.34
       curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
       echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
       curl -fsSL https://download.opensuse.org/repositories/isv:/cri-o:/prerelease:/main/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -40,10 +40,10 @@ import (
 )
 
 const (
-	kindVersion      = "v0.27.0"
-	kindImage        = "kindest/node:v1.32.2@sha256:f226345927d7e348497136874b6d207e0b32cc52154ad8323129352923a3142f"
-	kindDarwinSHA512 = "ccd2413c2293a80f4944937a0855fc800e5fe1ad41baea0b528ed390cdce473f076c1c0fd61f0d24adec87589878ab136377cd4a546c19a349bf140ecd7df5a3" //nolint:lll // full length SHA
-	kindLinuxSHA512  = "7b744426a5a8cb9908eda1cc9af3308deb0318cc589a7fc864f4717815839644e31b24b351ee46d14422d990b9eb3ab10a25063c97a76973534d6d112631000c" //nolint:lll // full length SHA
+	kindVersion      = "v0.30.0"
+	kindImage        = "kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a"
+	kindDarwinSHA512 = "437aab801fe8f4f75ec36b40c4963a554898d0498261ac440713cc0faea63f577fe009df0c6f55ca46c0572bf8fa23e4d0c55297a39549302557d15b4ae6f59f" //nolint:lll // full length SHA
+	kindLinuxSHA512  = "ac4bf7294522d48c5f573d938981d392f66e6e8a868dcbbcb82bb9217fe6a16d005d7b0556353a2d0e498f0ec49d1d80505de9a954f2c10781b4aba216e02cf6" //nolint:lll // full length SHA
 )
 
 var (


### PR DESCRIPTION

#### What type of PR is this?


/kind cleanup


#### What this PR does / why we need it:
Update CI to use kubernetes v1.34.
#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->
None
#### Does this PR have test?
None
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:
None
#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
None
```
