### PR TITLE
Remove apt.llvm.org dependency in verify job; use distro clang-format

### DIFF
--- a/hack/pull-security-profiles-operator-verify
+++ b/hack/pull-security-profiles-operator-verify
@@ -2,5 +2,6 @@
 set -euo pipefail
 
 ./hack/install-packages
+apt-get update
 apt-get install -y lsb-release clang-format
 make verify

--- a/hack/pull-security-profiles-operator-verify
+++ b/hack/pull-security-profiles-operator-verify
@@ -2,10 +2,5 @@
 set -euo pipefail
 
 ./hack/install-packages
-
-CLANG_VERSION=21
-apt-get install -y lsb-release
-curl -sSfL --retry 5 --retry-delay 3 https://apt.llvm.org/llvm.sh | bash -s -- $CLANG_VERSION all
-ln -sf /usr/bin/clang-format-$CLANG_VERSION /usr/bin/clang-format
-
+apt-get install -y lsb-release clang-format
 make verify


### PR DESCRIPTION
Remove apt.llvm.org dependency in verify job; use distro clang-format

The verify script installs LLVM/Clang 21 via apt.llvm.org, which is currently failing on Debian Trixie due to apt signature (SHA1) restrictions.

Since the script only requires `clang-format` before running `make verify`, replace the external LLVM install with the distro-provided `clang-format`.

This removes the failing dependency while preserving the intended behavior.

Fixes: https://github.com/kubernetes/kubernetes/issues/137097
