### PR TITLE
Cleanup high priority tech debt

### DIFF
--- a/api/selinuxprofile/v1alpha2/rawselinuxprofile_types.go
+++ b/api/selinuxprofile/v1alpha2/rawselinuxprofile_types.go
@@ -104,7 +104,7 @@ func (sp *RawSelinuxProfile) IsReconcilable() bool {
 type RawSelinuxProfileList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
-	Items           []SelinuxProfile `json:"items"`
+	Items           []RawSelinuxProfile `json:"items"`
 }
 
 func init() { //nolint:gochecknoinits // required to init the scheme

--- a/api/selinuxprofile/v1alpha2/zz_generated.deepcopy.go
+++ b/api/selinuxprofile/v1alpha2/zz_generated.deepcopy.go
@@ -133,7 +133,7 @@ func (in *RawSelinuxProfileList) DeepCopyInto(out *RawSelinuxProfileList) {
 	in.ListMeta.DeepCopyInto(&out.ListMeta)
 	if in.Items != nil {
 		in, out := &in.Items, &out.Items
-		*out = make([]SelinuxProfile, len(*in))
+		*out = make([]RawSelinuxProfile, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
@@ -192,13 +192,9 @@ func (b *BpfRecorder) Run() error {
 
 	b.logger.Info("Connecting to metrics server")
 
-	conn, cancel, err := b.connectMetrics()
+	conn, err := b.connectMetrics()
 	if err != nil {
 		return fmt.Errorf("connect to metrics server: %w", err)
-	}
-
-	if cancel != nil {
-		defer cancel()
 	}
 
 	if conn != nil {
@@ -245,9 +241,9 @@ func (b *BpfRecorder) Run() error {
 	return b.Serve(grpcServer, listener)
 }
 
-func (b *BpfRecorder) connectMetrics() (conn *grpc.ClientConn, cancel context.CancelFunc, err error) {
+func (b *BpfRecorder) connectMetrics() (conn *grpc.ClientConn, err error) {
 	if err := util.Retry(func() (err error) {
-		conn, cancel, err = b.DialMetrics()
+		conn, err = b.DialMetrics()
 		if err != nil {
 			return fmt.Errorf("connecting to local metrics GRPC server: %w", err)
 		}
@@ -256,8 +252,6 @@ func (b *BpfRecorder) connectMetrics() (conn *grpc.ClientConn, cancel context.Ca
 
 		b.metricsClient, err = b.BpfIncClient(client)
 		if err != nil {
-			cancel()
-
 			if err := b.CloseGRPC(conn); err != nil {
 				b.logger.Error(err, "Unable to close GRPC connection")
 			}
@@ -267,29 +261,24 @@ func (b *BpfRecorder) connectMetrics() (conn *grpc.ClientConn, cancel context.Ca
 
 		return nil
 	}, func(err error) bool { return true }); err != nil {
-		return nil, nil, fmt.Errorf("connect to local GRPC server: %w", err)
+		return nil, fmt.Errorf("connect to local GRPC server: %w", err)
 	}
 
-	return conn, cancel, nil
+	return conn, nil
 }
 
 // Dial can be used to connect to the default GRPC server by creating a new
 // client.
-func Dial() (*grpc.ClientConn, context.CancelFunc, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-
-	conn, err := grpc.DialContext( //nolint:staticcheck // TODO: migrate to grpc.NewClient
-		ctx,
+func Dial() (*grpc.ClientConn, error) {
+	conn, err := grpc.NewClient(
 		"unix://"+config.GRPCServerSocketBpfRecorder,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {
-		cancel()
-
-		return nil, nil, fmt.Errorf("GRPC dial: %w", err)
+		return nil, fmt.Errorf("GRPC dial: %w", err)
 	}
 
-	return conn, cancel, nil
+	return conn, nil
 }
 
 func (b *BpfRecorder) Start(

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_test.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_test.go
@@ -69,7 +69,7 @@ func TestRun(t *testing.T) {
 				mock.GetenvReturns(node)
 				mock.GoArchReturns(validGoArch)
 				mock.NewModuleFromBufferArgsReturns(&libbpfgo.Module{}, nil)
-				mock.DialMetricsReturns(&grpc.ClientConn{}, func() {}, nil)
+				mock.DialMetricsReturns(&grpc.ClientConn{}, nil)
 			},
 			assert: func(err error) {
 				require.NoError(t, err)
@@ -131,7 +131,7 @@ func TestRun(t *testing.T) {
 		{ // connectMetrics:DialMetrics fails
 			prepare: func(mock *bpfrecorderfakes.FakeImpl) {
 				mock.GetenvReturns(node)
-				mock.DialMetricsReturns(nil, nil, errTest)
+				mock.DialMetricsReturns(nil, errTest)
 			},
 			assert: func(err error) {
 				require.Error(t, err)
@@ -140,7 +140,7 @@ func TestRun(t *testing.T) {
 		{ // connectMetrics:BpfIncClient fails
 			prepare: func(mock *bpfrecorderfakes.FakeImpl) {
 				mock.GetenvReturns(node)
-				mock.DialMetricsReturns(&grpc.ClientConn{}, func() {}, nil)
+				mock.DialMetricsReturns(&grpc.ClientConn{}, nil)
 				mock.CloseGRPCReturns(errTest)
 				mock.BpfIncClientReturns(nil, errTest)
 			},

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_unsupported.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_unsupported.go
@@ -45,8 +45,8 @@ func (b *BpfRecorder) Run() error {
 
 // Dial can be used to connect to the default GRPC server by creating a new
 // client.
-func Dial() (*grpc.ClientConn, context.CancelFunc, error) {
-	return nil, nil, errUnsupported
+func Dial() (*grpc.ClientConn, error) {
+	return nil, errUnsupported
 }
 
 func (b *BpfRecorder) Start(

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorderfakes/fake_impl.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorderfakes/fake_impl.go
@@ -176,19 +176,17 @@ type FakeImpl struct {
 	destroyLinkReturnsOnCall map[int]struct {
 		result1 error
 	}
-	DialMetricsStub        func() (*grpc.ClientConn, context.CancelFunc, error)
+	DialMetricsStub        func() (*grpc.ClientConn, error)
 	dialMetricsMutex       sync.RWMutex
 	dialMetricsArgsForCall []struct {
 	}
 	dialMetricsReturns struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
+		result2 error
 	}
 	dialMetricsReturnsOnCall map[int]struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
+		result2 error
 	}
 	GetMapStub        func(*libbpfgo.Module, string) (*libbpfgo.BPFMap, error)
 	getMapMutex       sync.RWMutex
@@ -1268,7 +1266,7 @@ func (fake *FakeImpl) DestroyLinkReturnsOnCall(i int, result1 error) {
 	}{result1}
 }
 
-func (fake *FakeImpl) DialMetrics() (*grpc.ClientConn, context.CancelFunc, error) {
+func (fake *FakeImpl) DialMetrics() (*grpc.ClientConn, error) {
 	fake.dialMetricsMutex.Lock()
 	ret, specificReturn := fake.dialMetricsReturnsOnCall[len(fake.dialMetricsArgsForCall)]
 	fake.dialMetricsArgsForCall = append(fake.dialMetricsArgsForCall, struct {
@@ -1281,9 +1279,9 @@ func (fake *FakeImpl) DialMetrics() (*grpc.ClientConn, context.CancelFunc, error
 		return stub()
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeImpl) DialMetricsCallCount() int {
@@ -1292,39 +1290,36 @@ func (fake *FakeImpl) DialMetricsCallCount() int {
 	return len(fake.dialMetricsArgsForCall)
 }
 
-func (fake *FakeImpl) DialMetricsCalls(stub func() (*grpc.ClientConn, context.CancelFunc, error)) {
+func (fake *FakeImpl) DialMetricsCalls(stub func() (*grpc.ClientConn, error)) {
 	fake.dialMetricsMutex.Lock()
 	defer fake.dialMetricsMutex.Unlock()
 	fake.DialMetricsStub = stub
 }
 
-func (fake *FakeImpl) DialMetricsReturns(result1 *grpc.ClientConn, result2 context.CancelFunc, result3 error) {
+func (fake *FakeImpl) DialMetricsReturns(result1 *grpc.ClientConn, result2 error) {
 	fake.dialMetricsMutex.Lock()
 	defer fake.dialMetricsMutex.Unlock()
 	fake.DialMetricsStub = nil
 	fake.dialMetricsReturns = struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeImpl) DialMetricsReturnsOnCall(i int, result1 *grpc.ClientConn, result2 context.CancelFunc, result3 error) {
+func (fake *FakeImpl) DialMetricsReturnsOnCall(i int, result1 *grpc.ClientConn, result2 error) {
 	fake.dialMetricsMutex.Lock()
 	defer fake.dialMetricsMutex.Unlock()
 	fake.DialMetricsStub = nil
 	if fake.dialMetricsReturnsOnCall == nil {
 		fake.dialMetricsReturnsOnCall = make(map[int]struct {
 			result1 *grpc.ClientConn
-			result2 context.CancelFunc
-			result3 error
+			result2 error
 		})
 	}
 	fake.dialMetricsReturnsOnCall[i] = struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeImpl) GetMap(arg1 *libbpfgo.Module, arg2 string) (*libbpfgo.BPFMap, error) {

--- a/internal/pkg/daemon/bpfrecorder/impl.go
+++ b/internal/pkg/daemon/bpfrecorder/impl.go
@@ -86,7 +86,7 @@ type impl interface {
 	GoArch() string
 	Readlink(string) (string, error)
 	ParseUint(string) (uint32, error)
-	DialMetrics() (*grpc.ClientConn, context.CancelFunc, error)
+	DialMetrics() (*grpc.ClientConn, error)
 	BpfIncClient(client apimetrics.MetricsClient) (apimetrics.Metrics_BpfIncClient, error)
 	CloseGRPC(*grpc.ClientConn) error
 	SendMetric(apimetrics.Metrics_BpfIncClient, *apimetrics.BpfRequest) error
@@ -269,7 +269,7 @@ func (d *defaultImpl) ParseUint(s string) (uint32, error) {
 	return uint32(value), err
 }
 
-func (d *defaultImpl) DialMetrics() (*grpc.ClientConn, context.CancelFunc, error) {
+func (d *defaultImpl) DialMetrics() (*grpc.ClientConn, error) {
 	return metrics.Dial()
 }
 

--- a/internal/pkg/daemon/enricher/enricher.go
+++ b/internal/pkg/daemon/enricher/enricher.go
@@ -167,12 +167,11 @@ func (e *Enricher) Run() error {
 
 	var (
 		conn          *grpc.ClientConn
-		cancel        context.CancelFunc
 		metricsClient apimetrics.Metrics_AuditIncClient
 	)
 
 	if err := util.Retry(func() (err error) {
-		conn, cancel, err = e.Dial()
+		conn, err = e.Dial()
 		if err != nil {
 			return fmt.Errorf("connecting to local GRPC server: %w", err)
 		}
@@ -181,7 +180,6 @@ func (e *Enricher) Run() error {
 
 		metricsClient, err = e.AuditInc(client)
 		if err != nil {
-			cancel()
 			e.Close(conn)
 
 			return fmt.Errorf("create metrics audit client: %w", err)
@@ -192,7 +190,6 @@ func (e *Enricher) Run() error {
 		return fmt.Errorf("connect to local GRPC server: %w", err)
 	}
 
-	defer cancel()
 	defer e.Close(conn)
 
 	if err := e.startGrpcServer(); err != nil {
@@ -302,21 +299,16 @@ func (e *Enricher) startGrpcServer() error {
 
 // Dial can be used to connect to the default GRPC server by creating a new
 // client.
-func Dial() (*grpc.ClientConn, context.CancelFunc, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-
-	conn, err := grpc.DialContext( //nolint:staticcheck // TODO: migrate to grpc.NewClient
-		ctx,
+func Dial() (*grpc.ClientConn, error) {
+	conn, err := grpc.NewClient(
 		"unix://"+config.GRPCServerSocketEnricher,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {
-		cancel()
-
-		return nil, nil, fmt.Errorf("GRPC dial: %w", err)
+		return nil, fmt.Errorf("GRPC dial: %w", err)
 	}
 
-	return conn, cancel, nil
+	return conn, nil
 }
 
 func (e *Enricher) addToBacklog(line *types.AuditLine) error {

--- a/internal/pkg/daemon/enricher/enricher_test.go
+++ b/internal/pkg/daemon/enricher/enricher_test.go
@@ -112,7 +112,7 @@ func TestRun(t *testing.T) {
 			runAsync: false,
 			prepare: func(mock *enricherfakes.FakeImpl, lineChan chan *types.AuditLine) {
 				mock.GetenvReturns(node)
-				mock.DialReturns(nil, nil, errTest)
+				mock.DialReturns(nil, errTest)
 			},
 			assert: func(mock *enricherfakes.FakeImpl, lineChan chan *types.AuditLine, err error) {
 				require.Error(t, err)
@@ -123,7 +123,7 @@ func TestRun(t *testing.T) {
 			runAsync: false,
 			prepare: func(mock *enricherfakes.FakeImpl, lineChan chan *types.AuditLine) {
 				mock.GetenvReturns(node)
-				mock.DialReturns(nil, func() {}, errTest)
+				mock.DialReturns(nil, errTest)
 				mock.AuditIncReturns(nil, errTest)
 			},
 			assert: func(mock *enricherfakes.FakeImpl, lineChan chan *types.AuditLine, err error) {
@@ -135,7 +135,7 @@ func TestRun(t *testing.T) {
 			runAsync: false,
 			prepare: func(mock *enricherfakes.FakeImpl, lineChan chan *types.AuditLine) {
 				mock.GetenvReturns(node)
-				mock.DialReturns(nil, func() {}, errTest)
+				mock.DialReturns(nil, errTest)
 				mock.StartTailReturns(nil, errTest)
 			},
 			assert: func(mock *enricherfakes.FakeImpl, lineChan chan *types.AuditLine, err error) {
@@ -146,7 +146,7 @@ func TestRun(t *testing.T) {
 			runAsync: false,
 			prepare: func(mock *enricherfakes.FakeImpl, lineChan chan *types.AuditLine) {
 				mock.GetenvReturns(node)
-				mock.DialReturns(nil, func() {}, errTest)
+				mock.DialReturns(nil, errTest)
 				mock.ListenReturns(nil, errTest)
 			},
 			assert: func(mock *enricherfakes.FakeImpl, lineChan chan *types.AuditLine, err error) {
@@ -158,7 +158,7 @@ func TestRun(t *testing.T) {
 			runAsync: false,
 			prepare: func(mock *enricherfakes.FakeImpl, lineChan chan *types.AuditLine) {
 				mock.GetenvReturns(node)
-				mock.DialReturns(nil, func() {}, errTest)
+				mock.DialReturns(nil, errTest)
 				mock.ChownReturns(errTest)
 			},
 			assert: func(mock *enricherfakes.FakeImpl, lineChan chan *types.AuditLine, err error) {
@@ -169,7 +169,7 @@ func TestRun(t *testing.T) {
 			runAsync: false,
 			prepare: func(mock *enricherfakes.FakeImpl, lineChan chan *types.AuditLine) {
 				mock.GetenvReturns(node)
-				mock.DialReturns(nil, func() {}, errTest)
+				mock.DialReturns(nil, errTest)
 				close(lineChan)
 				mock.StartTailReturns(lineChan, nil)
 				mock.TailErrReturns(errTest)

--- a/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
+++ b/internal/pkg/daemon/enricher/enricherfakes/fake_impl.go
@@ -107,19 +107,17 @@ type FakeImpl struct {
 		result1 string
 		result2 error
 	}
-	DialStub        func() (*grpc.ClientConn, context.CancelFunc, error)
+	DialStub        func() (*grpc.ClientConn, error)
 	dialMutex       sync.RWMutex
 	dialArgsForCall []struct {
 	}
 	dialReturns struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
+		result2 error
 	}
 	dialReturnsOnCall map[int]struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
+		result2 error
 	}
 	EnvForPidStub        func(int) (map[string]string, error)
 	envForPidMutex       sync.RWMutex
@@ -691,7 +689,7 @@ func (fake *FakeImpl) ContainerIDForPIDReturnsOnCall(i int, result1 string, resu
 	}{result1, result2}
 }
 
-func (fake *FakeImpl) Dial() (*grpc.ClientConn, context.CancelFunc, error) {
+func (fake *FakeImpl) Dial() (*grpc.ClientConn, error) {
 	fake.dialMutex.Lock()
 	ret, specificReturn := fake.dialReturnsOnCall[len(fake.dialArgsForCall)]
 	fake.dialArgsForCall = append(fake.dialArgsForCall, struct {
@@ -704,9 +702,9 @@ func (fake *FakeImpl) Dial() (*grpc.ClientConn, context.CancelFunc, error) {
 		return stub()
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeImpl) DialCallCount() int {
@@ -715,39 +713,36 @@ func (fake *FakeImpl) DialCallCount() int {
 	return len(fake.dialArgsForCall)
 }
 
-func (fake *FakeImpl) DialCalls(stub func() (*grpc.ClientConn, context.CancelFunc, error)) {
+func (fake *FakeImpl) DialCalls(stub func() (*grpc.ClientConn, error)) {
 	fake.dialMutex.Lock()
 	defer fake.dialMutex.Unlock()
 	fake.DialStub = stub
 }
 
-func (fake *FakeImpl) DialReturns(result1 *grpc.ClientConn, result2 context.CancelFunc, result3 error) {
+func (fake *FakeImpl) DialReturns(result1 *grpc.ClientConn, result2 error) {
 	fake.dialMutex.Lock()
 	defer fake.dialMutex.Unlock()
 	fake.DialStub = nil
 	fake.dialReturns = struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeImpl) DialReturnsOnCall(i int, result1 *grpc.ClientConn, result2 context.CancelFunc, result3 error) {
+func (fake *FakeImpl) DialReturnsOnCall(i int, result1 *grpc.ClientConn, result2 error) {
 	fake.dialMutex.Lock()
 	defer fake.dialMutex.Unlock()
 	fake.DialStub = nil
 	if fake.dialReturnsOnCall == nil {
 		fake.dialReturnsOnCall = make(map[int]struct {
 			result1 *grpc.ClientConn
-			result2 context.CancelFunc
-			result3 error
+			result2 error
 		})
 	}
 	fake.dialReturnsOnCall[i] = struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeImpl) EnvForPid(arg1 int) (map[string]string, error) {

--- a/internal/pkg/daemon/enricher/impl.go
+++ b/internal/pkg/daemon/enricher/impl.go
@@ -57,7 +57,7 @@ func newDefaultImpl() *defaultImpl {
 //counterfeiter:generate . impl
 type impl interface {
 	Getenv(key string) string
-	Dial() (*grpc.ClientConn, context.CancelFunc, error)
+	Dial() (*grpc.ClientConn, error)
 	Close(*grpc.ClientConn) error
 	StartTail(src auditsource.AuditLineSource) (chan *types.AuditLine, error)
 	TailErr(src auditsource.AuditLineSource) error
@@ -87,7 +87,7 @@ func (d *defaultImpl) Getenv(key string) string {
 	return os.Getenv(key)
 }
 
-func (d *defaultImpl) Dial() (*grpc.ClientConn, context.CancelFunc, error) {
+func (d *defaultImpl) Dial() (*grpc.ClientConn, error) {
 	return metrics.Dial()
 }
 

--- a/internal/pkg/daemon/metrics/grpc.go
+++ b/internal/pkg/daemon/metrics/grpc.go
@@ -17,7 +17,6 @@ limitations under the License.
 package metrics
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -69,21 +68,16 @@ func (m *Metrics) ServeGRPC() error {
 
 // Dial can be used to connect to the default GRPC server by creating a new
 // client.
-func Dial() (*grpc.ClientConn, context.CancelFunc, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
-
-	conn, err := grpc.DialContext( //nolint:staticcheck // TODO: migrate to grpc.NewClient
-		ctx,
+func Dial() (*grpc.ClientConn, error) {
+	conn, err := grpc.NewClient(
 		"unix://"+config.GRPCServerSocketMetrics,
 		grpc.WithTransportCredentials(insecure.NewCredentials()),
 	)
 	if err != nil {
-		cancel()
-
-		return nil, nil, fmt.Errorf("GRPC dial: %w", err)
+		return nil, fmt.Errorf("GRPC dial: %w", err)
 	}
 
-	return conn, cancel, nil
+	return conn, nil
 }
 
 // AuditInc updates the metrics for the audit counter.

--- a/internal/pkg/daemon/profilerecorder/impl.go
+++ b/internal/pkg/daemon/profilerecorder/impl.go
@@ -55,7 +55,7 @@ type impl interface {
 	ManagerGetEventRecorderFor(manager.Manager, string) record.EventRecorder
 	GetPod(context.Context, client.Client, client.ObjectKey) (*corev1.Pod, error)
 	GetSPOD(context.Context, client.Client) (*spodapi.SecurityProfilesOperatorDaemon, error)
-	DialBpfRecorder() (*grpc.ClientConn, context.CancelFunc, error)
+	DialBpfRecorder() (*grpc.ClientConn, error)
 	StartBpfRecorder(context.Context, bpfrecorderapi.BpfRecorderClient) error
 	StopBpfRecorder(context.Context, bpfrecorderapi.BpfRecorderClient) error
 	SyscallsForProfile(
@@ -79,7 +79,7 @@ type impl interface {
 	ResetAvcs(
 		context.Context, enricherapi.EnricherClient, *enricherapi.AvcRequest,
 	) error
-	DialEnricher() (*grpc.ClientConn, context.CancelFunc, error)
+	DialEnricher() (*grpc.ClientConn, error)
 	GetRecording(context.Context, client.Client, client.ObjectKey) (*profilerecording1alpha1.ProfileRecording, error)
 	ApparmorForProfile(
 		context.Context,
@@ -142,7 +142,7 @@ func (*defaultImpl) GetSPOD(
 	return common.GetSPOD(ctx, c)
 }
 
-func (*defaultImpl) DialBpfRecorder() (*grpc.ClientConn, context.CancelFunc, error) {
+func (*defaultImpl) DialBpfRecorder() (*grpc.ClientConn, error) {
 	return bpfrecorder.Dial()
 }
 
@@ -219,7 +219,7 @@ func (*defaultImpl) ResetAvcs(
 	return err
 }
 
-func (*defaultImpl) DialEnricher() (*grpc.ClientConn, context.CancelFunc, error) {
+func (*defaultImpl) DialEnricher() (*grpc.ClientConn, error) {
 	return enricher.Dial()
 }
 

--- a/internal/pkg/daemon/profilerecorder/profilerecorder.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder.go
@@ -322,12 +322,12 @@ func (r *RecorderReconciler) Reconcile(ctx context.Context, req reconcile.Reques
 
 func (r *RecorderReconciler) getBpfRecorderClient(
 	ctx context.Context,
-) (bpfrecorderapi.BpfRecorderClient, context.CancelFunc, error) {
+) (bpfrecorderapi.BpfRecorderClient, error) {
 	r.log.Info("Checking if bpf recorder is enabled")
 
 	spod, err := r.getSPOD(ctx)
 	if err != nil {
-		return nil, nil, fmt.Errorf("getting SPOD config: %w", err)
+		return nil, fmt.Errorf("getting SPOD config: %w", err)
 	}
 
 	enableBpfRecorderEnv, err := strconv.ParseBool(os.Getenv(config.EnableBpfRecorderEnvKey))
@@ -336,29 +336,28 @@ func (r *RecorderReconciler) getBpfRecorderClient(
 	}
 
 	if !spod.Spec.EnableBpfRecorder && !enableBpfRecorderEnv {
-		return nil, nil, errors.New("bpf recorder is not enabled")
+		return nil, errors.New("bpf recorder is not enabled")
 	}
 
 	r.log.Info("Connecting to local GRPC bpf recorder server")
 
-	conn, cancel, err := r.DialBpfRecorder()
+	conn, err := r.DialBpfRecorder()
 	if err != nil {
-		return nil, nil, fmt.Errorf("connect to bpf recorder GRPC server: %w", err)
+		return nil, fmt.Errorf("connect to bpf recorder GRPC server: %w", err)
 	}
 
 	bpfRecorderClient := bpfrecorderapi.NewBpfRecorderClient(conn)
 
-	return bpfRecorderClient, cancel, nil
+	return bpfRecorderClient, nil
 }
 
 func (r *RecorderReconciler) startBpfRecorder(ctx context.Context) error {
-	recorderClient, cancel, err := r.getBpfRecorderClient(ctx)
+	recorderClient, err := r.getBpfRecorderClient(ctx)
 	if err != nil {
 		return fmt.Errorf("get bpf recorder client: %w", err)
 	}
-	defer cancel()
 
-	ctx, cancel = context.WithTimeout(ctx, reconcileTimeout)
+	ctx, cancel := context.WithTimeout(ctx, reconcileTimeout)
 	defer cancel()
 
 	r.log.Info("Starting BPF recorder on node")
@@ -367,14 +366,13 @@ func (r *RecorderReconciler) startBpfRecorder(ctx context.Context) error {
 }
 
 func (r *RecorderReconciler) stopBpfRecorder(ctx context.Context) error {
-	recorderClient, cancel1, err := r.getBpfRecorderClient(ctx)
+	recorderClient, err := r.getBpfRecorderClient(ctx)
 	if err != nil {
 		return fmt.Errorf("get bpf recorder client: %w", err)
 	}
-	defer cancel1()
 
-	ctx, cancel2 := context.WithTimeout(ctx, reconcileTimeout)
-	defer cancel2()
+	ctx, cancel := context.WithTimeout(ctx, reconcileTimeout)
+	defer cancel()
 
 	r.log.Info("Stopping BPF recorder on node")
 
@@ -447,12 +445,10 @@ func (r *RecorderReconciler) collectLogProfiles(
 
 	r.log.Info("Connecting to local GRPC enricher server")
 
-	conn, cancel, err := r.DialEnricher()
+	conn, err := r.DialEnricher()
 	if err != nil {
 		return fmt.Errorf("connecting to local GRPC server: %w", err)
 	}
-
-	defer cancel()
 
 	enricherClient := enricherapi.NewEnricherClient(conn)
 
@@ -718,11 +714,10 @@ func (r *RecorderReconciler) collectBpfProfiles(
 	podName types.NamespacedName,
 	profiles []profileToCollect,
 ) error {
-	recorderClient, cancel, err := r.getBpfRecorderClient(ctx)
+	recorderClient, err := r.getBpfRecorderClient(ctx)
 	if err != nil {
 		return fmt.Errorf("get bpf recorder client: %w", err)
 	}
-	defer cancel()
 
 	for _, profileToCollect := range profiles {
 		ptc := profileToCollect

--- a/internal/pkg/daemon/profilerecorder/profilerecorder_test.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder_test.go
@@ -181,7 +181,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
 				require.NoError(t, err)
@@ -224,7 +224,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.SyscallsForProfileReturns(
 					&bpfrecorderapi.SyscallsResponse{
 						Syscalls: []string{"prctl", "mkdir"},
@@ -278,7 +278,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.SyscallsForProfileReturns(
 					&bpfrecorderapi.SyscallsResponse{
 						Syscalls: []string{"prctl", "mkdir"},
@@ -317,7 +317,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.SyscallsForProfileReturns(
 					&bpfrecorderapi.SyscallsResponse{
 						Syscalls: []string{"prctl", "mkdir"},
@@ -356,7 +356,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, errTest)
+				mock.DialBpfRecorderReturns(nil, errTest)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
 				assert.Error(t, err)
@@ -387,14 +387,14 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.SyscallsForProfileReturns(
 					&bpfrecorderapi.SyscallsResponse{
 						Syscalls: []string{"prctl", "mkdir"},
 						GoArch:   runtime.GOARCH,
 					}, nil,
 				)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.StopBpfRecorderReturns(errTest)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
@@ -427,7 +427,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.SyscallsForProfileReturns(
 					&bpfrecorderapi.SyscallsResponse{
 						Syscalls: []string{"prctl", "mkdir"},
@@ -465,7 +465,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.SyscallsForProfileReturns(nil, bpfrecorder.ErrNotFound)
 				mock.StopBpfRecorderReturns(nil)
 			},
@@ -499,7 +499,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.SyscallsForProfileReturns(nil, errTest)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
@@ -519,7 +519,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, errTest)
+				mock.DialBpfRecorderReturns(nil, errTest)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
 				assert.Error(t, err)
@@ -538,7 +538,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.StartBpfRecorderReturns(errTest)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
@@ -593,7 +593,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
 				require.NoError(t, err)
@@ -636,7 +636,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.ApparmorForProfileReturns(
 					&bpfrecorderapi.ApparmorResponse{
 						Files: &bpfrecorderapi.ApparmorResponse_Files{
@@ -694,7 +694,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.ApparmorForProfileReturns(
 					&bpfrecorderapi.ApparmorResponse{
 						Files: &bpfrecorderapi.ApparmorResponse_Files{
@@ -738,7 +738,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, errTest)
+				mock.DialBpfRecorderReturns(nil, errTest)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
 				assert.Error(t, err)
@@ -769,7 +769,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.ApparmorForProfileReturns(
 					&bpfrecorderapi.ApparmorResponse{
 						Files: &bpfrecorderapi.ApparmorResponse_Files{
@@ -781,7 +781,7 @@ func TestReconcile(t *testing.T) {
 						Capabilities: []string{"test-cap"},
 					}, nil,
 				)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.StopBpfRecorderReturns(errTest)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
@@ -814,7 +814,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.ApparmorForProfileReturns(
 					&bpfrecorderapi.ApparmorResponse{
 						Files: &bpfrecorderapi.ApparmorResponse_Files{
@@ -857,7 +857,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.ApparmorForProfileReturns(nil, bpfrecorder.ErrNotFound)
 				mock.StopBpfRecorderReturns(nil)
 			},
@@ -891,7 +891,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.ApparmorForProfileReturns(nil, errTest)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
@@ -911,7 +911,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, errTest)
+				mock.DialBpfRecorderReturns(nil, errTest)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
 				assert.Error(t, err)
@@ -930,7 +930,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableBpfRecorder: true},
 				}, nil)
-				mock.DialBpfRecorderReturns(nil, func() {}, nil)
+				mock.DialBpfRecorderReturns(nil, nil)
 				mock.StartBpfRecorderReturns(errTest)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
@@ -1090,7 +1090,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableLogEnricher: true},
 				}, nil)
-				mock.DialEnricherReturns(nil, func() {}, nil)
+				mock.DialEnricherReturns(nil, nil)
 				mock.SyscallsReturns(
 					&enricherapi.SyscallsResponse{GoArch: runtime.GOARCH}, nil,
 				)
@@ -1140,7 +1140,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableLogEnricher: true},
 				}, nil)
-				mock.DialEnricherReturns(nil, func() {}, nil)
+				mock.DialEnricherReturns(nil, nil)
 				mock.SyscallsReturns(
 					&enricherapi.SyscallsResponse{GoArch: runtime.GOARCH}, nil,
 				)
@@ -1176,7 +1176,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableLogEnricher: true},
 				}, nil)
-				mock.DialEnricherReturns(nil, func() {}, nil)
+				mock.DialEnricherReturns(nil, nil)
 				mock.SyscallsReturns(
 					&enricherapi.SyscallsResponse{GoArch: runtime.GOARCH}, nil,
 				)
@@ -1212,7 +1212,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableLogEnricher: true},
 				}, nil)
-				mock.DialEnricherReturns(nil, func() {}, nil)
+				mock.DialEnricherReturns(nil, nil)
 				mock.SyscallsReturns(
 					&enricherapi.SyscallsResponse{GoArch: runtime.GOARCH}, nil,
 				)
@@ -1248,7 +1248,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableLogEnricher: true},
 				}, nil)
-				mock.DialEnricherReturns(nil, func() {}, nil)
+				mock.DialEnricherReturns(nil, nil)
 				mock.SyscallsReturns(nil, errTest)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
@@ -1269,7 +1269,7 @@ func TestReconcile(t *testing.T) {
 				}
 				sut.podsToWatch.Store(testRequest.String(), value)
 
-				mock.DialEnricherReturns(nil, func() {}, nil)
+				mock.DialEnricherReturns(nil, nil)
 				mock.GetPodReturns(&corev1.Pod{
 					Status: corev1.PodStatus{Phase: corev1.PodSucceeded},
 					ObjectMeta: metav1.ObjectMeta{
@@ -1281,7 +1281,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableLogEnricher: true},
 				}, nil)
-				mock.DialEnricherReturns(nil, func() {}, nil)
+				mock.DialEnricherReturns(nil, nil)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
 				assert.Error(t, err)
@@ -1313,7 +1313,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableLogEnricher: true},
 				}, nil)
-				mock.DialEnricherReturns(nil, func() {}, nil)
+				mock.DialEnricherReturns(nil, nil)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
 				assert.Error(t, err)
@@ -1345,7 +1345,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableLogEnricher: true},
 				}, nil)
-				mock.DialEnricherReturns(nil, func() {}, errTest)
+				mock.DialEnricherReturns(nil, errTest)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
 				assert.Error(t, err)
@@ -1434,7 +1434,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableLogEnricher: true},
 				}, nil)
-				mock.DialEnricherReturns(nil, func() {}, nil)
+				mock.DialEnricherReturns(nil, nil)
 				mock.AvcsReturns(&enricherapi.AvcResponse{
 					Avc: []*enricherapi.AvcResponse_SelinuxAvc{
 						{
@@ -1489,7 +1489,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableLogEnricher: true},
 				}, nil)
-				mock.DialEnricherReturns(nil, func() {}, nil)
+				mock.DialEnricherReturns(nil, nil)
 				mock.ResetAvcsReturns(errTest)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
@@ -1521,7 +1521,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableLogEnricher: true},
 				}, nil)
-				mock.DialEnricherReturns(nil, func() {}, nil)
+				mock.DialEnricherReturns(nil, nil)
 				mock.CreateOrUpdateReturns("", errTest)
 			},
 			assert: func(sut *RecorderReconciler, err error) {
@@ -1553,7 +1553,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableLogEnricher: true},
 				}, nil)
-				mock.DialEnricherReturns(nil, func() {}, nil)
+				mock.DialEnricherReturns(nil, nil)
 				mock.AvcsReturns(&enricherapi.AvcResponse{
 					Avc: []*enricherapi.AvcResponse_SelinuxAvc{
 						{Tcontext: "wrong"},
@@ -1590,7 +1590,7 @@ func TestReconcile(t *testing.T) {
 				mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
 					Spec: spodapi.SPODSpec{EnableLogEnricher: true},
 				}, nil)
-				mock.DialEnricherReturns(nil, func() {}, nil)
+				mock.DialEnricherReturns(nil, nil)
 				mock.AvcsReturns(nil, errTest)
 			},
 			assert: func(sut *RecorderReconciler, err error) {

--- a/internal/pkg/daemon/profilerecorder/profilerecorderfakes/fake_impl.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorderfakes/fake_impl.go
@@ -98,33 +98,29 @@ type FakeImpl struct {
 		result1 controllerutil.OperationResult
 		result2 error
 	}
-	DialBpfRecorderStub        func() (*grpc.ClientConn, context.CancelFunc, error)
+	DialBpfRecorderStub        func() (*grpc.ClientConn, error)
 	dialBpfRecorderMutex       sync.RWMutex
 	dialBpfRecorderArgsForCall []struct {
 	}
 	dialBpfRecorderReturns struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
+		result2 error
 	}
 	dialBpfRecorderReturnsOnCall map[int]struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
+		result2 error
 	}
-	DialEnricherStub        func() (*grpc.ClientConn, context.CancelFunc, error)
+	DialEnricherStub        func() (*grpc.ClientConn, error)
 	dialEnricherMutex       sync.RWMutex
 	dialEnricherArgsForCall []struct {
 	}
 	dialEnricherReturns struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
+		result2 error
 	}
 	dialEnricherReturnsOnCall map[int]struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
+		result2 error
 	}
 	GetPodStub        func(context.Context, client.Client, client.ObjectKey) (*v1.Pod, error)
 	getPodMutex       sync.RWMutex
@@ -581,7 +577,7 @@ func (fake *FakeImpl) CreateOrUpdateReturnsOnCall(i int, result1 controllerutil.
 	}{result1, result2}
 }
 
-func (fake *FakeImpl) DialBpfRecorder() (*grpc.ClientConn, context.CancelFunc, error) {
+func (fake *FakeImpl) DialBpfRecorder() (*grpc.ClientConn, error) {
 	fake.dialBpfRecorderMutex.Lock()
 	ret, specificReturn := fake.dialBpfRecorderReturnsOnCall[len(fake.dialBpfRecorderArgsForCall)]
 	fake.dialBpfRecorderArgsForCall = append(fake.dialBpfRecorderArgsForCall, struct {
@@ -594,9 +590,9 @@ func (fake *FakeImpl) DialBpfRecorder() (*grpc.ClientConn, context.CancelFunc, e
 		return stub()
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeImpl) DialBpfRecorderCallCount() int {
@@ -605,42 +601,39 @@ func (fake *FakeImpl) DialBpfRecorderCallCount() int {
 	return len(fake.dialBpfRecorderArgsForCall)
 }
 
-func (fake *FakeImpl) DialBpfRecorderCalls(stub func() (*grpc.ClientConn, context.CancelFunc, error)) {
+func (fake *FakeImpl) DialBpfRecorderCalls(stub func() (*grpc.ClientConn, error)) {
 	fake.dialBpfRecorderMutex.Lock()
 	defer fake.dialBpfRecorderMutex.Unlock()
 	fake.DialBpfRecorderStub = stub
 }
 
-func (fake *FakeImpl) DialBpfRecorderReturns(result1 *grpc.ClientConn, result2 context.CancelFunc, result3 error) {
+func (fake *FakeImpl) DialBpfRecorderReturns(result1 *grpc.ClientConn, result2 error) {
 	fake.dialBpfRecorderMutex.Lock()
 	defer fake.dialBpfRecorderMutex.Unlock()
 	fake.DialBpfRecorderStub = nil
 	fake.dialBpfRecorderReturns = struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeImpl) DialBpfRecorderReturnsOnCall(i int, result1 *grpc.ClientConn, result2 context.CancelFunc, result3 error) {
+func (fake *FakeImpl) DialBpfRecorderReturnsOnCall(i int, result1 *grpc.ClientConn, result2 error) {
 	fake.dialBpfRecorderMutex.Lock()
 	defer fake.dialBpfRecorderMutex.Unlock()
 	fake.DialBpfRecorderStub = nil
 	if fake.dialBpfRecorderReturnsOnCall == nil {
 		fake.dialBpfRecorderReturnsOnCall = make(map[int]struct {
 			result1 *grpc.ClientConn
-			result2 context.CancelFunc
-			result3 error
+			result2 error
 		})
 	}
 	fake.dialBpfRecorderReturnsOnCall[i] = struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeImpl) DialEnricher() (*grpc.ClientConn, context.CancelFunc, error) {
+func (fake *FakeImpl) DialEnricher() (*grpc.ClientConn, error) {
 	fake.dialEnricherMutex.Lock()
 	ret, specificReturn := fake.dialEnricherReturnsOnCall[len(fake.dialEnricherArgsForCall)]
 	fake.dialEnricherArgsForCall = append(fake.dialEnricherArgsForCall, struct {
@@ -653,9 +646,9 @@ func (fake *FakeImpl) DialEnricher() (*grpc.ClientConn, context.CancelFunc, erro
 		return stub()
 	}
 	if specificReturn {
-		return ret.result1, ret.result2, ret.result3
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeImpl) DialEnricherCallCount() int {
@@ -664,39 +657,36 @@ func (fake *FakeImpl) DialEnricherCallCount() int {
 	return len(fake.dialEnricherArgsForCall)
 }
 
-func (fake *FakeImpl) DialEnricherCalls(stub func() (*grpc.ClientConn, context.CancelFunc, error)) {
+func (fake *FakeImpl) DialEnricherCalls(stub func() (*grpc.ClientConn, error)) {
 	fake.dialEnricherMutex.Lock()
 	defer fake.dialEnricherMutex.Unlock()
 	fake.DialEnricherStub = stub
 }
 
-func (fake *FakeImpl) DialEnricherReturns(result1 *grpc.ClientConn, result2 context.CancelFunc, result3 error) {
+func (fake *FakeImpl) DialEnricherReturns(result1 *grpc.ClientConn, result2 error) {
 	fake.dialEnricherMutex.Lock()
 	defer fake.dialEnricherMutex.Unlock()
 	fake.DialEnricherStub = nil
 	fake.dialEnricherReturns = struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeImpl) DialEnricherReturnsOnCall(i int, result1 *grpc.ClientConn, result2 context.CancelFunc, result3 error) {
+func (fake *FakeImpl) DialEnricherReturnsOnCall(i int, result1 *grpc.ClientConn, result2 error) {
 	fake.dialEnricherMutex.Lock()
 	defer fake.dialEnricherMutex.Unlock()
 	fake.DialEnricherStub = nil
 	if fake.dialEnricherReturnsOnCall == nil {
 		fake.dialEnricherReturnsOnCall = make(map[int]struct {
 			result1 *grpc.ClientConn
-			result2 context.CancelFunc
-			result3 error
+			result2 error
 		})
 	}
 	fake.dialEnricherReturnsOnCall[i] = struct {
 		result1 *grpc.ClientConn
-		result2 context.CancelFunc
-		result3 error
-	}{result1, result2, result3}
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeImpl) GetPod(arg1 context.Context, arg2 client.Client, arg3 client.ObjectKey) (*v1.Pod, error) {

--- a/internal/pkg/manager/recordingmerger/apparmor.go
+++ b/internal/pkg/manager/recordingmerger/apparmor.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"regexp"
+	"slices"
 	"sort"
 	"strings"
 
@@ -296,29 +297,7 @@ func mergeDedupSortStrings(a, b *[]string) *[]string {
 
 	merged := append(*a, *b...)
 	sort.Strings(merged)
-	merged = compact(merged)
+	merged = slices.Compact(merged)
 
 	return &merged
-}
-
-// TODO: replace this with slices.Compact once all platform support Go 1.21.
-func compact(s []string) []string {
-	//nolint:all
-	if len(s) < 2 {
-		return s
-	}
-
-	i := 1
-
-	for k := 1; k < len(s); k++ {
-		if s[k] != s[k-1] {
-			if i != k {
-				s[i] = s[k]
-			}
-
-			i++
-		}
-	}
-
-	return s[:i]
 }


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup

#### What this PR does / why we need it:
- Fix `RawSelinuxProfileList.Items` type from `[]SelinuxProfile` to `[]RawSelinuxProfile`
- Replace hand-rolled `compact()` with `slices.Compact` (Go 1.21+ is long available)
- Migrate deprecated `grpc.DialContext` to `grpc.NewClient`

#### Which issue(s) this PR fixes:
None

#### Does this PR have test?
Existing unit tests pass. The gRPC and deepcopy changes are covered by regenerated fakes and deepcopy code.

#### Special notes for your reviewer:
The `GetEventRecorderFor` to `GetEventRecorder` migration was considered but excluded because the new `events.EventRecorder` has a fundamentally different method signature, affecting 60+ call sites. That should be a separate effort.

#### Does this PR introduce a user-facing change?
```release-note
NONE
```