### PR TITLE
Fix nix CI after flakes migration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -238,8 +238,7 @@ define nix-build-sign-spoc-to
 	cp -f result/spoc $(BUILD_DIR)/spoc.$(1)
 	cosign sign-blob -y \
 		$(BUILD_DIR)/spoc.$(1) \
-		--output-signature $(BUILD_DIR)/spoc.$(1).sig \
-		--output-certificate $(BUILD_DIR)/spoc.$(1).cert
+		--bundle $(BUILD_DIR)/spoc.$(1).bundle
 	cd $(BUILD_DIR) && sha512sum spoc.$(1) > spoc.$(1).sha512
 endef
 
@@ -253,8 +252,7 @@ nix-spoc: nix-spoc-amd64 nix-spoc-arm64 nix-spoc-ppc64le nix-spoc-s390x ## Build
 		-o $(BUILD_DIR)/spoc.spdx
 	cosign sign-blob -y \
 		$(BUILD_DIR)/spoc.spdx \
-		--output-signature $(BUILD_DIR)/spoc.spdx.sig \
-		--output-certificate $(BUILD_DIR)/spoc.spdx.cert
+		--bundle $(BUILD_DIR)/spoc.spdx.bundle
 
 .PHONY: nix-spoc-amd64
 nix-spoc-amd64: $(BUILD_DIR) ## Build and sign the spoc binary via nix for amd64

--- a/hack/image-cross.sh
+++ b/hack/image-cross.sh
@@ -34,7 +34,7 @@ for ARCH in "${ARCHES[@]}"; do
         -t "$IMAGE-$ARCH:$VERSION" \
         -t "$IMAGE-$ARCH:latest" \
         --build-arg version="$VERSION" \
-        --build-arg target="nix/default-$ARCH.nix" \
+        --build-arg target="spo-$ARCH" \
         .
     for T in "${TAGS[@]}"; do
         docker push "$IMAGE-$ARCH:$T"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes two CI failures on main after the nix flakes migration:

1. **nix spoc push (GitHub Actions):** cosign sign-blob now requires `--bundle` instead of the deprecated `--output-signature`/`--output-certificate` flags.
2. **push-image (Prow):** `hack/image-cross.sh` still used the old `nix/default-$ARCH.nix` target paths instead of the new flake package names (`spo-$ARCH`).

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```