### PR TITLE
feat: add flag to enable anonymous metrics access

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -80,22 +80,23 @@ import (
 )
 
 const (
-	spocCmd                      string = "spoc"
-	jsonFlag                     string = "json"
-	nodeStatusControllerFlag     string = "with-nodestatus-controller"
-	spodControllerFlag           string = "with-spod-controller"
-	workloadAnnotatorFlag        string = "with-workload-annotator"
-	recordingMergerFlag          string = "with-recording-merger"
-	recordingFlag                string = "with-recording"
-	seccompFlag                  string = "with-seccomp"
-	selinuxFlag                  string = "with-selinux"
-	apparmorFlag                 string = "with-apparmor"
-	webhookFlag                  string = "webhook"
-	memOptimFlag                 string = "with-mem-optim"
-	defaultWebhookPort           int    = 9443
-	auditLogIntervalSecondsParam string = "audit-log-interval-seconds"
-	auditLogPathParam            string = "audit-log-path"
-	auditLogMaxSizeParam         string = "audit-log-maxsize"
+	spocCmd                          string = "spoc"
+	jsonFlag                         string = "json"
+	nodeStatusControllerFlag         string = "with-nodestatus-controller"
+	spodControllerFlag               string = "with-spod-controller"
+	workloadAnnotatorFlag            string = "with-workload-annotator"
+	recordingMergerFlag              string = "with-recording-merger"
+	recordingFlag                    string = "with-recording"
+	seccompFlag                      string = "with-seccomp"
+	selinuxFlag                      string = "with-selinux"
+	apparmorFlag                     string = "with-apparmor"
+	webhookFlag                      string = "webhook"
+	memOptimFlag                     string = "with-mem-optim"
+	enableAnonymousMetricsAccessFlag string = "enable-anonymous-metrics-access"
+	defaultWebhookPort               int    = 9443
+	auditLogIntervalSecondsParam     string = "audit-log-interval-seconds"
+	auditLogPathParam                string = "audit-log-path"
+	auditLogMaxSizeParam             string = "audit-log-maxsize"
 	// The plural form is not used for audit-log-file-maxbackup to match the k8s api server audit log options.
 	auditLogMaxBackupParam   string = "audit-log-maxbackup"
 	auditLogMaxAgeParam      string = "audit-log-maxage"
@@ -384,6 +385,11 @@ func main() {
 			Value:   config.DefaultProfilingPort,
 			EnvVars: []string{config.ProfilingPortEnvKey},
 		},
+		&cli.BoolFlag{
+			Name:    enableAnonymousMetricsAccessFlag,
+			Usage:   "enable anonymous metrics access",
+			EnvVars: []string{config.EnableAnonymousMetricsAccessEnvKey},
+		},
 	}
 
 	if err := app.Run(os.Args); err != nil {
@@ -665,20 +671,29 @@ func runDaemon(ctx *cli.Context, info *version.Info) error {
 		c.NextProtos = []string{"http/1.1"}
 	}
 
+	metricsOptions := metricsserver.Options{
+		BindAddress: fmt.Sprintf(":%d", bindata.ContainerPort),
+		ExtraHandlers: map[string]http.Handler{
+			metrics.HandlerPath: met.Handler(),
+		},
+	}
+
+	if ctx.Bool(enableAnonymousMetricsAccessFlag) {
+		setupLog.Info("Anonymous metrics access allowed")
+
+		metricsOptions.SecureServing = false
+	} else {
+		metricsOptions.SecureServing = true
+		metricsOptions.CertDir = bindata.MetricsCertPath
+		metricsOptions.FilterProvider = metricsfilters.WithAuthenticationAndAuthorization
+		metricsOptions.TLSOpts = []func(*tls.Config){disableHTTP2}
+	}
+
 	ctrlOpts := ctrl.Options{
 		Cache:                  cache.Options{SyncPeriod: &sync},
 		HealthProbeBindAddress: fmt.Sprintf(":%d", config.HealthProbePort),
 		NewCache:               newMemoryOptimizedCache(ctx),
-		Metrics: metricsserver.Options{
-			BindAddress:    fmt.Sprintf(":%d", bindata.ContainerPort),
-			CertDir:        bindata.MetricsCertPath,
-			SecureServing:  true,
-			FilterProvider: metricsfilters.WithAuthenticationAndAuthorization,
-			ExtraHandlers: map[string]http.Handler{
-				metrics.HandlerPath: met.Handler(),
-			},
-			TLSOpts: []func(*tls.Config){disableHTTP2},
-		},
+		Metrics:                metricsOptions,
 	}
 
 	setControllerOptionsForNamespaces(&ctrlOpts)

--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -80,23 +80,23 @@ import (
 )
 
 const (
-	spocCmd                          string = "spoc"
-	jsonFlag                         string = "json"
-	nodeStatusControllerFlag         string = "with-nodestatus-controller"
-	spodControllerFlag               string = "with-spod-controller"
-	workloadAnnotatorFlag            string = "with-workload-annotator"
-	recordingMergerFlag              string = "with-recording-merger"
-	recordingFlag                    string = "with-recording"
-	seccompFlag                      string = "with-seccomp"
-	selinuxFlag                      string = "with-selinux"
-	apparmorFlag                     string = "with-apparmor"
-	webhookFlag                      string = "webhook"
-	memOptimFlag                     string = "with-mem-optim"
-	enableAnonymousMetricsAccessFlag string = "enable-anonymous-metrics-access"
-	defaultWebhookPort               int    = 9443
-	auditLogIntervalSecondsParam     string = "audit-log-interval-seconds"
-	auditLogPathParam                string = "audit-log-path"
-	auditLogMaxSizeParam             string = "audit-log-maxsize"
+	spocCmd                         string = "spoc"
+	jsonFlag                        string = "json"
+	nodeStatusControllerFlag        string = "with-nodestatus-controller"
+	spodControllerFlag              string = "with-spod-controller"
+	workloadAnnotatorFlag           string = "with-workload-annotator"
+	recordingMergerFlag             string = "with-recording-merger"
+	recordingFlag                   string = "with-recording"
+	seccompFlag                     string = "with-seccomp"
+	selinuxFlag                     string = "with-selinux"
+	apparmorFlag                    string = "with-apparmor"
+	webhookFlag                     string = "webhook"
+	memOptimFlag                    string = "with-mem-optim"
+	enableInsecureMetricsAccessFlag string = "enable-insecure-metrics-access"
+	defaultWebhookPort              int    = 9443
+	auditLogIntervalSecondsParam    string = "audit-log-interval-seconds"
+	auditLogPathParam               string = "audit-log-path"
+	auditLogMaxSizeParam            string = "audit-log-maxsize"
 	// The plural form is not used for audit-log-file-maxbackup to match the k8s api server audit log options.
 	auditLogMaxBackupParam   string = "audit-log-maxbackup"
 	auditLogMaxAgeParam      string = "audit-log-maxage"
@@ -386,9 +386,9 @@ func main() {
 			EnvVars: []string{config.ProfilingPortEnvKey},
 		},
 		&cli.BoolFlag{
-			Name:    enableAnonymousMetricsAccessFlag,
-			Usage:   "enable anonymous metrics access",
-			EnvVars: []string{config.EnableAnonymousMetricsAccessEnvKey},
+			Name:    enableInsecureMetricsAccessFlag,
+			Usage:   "enable insecure metrics access (disables TLS and authentication)",
+			EnvVars: []string{config.EnableInsecureMetricsAccessEnvKey},
 		},
 	}
 
@@ -678,8 +678,8 @@ func runDaemon(ctx *cli.Context, info *version.Info) error {
 		},
 	}
 
-	if ctx.Bool(enableAnonymousMetricsAccessFlag) {
-		setupLog.Info("Anonymous metrics access allowed")
+	if ctx.Bool(enableInsecureMetricsAccessFlag) {
+		setupLog.Info("Insecure metrics access allowed (TLS and authentication disabled)")
 
 		metricsOptions.SecureServing = false
 	} else {

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -94,6 +94,9 @@ const (
 	// EnableRecordingEnvKey is the environment variable key to enabling profile recording.
 	EnableRecordingEnvKey = "ENABLE_RECORDING"
 
+	// EnableAnonymousMetricsAccessEnvKey is the environment variable key for enabling anonymous metrics access.
+	EnableAnonymousMetricsAccessEnvKey = "ENABLE_ANONYMOUS_METRICS_ACCESS"
+
 	// VerboseLevel is the increased verbosity log level.
 	VerboseLevel = 1
 

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -94,7 +94,8 @@ const (
 	// EnableRecordingEnvKey is the environment variable key to enabling profile recording.
 	EnableRecordingEnvKey = "ENABLE_RECORDING"
 
-	// EnableInsecureMetricsAccessEnvKey is the environment variable key for enabling insecure metrics access(disables TLS and authentication).
+	// EnableInsecureMetricsAccessEnvKey is the environment variable key for enabling insecure
+	// metrics access(disables TLS and authentication).
 	EnableInsecureMetricsAccessEnvKey = "ENABLE_INSECURE_METRICS_ACCESS"
 
 	// VerboseLevel is the increased verbosity log level.

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -94,8 +94,8 @@ const (
 	// EnableRecordingEnvKey is the environment variable key to enabling profile recording.
 	EnableRecordingEnvKey = "ENABLE_RECORDING"
 
-	// EnableAnonymousMetricsAccessEnvKey is the environment variable key for enabling anonymous metrics access.
-	EnableAnonymousMetricsAccessEnvKey = "ENABLE_ANONYMOUS_METRICS_ACCESS"
+	// EnableInsecureMetricsAccessEnvKey is the environment variable key for enabling insecure metrics access(disables TLS and authentication).
+	EnableInsecureMetricsAccessEnvKey = "ENABLE_INSECURE_METRICS_ACCESS"
 
 	// VerboseLevel is the increased verbosity log level.
 	VerboseLevel = 1


### PR DESCRIPTION


#### What type of PR is this?


/kind feature


#### What this PR does / why we need it:

Allow metrics access without authentication.
The default behavior is still require authentication.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add --enable-insecure-metrics-access flag for unauthenticated/unencrypted
  metrics access; default secure behavior remains unchanged.
```
