### PR TITLE
Enable kubectl node debug label test in SPO with k8s 1.34

### DIFF
--- a/test/tc_json_enricher_test.go
+++ b/test/tc_json_enricher_test.go
@@ -193,12 +193,10 @@ spec:
 
 	nodeName := e.kubectl("get", "nodes",
 		"-o", "jsonpath='{.items[0].metadata.name}'")
-	e.kubectl("debug", "--profile", "general", "node/"+strings.Trim(nodeName, "'"), "--image", "busybox",
-		"-it", "--", "env")
-	// Uncomment after kubectl debug node label.
-	// PR https://github.com/kubernetes/kubernetes/pull/131791.
-	// e.Contains(nodeDebuggingPodEnvOutput, "SPO_EXEC_REQUEST_UID")
-	// e.logf("The env output has SPO_EXEC_REQUEST_UID")
+	nodeDebuggingPodEnvOutput := e.kubectl("debug", "--profile", "general",
+		"node/"+strings.Trim(nodeName, "'"), "--image", "busybox", "-it", "--", "env")
+	e.Contains(nodeDebuggingPodEnvOutput, "SPO_EXEC_REQUEST_UID")
+	e.logf("The env output has SPO_EXEC_REQUEST_UID")
 
 	// Wait for the flush interval.
 	time.Sleep(20 * time.Second)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?
/kind cleanup

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:
The PR https://github.com/kubernetes/kubernetes/pull/131791 is part of 1.34 and the CI environment of SPO is upgraded to 1.34 in https://github.com/kubernetes-sigs/security-profiles-operator/pull/2984.

Hence enabling the test which checks to ensure that the label is set by the webhook for the audit logging feature.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?
Yes
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
