### PR TITLE
OCPBUGS-62730 - Fixed typos and truncated field values in JSON audit logs generated by the JSON enricher

### DIFF
--- a/internal/pkg/daemon/enricher/jsonenricher.go
+++ b/internal/pkg/daemon/enricher/jsonenricher.go
@@ -320,14 +320,20 @@ func (e *JsonEnricher) Run(ctx context.Context, runErr chan<- error) {
 					"unable to get uid and gid", "line", line)
 			}
 
-			logBucket.ProcessInfo = e.fetchProcessInfo(auditLine.ProcessID,
+			pi := e.fetchProcessInfo(auditLine.ProcessID,
 				auditLine.Executable, uid, gid)
+			logBucket.Mu.Lock()
+			logBucket.ProcessInfo = pi
+			logBucket.Mu.Unlock()
 		}
 
 		e.processEbpf(logBucket, auditLine)
 
 		if logBucket.ContainerInfo == nil {
-			logBucket.ContainerInfo = e.fetchContainerInfo(ctx, auditLine.ProcessID, nodeName)
+			ci := e.fetchContainerInfo(ctx, auditLine.ProcessID, nodeName)
+			logBucket.Mu.Lock()
+			logBucket.ContainerInfo = ci
+			logBucket.Mu.Unlock()
 		}
 
 		logBucket.SyscallIds.LoadOrStore(auditLine.SystemCallID, struct{}{})
@@ -341,6 +347,9 @@ func (e *JsonEnricher) Run(ctx context.Context, runErr chan<- error) {
 }
 
 func (e *JsonEnricher) processEbpf(logBucket *types.LogBucket, auditLine *types.AuditLine) {
+	logBucket.Mu.Lock()
+	defer logBucket.Mu.Unlock()
+
 	if e.bpfProcessCache != nil && logBucket.ProcessInfo != nil && logBucket.ProcessInfo.CmdLine == "" {
 		cmdLine, errCmdLine := e.bpfProcessCache.GetCmdLine(auditLine.ProcessID)
 		if errCmdLine == nil {
@@ -434,6 +443,9 @@ func (e *JsonEnricher) dispatchSeccompLine(
 
 		return true
 	})
+
+	logBucket.Mu.RLock()
+	defer logBucket.Mu.RUnlock()
 
 	var resource map[string]string
 

--- a/internal/pkg/daemon/enricher/types/types.go
+++ b/internal/pkg/daemon/enricher/types/types.go
@@ -72,6 +72,7 @@ type ProcessInfo struct {
 	ExecRequestId *string
 }
 type LogBucket struct {
+	Mu            sync.RWMutex
 	SyscallIds    sync.Map
 	ContainerInfo *ContainerInfo
 	ProcessInfo   *ProcessInfo


### PR DESCRIPTION
#### What type of PR is this?

  /kind bug

#### What this PR does / why we need it:

  This PR fixes typos and truncated field values in the JSON audit logs generated by the Security Profiles Operator's JSON enricher. The issue manifested as:
  - Misspelled keys: "namspace", "namepace", "amespace" instead of "namespace"
  - Truncated values: "ecurity-profiles-operator" instead of "security-profiles-operator"

  **Changes:**
  - Extract `podName`, `namespace`, and `containerName` from `ContainerInfo` into local variables before assigning to the resource map
  - Create a local copy of `nodeName` before assigning to the node map

  This ensures all JSON keys and values in audit logs are correctly spelled and complete.

  #### Which issue(s) this PR fixes:

  Fixes [OCPBUGS-62730](https://issues.redhat.com/browse/OCPBUGS-62730)

  #### Does this PR have test?

Tested manually to verify the values
test result:
```
export KUBECONFIG=/home/bgudi/work/src/github.com/openshift/kubeconfigFiles/370936/kubeconfig && NS="security-profiles-operator" && POD="my-pod"

# Run test commands
oc exec -n $NS $POD -- sh -c "id"
oc exec -n $NS $POD -- sh -c "cat /etc/os-release"
oc exec -n $NS $POD -- sh -c "ls -l /tmp"
oc exec -n $NS $POD -- sh -c "echo hello"
oc exec -n $NS $POD -- sh -c "hostname"

echo "Commands executed"
uid=0(root) gid=0(root) groups=0(root)
PRETTY_NAME="Debian GNU/Linux 10 (buster)"
NAME="Debian GNU/Linux"
VERSION_ID="10"
VERSION="10 (buster)"
VERSION_CODENAME=buster
ID=debian
HOME_URL="https://www.debian.org/"
SUPPORT_URL="https://www.debian.org/support"
BUG_REPORT_URL="https://bugs.debian.org/"
total 0
hello
my-pod
Commands executed

$ oc rsh -n security-profiles-operator my-pod sh -c "id && hostname && pwd"
uid=0(root) gid=0(root) groups=0(root)
my-pod
/
$ oc rsh -n security-profiles-operator my-pod sh -c "whoami && date && uname -a"
root
Tue Mar 10 15:02:27 UTC 2026
Linux my-pod 5.14.0-570.96.1.el9_6.x86_64 #1 SMP PREEMPT_DYNAMIC Mon Mar 2 20:41:08 EST 2026 x86_64 GNU/Linux
$ oc debug node/bgudi-j9-85mrm-worker-b-mgdfh
Starting pod/bgudi-j9-85mrm-worker-b-mgdfh-debug-9wqth ...
To use host binaries, run `chroot /host`. Instead, if you need to access host namespaces, run `nsenter -a -t 1`.
Pod IP: 10.0.128.5
If you don't see a command prompt, try pressing enter.
sh-5.1# chroot /host
sh-5.1# cd /tmp/logs/
sh-5.1# ls -ltr
total 16
-rw-------. 1 root root 12384 Jan  9 09:10 audit1.log
sh-5.1# cd /tmp/logs/
sh-5.1# grep my-pod audit1.log 
{"auditID":"dcf1f056-20b5-436c-bea0-8b0dcc1ceeba","cmdLine":"nginx: worker process ","executable":"/usr/sbin/nginx","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":13839,"resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["getpid"],"timestamp":"2026-03-10T14:38:18.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"eafc2dba-fdd6-4061-a47d-9bfa6fc9a5a8","cmdLine":"","executable":"/usr/bin/crun","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":13813,"resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["execve","clone","getpid"],"timestamp":"2026-03-10T14:38:18.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"8e5abe10-94b0-4d8c-988e-949fc7bec62e","cmdLine":"env SPO_EXEC_REQUEST_UID=f0ee0b34-99ee-4303-9bb2-8628648e40eb sh -c id ","executable":"/usr/bin/crun","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":15980,"requestUID":"f0ee0b34-99ee-4303-9bb2-8628648e40eb","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["clone","execve","getpid"],"timestamp":"2026-03-10T14:45:23.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"170fea62-6907-432b-baee-0ec80c9ceb30","cmdLine":"id ","executable":"/bin/dash","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":15981,"requestUID":"f0ee0b34-99ee-4303-9bb2-8628648e40eb","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["execve"],"timestamp":"2026-03-10T14:45:23.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"bf87a8c2-256b-47a2-a7ac-9223f79ffd72","cmdLine":"env SPO_EXEC_REQUEST_UID=580bfd76-e3d3-434c-bea2-22002212a212 sh -c cat /etc/os-release ","executable":"/usr/bin/crun","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":15997,"requestUID":"580bfd76-e3d3-434c-bea2-22002212a212","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["getpid","execve","clone"],"timestamp":"2026-03-10T14:45:28.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"c55ee8d5-9246-42cc-bbee-033e0dd53b32","cmdLine":"cat /etc/os-release ","executable":"/bin/dash","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":15998,"requestUID":"580bfd76-e3d3-434c-bea2-22002212a212","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["execve"],"timestamp":"2026-03-10T14:45:28.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"1c338155-e939-41e2-a4ac-9ff00cf96114","cmdLine":"env SPO_EXEC_REQUEST_UID=866ee807-6843-44d3-b0bf-68efa0296aa7 sh -c ls -l /tmp ","executable":"/usr/bin/crun","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":16036,"requestUID":"866ee807-6843-44d3-b0bf-68efa0296aa7","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["clone","getpid","execve"],"timestamp":"2026-03-10T14:45:33.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"310bd7f4-b20c-4bb0-ad90-8ccb2482989f","cmdLine":"ls -l /tmp ","executable":"/bin/dash","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":16037,"requestUID":"866ee807-6843-44d3-b0bf-68efa0296aa7","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["execve"],"timestamp":"2026-03-10T14:45:33.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"cc5e8b03-45a7-434a-ad25-23d40ba42435","cmdLine":"env SPO_EXEC_REQUEST_UID=de193172-188c-4596-a2a0-b64f75a1b8e4 sh -c echo hello ","executable":"/usr/bin/crun","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":16054,"requestUID":"de193172-188c-4596-a2a0-b64f75a1b8e4","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["execve","getpid"],"timestamp":"2026-03-10T14:45:38.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"8f6d2647-c645-46c8-8e68-71340865f0d5","cmdLine":"hostname ","executable":"/bin/dash","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":16086,"requestUID":"67fbde79-72ed-433f-af29-5e70aca699ae","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["execve"],"timestamp":"2026-03-10T14:45:43.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"5bb77b98-62db-4fc7-8d6a-0e823eb129e9","cmdLine":"env SPO_EXEC_REQUEST_UID=67fbde79-72ed-433f-af29-5e70aca699ae sh -c hostname ","executable":"/usr/bin/crun","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":16085,"requestUID":"67fbde79-72ed-433f-af29-5e70aca699ae","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["execve","getpid","clone"],"timestamp":"2026-03-10T14:45:43.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"01d38321-7418-4602-875c-1746d3280493","cmdLine":"id ","executable":"/bin/dash","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":21061,"requestUID":"bb9ed0f2-383f-49f8-8e3d-27afb62c8642","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["execve"],"timestamp":"2026-03-10T15:02:14.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"f1f446ca-368c-4f89-9964-b04361121506","cmdLine":"hostname ","executable":"/bin/dash","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":21062,"requestUID":"bb9ed0f2-383f-49f8-8e3d-27afb62c8642","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["execve"],"timestamp":"2026-03-10T15:02:14.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"ae322208-27f7-46f6-82da-561d23e38397","cmdLine":"env SPO_EXEC_REQUEST_UID=bb9ed0f2-383f-49f8-8e3d-27afb62c8642 sh -c id \u0026\u0026 hostname \u0026\u0026 pwd ","executable":"/usr/bin/crun","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":21060,"requestUID":"bb9ed0f2-383f-49f8-8e3d-27afb62c8642","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["getpid","clone","execve"],"timestamp":"2026-03-10T15:02:14.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"71c8da94-3eb6-4375-baaa-0725a909bd8c","cmdLine":"date ","executable":"/bin/dash","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":21133,"requestUID":"7565f237-4c9c-4f1a-ac0f-107741f25658","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["execve"],"timestamp":"2026-03-10T15:02:27.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"35caf221-ccb7-4d8f-8f18-21d21bedbae4","cmdLine":"env SPO_EXEC_REQUEST_UID=7565f237-4c9c-4f1a-ac0f-107741f25658 sh -c whoami \u0026\u0026 date \u0026\u0026 uname -a ","executable":"/usr/bin/crun","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":21131,"requestUID":"7565f237-4c9c-4f1a-ac0f-107741f25658","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["getpid","clone","execve"],"timestamp":"2026-03-10T15:02:27.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"8a82fcac-7d8e-4688-a2c1-65dad315711a","cmdLine":"whoami ","executable":"/bin/dash","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":21132,"requestUID":"7565f237-4c9c-4f1a-ac0f-107741f25658","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["execve"],"timestamp":"2026-03-10T15:02:27.000Z","uid":0,"version":"spo/v1_alpha"}
{"auditID":"c85b2c88-36b7-44af-af48-8c62f108865b","cmdLine":"uname -a ","executable":"/bin/dash","gid":0,"node":{"name":"bgudi-421-gbz8t-worker-c-sq569"},"pid":21134,"requestUID":"7565f237-4c9c-4f1a-ac0f-107741f25658","resource":{"container":"nginx","namespace":"security-profiles-operator","pod":"my-pod"},"syscalls":["execve"],"timestamp":"2026-03-10T15:02:27.000Z","uid":0,"version":"spo/v1_alpha"}
```

With this fix, all field names and values are now complete and correctly spelled.

  #### Special notes for your reviewer:

  The fix is minimal and surgical - by copying string values to local variables before map assignment, we prevent the memory corruption that was causing character truncation and field name typos. This is a critical fix for audit log reliability and automated log processing.

  #### Does this PR introduce a user-facing change?

  ```release-note
  Fixed typos and truncated field values in JSON audit logs generated by the Security Profiles Operator's JSON enricher. 
```
