### PR TITLE
Extract shared reconciliation logic from profile controllers

### DIFF
--- a/internal/pkg/daemon/apparmorprofile/apparmorprofile.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmorprofile.go
@@ -28,9 +28,7 @@ import (
 	aa "github.com/pjbgf/go-apparmor/pkg/apparmor"
 	"github.com/pjbgf/go-apparmor/pkg/hostop"
 	"k8s.io/client-go/tools/record"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/scheme"
 
@@ -38,6 +36,7 @@ import (
 	statusv1alpha1 "sigs.k8s.io/security-profiles-operator/api/secprofnodestatus/v1alpha1"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/controller"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/common"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/metrics"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/nodestatus"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/util"
@@ -47,13 +46,9 @@ const (
 	// default reconcile timeout.
 	reconcileTimeout = 1 * time.Minute
 
-	wait = 10 * time.Second
-
-	errGetProfile         = "cannot get profile"
 	errAppArmorProfileNil = "apparmor profile cannot be nil"
 
 	reasonAppArmorNotSupported  string = "AppArmorNotSupportedOnNode"
-	reasonCannotUpdateStatus    string = "CannotUpdateNodeStatus"
 	reasonCannotLoadProfile     string = "CannotLoadAppArmorProfile"
 	reasonCannotUnloadProfile   string = "CannotUnloadAppArmorProfile"
 	reasonCannotUpdateProfile   string = "CannotUpdateAppArmorProfile"
@@ -140,7 +135,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			return reconcile.Result{}, nil
 		}
 
-		return reconcile.Result{}, fmt.Errorf("%s: %w", errGetProfile, err)
+		return reconcile.Result{}, fmt.Errorf("%s: %w", common.ErrGetProfile, err)
 	}
 
 	return r.reconcileAppArmorProfile(ctx, appArmorProfile, logger)
@@ -173,19 +168,13 @@ func (r *Reconciler) reconcileAppArmorProfile(
 	}
 
 	// The object is not being deleted
-	exists, existErr := nodeStatus.Exists(ctx)
-	if existErr != nil {
-		return reconcile.Result{}, fmt.Errorf("checking if node status exists: %w", existErr)
+	created, result, ensureErr := common.EnsureNodeStatus(ctx, nodeStatus, l)
+	if ensureErr != nil {
+		return result, ensureErr
 	}
 
-	if !exists {
-		if err := nodeStatus.Create(ctx); err != nil {
-			return reconcile.Result{}, fmt.Errorf("cannot ensure node status: %w", err)
-		}
-
-		l.Info("Created an initial status for this node")
-
-		return reconcile.Result{RequeueAfter: wait}, nil
+	if created {
+		return result, nil
 	}
 
 	isAlreadyInstalled, getErr := nodeStatus.Matches(ctx, statusv1alpha1.ProfileStateInstalled)
@@ -203,8 +192,8 @@ func (r *Reconciler) reconcileAppArmorProfile(
 
 	if err := nodeStatus.SetNodeStatus(ctx, statusv1alpha1.ProfileStateInstalled); err != nil {
 		l.Error(err, "cannot update node status")
-		r.metrics.IncAppArmorProfileError(sp.GetName(), reasonCannotUpdateStatus)
-		r.record.Event(sp, util.EventTypeWarning, reasonCannotUpdateStatus, err.Error())
+		r.metrics.IncAppArmorProfileError(sp.GetName(), common.ReasonCannotUpdateStatus)
+		r.record.Event(sp, util.EventTypeWarning, common.ReasonCannotUpdateStatus, err.Error())
 
 		return reconcile.Result{}, fmt.Errorf("updating status in AppArmorProfile reconciler: %w", err)
 	}
@@ -230,58 +219,16 @@ func (r *Reconciler) reconcileDeletion(
 	sp *v1alpha1.AppArmorProfile,
 	nsc *nodestatus.StatusClient,
 ) (reconcile.Result, error) {
-	hasStatus, err := nsc.Exists(ctx)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("checking if node status exists: %w", err)
-	}
-
-	// Set the status if it hasn't been deleted already
-	if hasStatus {
-		isTerminating, getErr := nsc.Matches(ctx, statusv1alpha1.ProfileStateTerminating)
-		if getErr != nil {
-			r.log.Error(getErr, "couldn't get current status")
-
-			return reconcile.Result{}, fmt.Errorf("getting status for deleted AppArmorProfile: %w", getErr)
-		}
-
-		if !isTerminating {
-			r.log.Info("setting status to terminating")
-
-			if err := nsc.SetNodeStatus(ctx, statusv1alpha1.ProfileStateTerminating); err != nil {
-				r.log.Error(err, "cannot update AppArmorProfile status")
-				r.metrics.IncAppArmorProfileError(sp.GetName(), reasonCannotUpdateProfile)
-				r.record.Event(sp, util.EventTypeWarning, reasonCannotUpdateProfile, err.Error())
-
-				return reconcile.Result{}, fmt.Errorf("updating status for deleted AppArmorProfile: %w", err)
-			}
-
-			return reconcile.Result{Requeue: true, RequeueAfter: wait}, nil
-		}
-	}
-
-	if controllerutil.ContainsFinalizer(sp, util.HasActivePodsFinalizerString) {
-		r.log.Info("cannot delete profile in use by pod, requeuing")
-
-		return reconcile.Result{RequeueAfter: wait}, nil
-	}
-
-	if err := r.handleDeletion(sp); err != nil {
-		r.log.Error(err, "cannot delete profile")
-		r.metrics.IncAppArmorProfileError(sp.GetName(), reasonCannotUnloadProfile)
-		r.record.Event(sp, util.EventTypeWarning, reasonCannotUnloadProfile, err.Error())
-
-		return ctrl.Result{}, fmt.Errorf("handling file deletion for deleted AppArmorProfile: %w", err)
-	}
-
-	if err := nsc.Remove(ctx, r.client); err != nil {
-		r.log.Error(err, "cannot remove node status/finalizer from apparmor profile")
-		r.metrics.IncAppArmorProfileError(sp.GetName(), reasonCannotUpdateStatus)
-		r.record.Event(sp, util.EventTypeWarning, reasonCannotUpdateStatus, err.Error())
-
-		return ctrl.Result{}, fmt.Errorf("deleting node status/finalizer for deleted AppArmorProfile: %w", err)
-	}
-
-	return ctrl.Result{}, nil
+	return common.ReconcileDeletion(
+		ctx, sp, nsc, r.client, r.log, r.record,
+		common.DeletionReasons{
+			CannotUpdateProfile: reasonCannotUpdateProfile,
+			CannotRemoveProfile: reasonCannotUnloadProfile,
+			CannotUpdateStatus:  common.ReasonCannotUpdateStatus,
+		},
+		func(reason string) { r.metrics.IncAppArmorProfileError(sp.GetName(), reason) },
+		func() error { return r.handleDeletion(sp) },
+	)
 }
 
 func (r *Reconciler) handleDeletion(sp *v1alpha1.AppArmorProfile) error {

--- a/internal/pkg/daemon/common/reconciler.go
+++ b/internal/pkg/daemon/common/reconciler.go
@@ -1,0 +1,142 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	statusv1alpha1 "sigs.k8s.io/security-profiles-operator/api/secprofnodestatus/v1alpha1"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/nodestatus"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/util"
+)
+
+const (
+	Wait                     = 10 * time.Second
+	ErrGetProfile            = "cannot get profile"
+	ReasonCannotUpdateStatus = "CannotUpdateNodeStatus"
+)
+
+// DeletionReasons holds profile-type-specific event reason strings used
+// during deletion reconciliation.
+type DeletionReasons struct {
+	CannotUpdateProfile string
+	CannotRemoveProfile string
+	CannotUpdateStatus  string
+}
+
+// ReconcileDeletion implements the shared deletion reconciliation flow for
+// profile controllers. Profile-specific behavior is injected via callbacks:
+// incError increments the appropriate error metric, and handleDeletion
+// performs the actual profile removal (e.g., file delete or kernel unload).
+func ReconcileDeletion(
+	ctx context.Context,
+	profile client.Object,
+	nsc *nodestatus.StatusClient,
+	cl client.Client,
+	log logr.Logger,
+	rec record.EventRecorder,
+	reasons DeletionReasons,
+	incError func(reason string),
+	handleDeletion func() error,
+) (reconcile.Result, error) {
+	hasStatus, err := nsc.Exists(ctx)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("checking if node status exists: %w", err)
+	}
+
+	if hasStatus {
+		isTerminating, getErr := nsc.Matches(ctx, statusv1alpha1.ProfileStateTerminating)
+		if getErr != nil {
+			log.Error(getErr, "couldn't get current status")
+
+			return reconcile.Result{}, fmt.Errorf("getting status for deleted profile: %w", getErr)
+		}
+
+		if !isTerminating {
+			log.Info("setting status to terminating")
+
+			if err := nsc.SetNodeStatus(ctx, statusv1alpha1.ProfileStateTerminating); err != nil {
+				log.Error(err, "cannot update profile status")
+				incError(reasons.CannotUpdateProfile)
+				rec.Event(profile, util.EventTypeWarning, reasons.CannotUpdateProfile, err.Error())
+
+				return reconcile.Result{}, fmt.Errorf("updating status for deleted profile: %w", err)
+			}
+
+			return reconcile.Result{Requeue: true, RequeueAfter: Wait}, nil
+		}
+	}
+
+	if controllerutil.ContainsFinalizer(profile, util.HasActivePodsFinalizerString) {
+		log.Info("cannot delete profile in use by pod, requeuing")
+
+		return reconcile.Result{RequeueAfter: Wait}, nil
+	}
+
+	if err := handleDeletion(); err != nil {
+		log.Error(err, "cannot delete profile")
+		incError(reasons.CannotRemoveProfile)
+		rec.Event(profile, util.EventTypeWarning, reasons.CannotRemoveProfile, err.Error())
+
+		return ctrl.Result{}, fmt.Errorf("handling deletion for deleted profile: %w", err)
+	}
+
+	if err := nsc.Remove(ctx, cl); err != nil {
+		log.Error(err, "cannot remove node status/finalizer from profile")
+		incError(reasons.CannotUpdateStatus)
+		rec.Event(profile, util.EventTypeWarning, reasons.CannotUpdateStatus, err.Error())
+
+		return ctrl.Result{}, fmt.Errorf("deleting node status/finalizer for deleted profile: %w", err)
+	}
+
+	return ctrl.Result{}, nil
+}
+
+// EnsureNodeStatus checks whether the node status for a profile exists and
+// creates it if it does not. Returns (true, requeueResult, nil) when the
+// status was just created, signaling that the caller should requeue.
+func EnsureNodeStatus(
+	ctx context.Context,
+	nsc *nodestatus.StatusClient,
+	log logr.Logger,
+) (bool, reconcile.Result, error) {
+	exists, err := nsc.Exists(ctx)
+	if err != nil {
+		return false, reconcile.Result{}, fmt.Errorf("checking if node status exists: %w", err)
+	}
+
+	if !exists {
+		if err := nsc.Create(ctx); err != nil {
+			return false, reconcile.Result{}, fmt.Errorf("cannot ensure node status: %w", err)
+		}
+
+		log.Info("Created an initial status for this node")
+
+		return true, reconcile.Result{RequeueAfter: Wait}, nil
+	}
+
+	return false, reconcile.Result{}, nil
+}

--- a/internal/pkg/daemon/common/reconciler_test.go
+++ b/internal/pkg/daemon/common/reconciler_test.go
@@ -1,0 +1,285 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package common
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	seccompprofileapi "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"
+	statusv1alpha1 "sigs.k8s.io/security-profiles-operator/api/secprofnodestatus/v1alpha1"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/nodestatus"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/util"
+)
+
+const testNodeName = "test-node"
+
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	seccompprofileapi.SchemeBuilder.AddToScheme(s) //nolint:errcheck // test helper
+	statusv1alpha1.SchemeBuilder.AddToScheme(s)    //nolint:errcheck // test helper
+
+	return s
+}
+
+func testProfile(finalizers ...string) *seccompprofileapi.SeccompProfile {
+	return &seccompprofileapi.SeccompProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-profile",
+			Namespace:  "default",
+			Finalizers: finalizers,
+		},
+	}
+}
+
+func testReasons() DeletionReasons {
+	return DeletionReasons{
+		CannotUpdateProfile: "CannotUpdate",
+		CannotRemoveProfile: "CannotRemove",
+		CannotUpdateStatus:  "CannotUpdateStatus",
+	}
+}
+
+func testNodeStatus(
+	t *testing.T, profile *seccompprofileapi.SeccompProfile, cl client.Client,
+) *nodestatus.StatusClient {
+	t.Helper()
+
+	nsc, err := nodestatus.NewForProfile(profile, cl)
+	require.NoError(t, err)
+
+	return nsc
+}
+
+//nolint:paralleltest // subtests modify environment variables and cannot run in parallel
+func TestReconcileDeletion(t *testing.T) {
+	t.Setenv("NODE_NAME", testNodeName)
+
+	errTest := errors.New("test error")
+
+	cases := []struct {
+		name           string
+		profile        *seccompprofileapi.SeccompProfile
+		mockClient     *util.MockClient
+		handleDeletion func() error
+		wantResult     reconcile.Result
+		wantErr        bool
+		wantIncError   bool
+	}{
+		{
+			name:    "NoStatusExists_NoDeletionNeeded",
+			profile: testProfile(),
+			mockClient: &util.MockClient{
+				MockGet:    util.NewMockGetFn(errors.New("not found")),
+				MockUpdate: util.NewMockUpdateFn(nil),
+				MockDelete: util.NewMockDeleteFn(nil),
+				MockScheme: util.NewMockSchemeFn(testScheme()),
+			},
+			handleDeletion: func() error { return nil },
+			wantResult:     reconcile.Result{},
+			wantErr:        true,
+		},
+		{
+			name:    "StatusExistsNotTerminating_SetsTerminatingAndRequeues",
+			profile: testProfile(util.GetFinalizerNodeString(testNodeName)),
+			mockClient: &util.MockClient{
+				MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					if ns, ok := obj.(*statusv1alpha1.SecurityProfileNodeStatus); ok {
+						ns.Status = statusv1alpha1.ProfileStatePending
+						ns.Labels = map[string]string{
+							statusv1alpha1.StatusStateLabel: string(statusv1alpha1.ProfileStatePending),
+						}
+					}
+
+					return nil
+				},
+				MockUpdate: util.NewMockUpdateFn(nil),
+				MockScheme: util.NewMockSchemeFn(testScheme()),
+			},
+			handleDeletion: func() error { return nil },
+			wantResult:     reconcile.Result{Requeue: true, RequeueAfter: Wait},
+			wantErr:        false,
+		},
+		{
+			name:    "StatusExistsTerminating_ActivePodsFinalizer_Requeues",
+			profile: testProfile(util.GetFinalizerNodeString(testNodeName), util.HasActivePodsFinalizerString),
+			mockClient: &util.MockClient{
+				MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					if ns, ok := obj.(*statusv1alpha1.SecurityProfileNodeStatus); ok {
+						ns.Status = statusv1alpha1.ProfileStateTerminating
+						ns.Labels = map[string]string{
+							statusv1alpha1.StatusStateLabel: string(statusv1alpha1.ProfileStateTerminating),
+						}
+					}
+
+					return nil
+				},
+				MockScheme: util.NewMockSchemeFn(testScheme()),
+			},
+			handleDeletion: func() error { return nil },
+			wantResult:     reconcile.Result{RequeueAfter: Wait},
+			wantErr:        false,
+		},
+		{
+			name:    "HandleDeletionFails",
+			profile: testProfile(util.GetFinalizerNodeString(testNodeName)),
+			mockClient: &util.MockClient{
+				MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					if ns, ok := obj.(*statusv1alpha1.SecurityProfileNodeStatus); ok {
+						ns.Status = statusv1alpha1.ProfileStateTerminating
+						ns.Labels = map[string]string{
+							statusv1alpha1.StatusStateLabel: string(statusv1alpha1.ProfileStateTerminating),
+						}
+					}
+
+					return nil
+				},
+				MockScheme: util.NewMockSchemeFn(testScheme()),
+			},
+			handleDeletion: func() error { return errTest },
+			wantResult:     reconcile.Result{},
+			wantErr:        true,
+			wantIncError:   true,
+		},
+		{
+			name:    "HappyPath_DeletionSucceeds",
+			profile: testProfile(util.GetFinalizerNodeString(testNodeName)),
+			mockClient: &util.MockClient{
+				MockGet: func(_ context.Context, _ client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+					if ns, ok := obj.(*statusv1alpha1.SecurityProfileNodeStatus); ok {
+						ns.Status = statusv1alpha1.ProfileStateTerminating
+						ns.Labels = map[string]string{
+							statusv1alpha1.StatusStateLabel: string(statusv1alpha1.ProfileStateTerminating),
+						}
+					}
+
+					return nil
+				},
+				MockUpdate: util.NewMockUpdateFn(nil),
+				MockDelete: util.NewMockDeleteFn(nil),
+				MockScheme: util.NewMockSchemeFn(testScheme()),
+			},
+			handleDeletion: func() error { return nil },
+			wantResult:     reconcile.Result{},
+			wantErr:        false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			nsc := testNodeStatus(t, tc.profile, tc.mockClient)
+
+			incErrorCalled := false
+			incError := func(_ string) { incErrorCalled = true }
+
+			recorder := record.NewFakeRecorder(10)
+
+			gotResult, gotErr := ReconcileDeletion(
+				t.Context(), tc.profile, nsc, tc.mockClient,
+				log.Log, recorder, testReasons(), incError, tc.handleDeletion,
+			)
+
+			if tc.wantErr {
+				require.Error(t, gotErr)
+			} else {
+				require.NoError(t, gotErr)
+			}
+
+			require.Equal(t, tc.wantResult, gotResult)
+
+			if tc.wantIncError {
+				require.True(t, incErrorCalled, "expected incError to be called")
+			}
+		})
+	}
+}
+
+//nolint:paralleltest // subtests modify environment variables and cannot run in parallel
+func TestEnsureNodeStatus(t *testing.T) {
+	t.Setenv("NODE_NAME", testNodeName)
+
+	cases := []struct {
+		name        string
+		profile     *seccompprofileapi.SeccompProfile
+		mockClient  *util.MockClient
+		wantCreated bool
+		wantResult  reconcile.Result
+		wantErr     bool
+	}{
+		{
+			name:    "AlreadyExists",
+			profile: testProfile(util.GetFinalizerNodeString(testNodeName)),
+			mockClient: &util.MockClient{
+				MockGet:    util.NewMockGetFn(nil),
+				MockScheme: util.NewMockSchemeFn(testScheme()),
+			},
+			wantCreated: false,
+			wantResult:  reconcile.Result{},
+			wantErr:     false,
+		},
+		{
+			name:    "ExistsCheckFails",
+			profile: testProfile(util.GetFinalizerNodeString(testNodeName)),
+			mockClient: &util.MockClient{
+				MockGet:    util.NewMockGetFn(errors.New("api error")),
+				MockScheme: util.NewMockSchemeFn(testScheme()),
+			},
+			wantCreated: false,
+			wantResult:  reconcile.Result{},
+			wantErr:     true,
+		},
+		{
+			name:    "CreatedSuccessfully",
+			profile: testProfile(),
+			mockClient: &util.MockClient{
+				MockGet:    util.NewMockGetFn(nil),
+				MockCreate: util.NewMockCreateFn(nil),
+				MockUpdate: util.NewMockUpdateFn(nil),
+				MockScheme: util.NewMockSchemeFn(testScheme()),
+			},
+			wantCreated: true,
+			wantResult:  reconcile.Result{RequeueAfter: Wait},
+			wantErr:     false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			nsc := testNodeStatus(t, tc.profile, tc.mockClient)
+
+			gotCreated, gotResult, gotErr := EnsureNodeStatus(t.Context(), nsc, log.Log)
+
+			if tc.wantErr {
+				require.Error(t, gotErr)
+			} else {
+				require.NoError(t, gotErr)
+			}
+
+			require.Equal(t, tc.wantCreated, gotCreated)
+			require.Equal(t, tc.wantResult, gotResult)
+		})
+	}
+}

--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -39,7 +39,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -52,6 +51,7 @@ import (
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/artifact"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/controller"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/common"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/metrics"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/nodestatus"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/util"
@@ -61,9 +61,6 @@ const (
 	// default reconcile timeout.
 	reconcileTimeout = 5 * time.Minute
 
-	wait = 10 * time.Second
-
-	errGetProfile          = "cannot get profile"
 	errSeccompProfileNil   = "seccomp profile cannot be nil"
 	errSavingProfile       = "cannot save profile"
 	errCreatingOperatorDir = "cannot create operator directory"
@@ -83,7 +80,6 @@ const (
 	reasonCannotSaveProfile     string = "CannotSaveSeccompProfile"
 	reasonCannotRemoveProfile   string = "CannotRemoveSeccompProfile"
 	reasonCannotUpdateProfile   string = "CannotUpdateSeccompProfile"
-	reasonCannotUpdateStatus    string = "CannotUpdateNodeStatus"
 	reasonProfileNotAllowed     string = "ProfileNotAllowed"
 	reasonSavedProfile          string = "SavedSeccompProfile"
 
@@ -306,7 +302,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req reconcile.Request) (reco
 			return reconcile.Result{}, nil
 		}
 
-		return reconcile.Result{}, fmt.Errorf("%s: %w", errGetProfile, err)
+		return reconcile.Result{}, fmt.Errorf("%s: %w", common.ErrGetProfile, err)
 	}
 
 	return r.reconcileSeccompProfile(ctx, seccompProfile, logger)
@@ -476,7 +472,7 @@ func (r *Reconciler) reconcileSeccompProfile(
 	if err != nil {
 		l.Error(err, "merge base profile")
 
-		return reconcile.Result{RequeueAfter: wait}, nil
+		return reconcile.Result{RequeueAfter: common.Wait}, nil
 	}
 
 	l.Info("Validate profile")
@@ -503,21 +499,13 @@ func (r *Reconciler) reconcileSeccompProfile(
 	profilePath := sp.GetProfilePath()
 
 	// The object is not being deleted
-	exists, existErr := nodeStatus.Exists(ctx)
-	if existErr != nil {
-		return reconcile.Result{}, fmt.Errorf("checking if node status exists: %w", existErr)
+	created, result, ensureErr := common.EnsureNodeStatus(ctx, nodeStatus, l)
+	if ensureErr != nil {
+		return result, ensureErr
 	}
 
-	if !exists {
-		l.Info("Creating node status")
-
-		if err := nodeStatus.Create(ctx); err != nil {
-			return reconcile.Result{}, fmt.Errorf("cannot ensure node status: %w", err)
-		}
-
-		l.Info("Created an initial status for this node")
-
-		return reconcile.Result{RequeueAfter: wait}, nil
+	if created {
+		return result, nil
 	}
 
 	if !sp.IsReconcilable() {
@@ -563,8 +551,8 @@ func (r *Reconciler) reconcileSeccompProfile(
 
 	if err := nodeStatus.SetNodeStatus(ctx, statusv1alpha1.ProfileStateInstalled); err != nil {
 		l.Error(err, "cannot update node status")
-		r.metrics.IncSeccompProfileError(reasonCannotUpdateStatus)
-		r.record.Event(sp, util.EventTypeWarning, reasonCannotUpdateStatus, err.Error())
+		r.metrics.IncSeccompProfileError(common.ReasonCannotUpdateStatus)
+		r.record.Event(sp, util.EventTypeWarning, common.ReasonCannotUpdateStatus, err.Error())
 
 		return reconcile.Result{}, fmt.Errorf("updating status in SeccompProfile reconciler: %w", err)
 	}
@@ -583,58 +571,16 @@ func (r *Reconciler) reconcileDeletion(
 	sp *seccompprofileapi.SeccompProfile,
 	nsc *nodestatus.StatusClient,
 ) (reconcile.Result, error) {
-	hasStatus, err := nsc.Exists(ctx)
-	if err != nil {
-		return ctrl.Result{}, fmt.Errorf("checking if node status exists: %w", err)
-	}
-
-	// Set the status if it hasn't been deleted already
-	if hasStatus {
-		isTerminating, getErr := nsc.Matches(ctx, statusv1alpha1.ProfileStateTerminating)
-		if getErr != nil {
-			r.log.Error(getErr, "couldn't get current status")
-
-			return reconcile.Result{}, fmt.Errorf("getting status for deleted SeccompProfile: %w", getErr)
-		}
-
-		if !isTerminating {
-			r.log.Info("setting status to terminating")
-
-			if err := nsc.SetNodeStatus(ctx, statusv1alpha1.ProfileStateTerminating); err != nil {
-				r.log.Error(err, "cannot update SeccompProfile status")
-				r.metrics.IncSeccompProfileError(reasonCannotUpdateProfile)
-				r.record.Event(sp, util.EventTypeWarning, reasonCannotUpdateProfile, err.Error())
-
-				return reconcile.Result{}, fmt.Errorf("updating status for deleted SeccompProfile: %w", err)
-			}
-
-			return reconcile.Result{Requeue: true, RequeueAfter: wait}, nil
-		}
-	}
-
-	if controllerutil.ContainsFinalizer(sp, util.HasActivePodsFinalizerString) {
-		r.log.Info("cannot delete profile in use by pod, requeuing")
-
-		return reconcile.Result{RequeueAfter: wait}, nil
-	}
-
-	if err := r.handleDeletion(sp); err != nil {
-		r.log.Error(err, "cannot delete profile")
-		r.metrics.IncSeccompProfileError(reasonCannotRemoveProfile)
-		r.record.Event(sp, util.EventTypeWarning, reasonCannotRemoveProfile, err.Error())
-
-		return ctrl.Result{}, fmt.Errorf("handling file deletion for deleted SeccompProfile: %w", err)
-	}
-
-	if err := nsc.Remove(ctx, r.client); err != nil {
-		r.log.Error(err, "cannot remove node status/finalizer from seccomp profile")
-		r.metrics.IncSeccompProfileError(reasonCannotUpdateStatus)
-		r.record.Event(sp, util.EventTypeWarning, reasonCannotUpdateStatus, err.Error())
-
-		return ctrl.Result{}, fmt.Errorf("deleting node status/finalizer for deleted SeccompProfile: %w", err)
-	}
-
-	return ctrl.Result{}, nil
+	return common.ReconcileDeletion(
+		ctx, sp, nsc, r.client, r.log, r.record,
+		common.DeletionReasons{
+			CannotUpdateProfile: reasonCannotUpdateProfile,
+			CannotRemoveProfile: reasonCannotRemoveProfile,
+			CannotUpdateStatus:  common.ReasonCannotUpdateStatus,
+		},
+		func(reason string) { r.metrics.IncSeccompProfileError(reason) },
+		func() error { return r.handleDeletion(sp) },
+	)
 }
 
 func (r *Reconciler) handleDeletion(sp *seccompprofileapi.SeccompProfile) error {

--- a/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
@@ -39,6 +39,7 @@ import (
 	spodapi "sigs.k8s.io/security-profiles-operator/api/spod/v1alpha1"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/artifact"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/common"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/metrics"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/seccompprofile/seccompprofilefakes"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/util"
@@ -85,7 +86,7 @@ func TestReconcile(t *testing.T) {
 			wantResult: reconcile.Result{},
 			wantErr: func() error {
 				if seccomp.IsEnabled() {
-					return fmt.Errorf("%s: %w", errGetProfile, errOops)
+					return fmt.Errorf("%s: %w", common.ErrGetProfile, errOops)
 				}
 
 				return nil


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

Extracts the duplicated deletion reconciliation flow and node status lifecycle management from the seccomp and apparmor profile daemon controllers into shared functions in `internal/pkg/daemon/common/reconciler.go`. Profile-specific behavior (metrics, file/kernel removal) is injected via callbacks.
SELinux is excluded since it has a fundamentally different reconciliation flow.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Yes

#### Special notes for your reviewer:

Internal error messages were slightly generalized (e.g., "deleted SeccompProfile" became "deleted profile"). Kubernetes event reason strings remain profile-type-specific via the `DeletionReasons` struct.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```