### PR TITLE
spod: chown emptyDir mounts via fsGroup so cosign TUF cache works

### DIFF
--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -157,6 +157,7 @@ var Manifest = &appsv1.DaemonSet{
 					SeccompProfile: &corev1.SeccompProfile{
 						Type: corev1.SeccompProfileTypeRuntimeDefault,
 					},
+					FSGroup: &userRootless,
 				},
 				InitContainers: []corev1.Container{
 					{


### PR DESCRIPTION

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Sets `FSGroup: UserRootless` on the spod `PodSecurityContext`. The spod main container runs as UID 65535 (`UserRootless`) with `ReadOnlyRootFilesystem: true`, and mounts an `emptyDir` named `home-volume` at `HomeDirectory` (`/home`). With no `fsGroup` on the pod, kubelet leaves emptyDir volumes owned by `root:root` mode `0755`, so the non-root container cannot create `/home/.sigstore/`. cosign's TUF client surfaces this as:

```
WARNING: Could not fetch trusted_root.json from the TUF repository.
  chmod /home/.sigstore/root/tuf-repo-cdn.sigstore.dev/tuf_tmpXXX: operation not permitted
ERROR cannot pull base profile oci://ghcr.io/security-profiles/runc:vX.Y.Z
  err="verify signature: getting Rekor public keys: creating cached local store: operation not permitted"
```

So with the default `disableOciArtifactSignatureVerification: false`, any `SeccompProfile` referencing an `oci://` base profile is unusable today. Users have had to set `disableOciArtifactSignatureVerification: true` on the spod CR, defeating the supply-chain protection that motivated using a signed OCI artifact in the first place.

`fsGroup: UserRootless` makes kubelet recursively chown the emptyDirs to `:65535` with group-write. The other emptyDir mounts on the spod main container (`tmp-volume`, `grpc-server-volume`, `selinuxd-private-volume`, `selinux-drop-dir`) are unaffected (they were already writable by the container UID through different means). HostPath mounts are not chowned by `fsGroup` and remain unchanged. No other containers in the pod (init / non-root-enabler / metrics / log-enricher / bpf-recorder / selinuxd) have a behaviour-altering interaction with `fsGroup`.

The hardcoded TUF cache path comes from the vendored sigstore client (`vendor/github.com/sigstore/sigstore/pkg/tuf/client.go` ≈ line 561), so an env var override (`TUF_ROOT`) was considered as an alternative. Fixing ownership at the volume layer is the smaller and more direct change, and it doesn't introduce a new env var to document.

#### Which issue(s) this PR fixes:

Fixes #3162

#### Does this PR have test?

No new automated tests. Manual verification: install SPO from this branch into a kind cluster, leave `disableOciArtifactSignatureVerification` at its default `false`, apply a `SeccompProfile` referencing `oci://ghcr.io/security-profiles/runc:v1.3.3`, observe spod logs — cosign successfully fetches and caches TUF metadata at `/home/.sigstore/`, and the profile reaches `status.status: Installed` (still amd64-only on the published artifact side; that's the orthogonal #3161).

#### Special notes for your reviewer:

`test/tc_base_profiles_oci_test.go` is currently `nolint:unused` ("test is flaky and therefore got deactivated") and patches spod with `"disableOciArtifactSignatureVerification": true` to bypass the very issue this PR fixes. With this change, that patch can be dropped and the test could be re-enabled — but I haven't bundled that here because the original flakiness reason isn't documented in the surrounding history, and re-enabling without understanding the prior flakiness feels out of scope for a fix PR. Happy to do it as a follow-up if you'd prefer.

Related: #3161 (runc OCI base-profile artifacts published as amd64-only) is the other half of the OCI base-profile path. That one is on the publishing side and is independent of this fix.

#### Does this PR introduce a user-facing change?

```release-note
spod: cosign signature verification on OCI base profiles now works in the default configuration. Previously the cosign TUF metadata cache write to `/home/.sigstore/` failed because the `home-volume` emptyDir was owned by `root:root` while the spod main container runs as a non-root UID. Setting `FSGroup: UserRootless` on the PodSecurityContext makes the emptyDir writable by the container user, so users no longer need `disableOciArtifactSignatureVerification: true` as a workaround.
```
