### PR TITLE
api: replace *[]string with []string in AppArmorProfile

### DIFF
--- a/api/apparmorprofile/v1alpha1/apparmorprofile_types.go
+++ b/api/apparmorprofile/v1alpha1/apparmorprofile_types.go
@@ -34,19 +34,19 @@ var (
 // AppArmorExecutablesRules stores the rules for allowed executable.
 type AppArmorExecutablesRules struct {
 	// AllowedExecutables list of allowed executables.
-	AllowedExecutables *[]string `json:"allowedExecutables,omitempty"`
+	AllowedExecutables []string `json:"allowedExecutables,omitempty"`
 	// AllowedLibraries list of allowed libraries.
-	AllowedLibraries *[]string `json:"allowedLibraries,omitempty"`
+	AllowedLibraries []string `json:"allowedLibraries,omitempty"`
 }
 
 // AppArmorFsRules stores the rules for file system access.
 type AppArmorFsRules struct {
 	// ReadOnlyPaths list of allowed read only file paths.
-	ReadOnlyPaths *[]string `json:"readOnlyPaths,omitempty"`
+	ReadOnlyPaths []string `json:"readOnlyPaths,omitempty"`
 	// WriteOnlyPaths list of allowed write only file paths.
-	WriteOnlyPaths *[]string `json:"writeOnlyPaths,omitempty"`
+	WriteOnlyPaths []string `json:"writeOnlyPaths,omitempty"`
 	// ReadWritePaths list of allowed read write file paths.
-	ReadWritePaths *[]string `json:"readWritePaths,omitempty"`
+	ReadWritePaths []string `json:"readWritePaths,omitempty"`
 }
 
 // AppArmorAllowedProtocols stores the rules for allowed networking protocols.
@@ -67,7 +67,7 @@ type AppArmorNetworkRules struct {
 
 // AllowedCapabilities stores the rules of allowed Linux capabilities.
 type AppArmorCapabilityRules struct {
-	// AllowedCapabilities lost of allowed capabilities.
+	// AllowedCapabilities list of allowed capabilities.
 	AllowedCapabilities []string `json:"allowedCapabilities,omitempty"`
 }
 

--- a/api/apparmorprofile/v1alpha1/zz_generated.deepcopy.go
+++ b/api/apparmorprofile/v1alpha1/zz_generated.deepcopy.go
@@ -109,21 +109,13 @@ func (in *AppArmorExecutablesRules) DeepCopyInto(out *AppArmorExecutablesRules) 
 	*out = *in
 	if in.AllowedExecutables != nil {
 		in, out := &in.AllowedExecutables, &out.AllowedExecutables
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.AllowedLibraries != nil {
 		in, out := &in.AllowedLibraries, &out.AllowedLibraries
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 }
 
@@ -142,30 +134,18 @@ func (in *AppArmorFsRules) DeepCopyInto(out *AppArmorFsRules) {
 	*out = *in
 	if in.ReadOnlyPaths != nil {
 		in, out := &in.ReadOnlyPaths, &out.ReadOnlyPaths
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.WriteOnlyPaths != nil {
 		in, out := &in.WriteOnlyPaths, &out.WriteOnlyPaths
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 	if in.ReadWritePaths != nil {
 		in, out := &in.ReadWritePaths, &out.ReadWritePaths
-		*out = new([]string)
-		if **in != nil {
-			in, out := *in, *out
-			*out = make([]string, len(*in))
-			copy(*out, *in)
-		}
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/deploy/base-crds/crds/apparmorprofile.yaml
+++ b/deploy/base-crds/crds/apparmorprofile.yaml
@@ -53,7 +53,7 @@ spec:
                     description: Capability rules for Linux capabilities.
                     properties:
                       allowedCapabilities:
-                        description: AllowedCapabilities lost of allowed capabilities.
+                        description: AllowedCapabilities list of allowed capabilities.
                         items:
                           type: string
                         type: array

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -2317,7 +2317,7 @@ spec:
                     description: Capability rules for Linux capabilities.
                     properties:
                       allowedCapabilities:
-                        description: AllowedCapabilities lost of allowed capabilities.
+                        description: AllowedCapabilities list of allowed capabilities.
                         items:
                           type: string
                         type: array

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2317,7 +2317,7 @@ spec:
                     description: Capability rules for Linux capabilities.
                     properties:
                       allowedCapabilities:
-                        description: AllowedCapabilities lost of allowed capabilities.
+                        description: AllowedCapabilities list of allowed capabilities.
                         items:
                           type: string
                         type: array

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -66,7 +66,7 @@ spec:
                     description: Capability rules for Linux capabilities.
                     properties:
                       allowedCapabilities:
-                        description: AllowedCapabilities lost of allowed capabilities.
+                        description: AllowedCapabilities list of allowed capabilities.
                         items:
                           type: string
                         type: array

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -2322,7 +2322,7 @@ spec:
                     description: Capability rules for Linux capabilities.
                     properties:
                       allowedCapabilities:
-                        description: AllowedCapabilities lost of allowed capabilities.
+                        description: AllowedCapabilities list of allowed capabilities.
                         items:
                           type: string
                         type: array

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2317,7 +2317,7 @@ spec:
                     description: Capability rules for Linux capabilities.
                     properties:
                       allowedCapabilities:
-                        description: AllowedCapabilities lost of allowed capabilities.
+                        description: AllowedCapabilities list of allowed capabilities.
                         items:
                           type: string
                         type: array

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -66,7 +66,7 @@ spec:
                     description: Capability rules for Linux capabilities.
                     properties:
                       allowedCapabilities:
-                        description: AllowedCapabilities lost of allowed capabilities.
+                        description: AllowedCapabilities list of allowed capabilities.
                         items:
                           type: string
                         type: array

--- a/internal/pkg/cli/recorder/recorder.go
+++ b/internal/pkg/cli/recorder/recorder.go
@@ -249,14 +249,14 @@ func (r *Recorder) generateAppArmorProfile(mntns uint32) apparmorprofileapi.AppA
 			sort.Strings(processed.FileProcessed.AllowedExecutables)
 			ExecutableAllowedExecCopy := make([]string, len(processed.FileProcessed.AllowedExecutables))
 			copy(ExecutableAllowedExecCopy, processed.FileProcessed.AllowedExecutables)
-			abstract.Executable.AllowedExecutables = &ExecutableAllowedExecCopy
+			abstract.Executable.AllowedExecutables = ExecutableAllowedExecCopy
 		}
 
 		if len(processed.FileProcessed.AllowedLibraries) != 0 {
 			sort.Strings(processed.FileProcessed.AllowedLibraries)
 			ExecutableAllowedLibCopy := make([]string, len(processed.FileProcessed.AllowedLibraries))
 			copy(ExecutableAllowedLibCopy, processed.FileProcessed.AllowedLibraries)
-			abstract.Executable.AllowedLibraries = &ExecutableAllowedLibCopy
+			abstract.Executable.AllowedLibraries = ExecutableAllowedLibCopy
 		}
 	}
 
@@ -269,21 +269,21 @@ func (r *Recorder) generateAppArmorProfile(mntns uint32) apparmorprofileapi.AppA
 			sort.Strings(processed.FileProcessed.ReadOnlyPaths)
 			FileReadOnlyCopy := make([]string, len(processed.FileProcessed.ReadOnlyPaths))
 			copy(FileReadOnlyCopy, processed.FileProcessed.ReadOnlyPaths)
-			files.ReadOnlyPaths = &FileReadOnlyCopy
+			files.ReadOnlyPaths = FileReadOnlyCopy
 		}
 
 		if len(processed.FileProcessed.WriteOnlyPaths) != 0 {
 			sort.Strings(processed.FileProcessed.WriteOnlyPaths)
 			FileWriteOnlyCopy := make([]string, len(processed.FileProcessed.WriteOnlyPaths))
 			copy(FileWriteOnlyCopy, processed.FileProcessed.WriteOnlyPaths)
-			files.WriteOnlyPaths = &FileWriteOnlyCopy
+			files.WriteOnlyPaths = FileWriteOnlyCopy
 		}
 
 		if len(processed.FileProcessed.ReadWritePaths) != 0 {
 			sort.Strings(processed.FileProcessed.ReadWritePaths)
 			FileReadWriteCopy := make([]string, len(processed.FileProcessed.ReadWritePaths))
 			copy(FileReadWriteCopy, processed.FileProcessed.ReadWritePaths)
-			files.ReadWritePaths = &FileReadWriteCopy
+			files.ReadWritePaths = FileReadWriteCopy
 		}
 
 		abstract.Filesystem = &files

--- a/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor_test.go
+++ b/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor_test.go
@@ -39,7 +39,7 @@ func TestGenerateProfile(t *testing.T) {
 			complainMode: false,
 			abstract: &apparmorprofileapi.AppArmorAbstract{
 				Filesystem: &apparmorprofileapi.AppArmorFsRules{
-					ReadOnlyPaths: &[]string{"/etc/passwd"},
+					ReadOnlyPaths: []string{"/etc/passwd"},
 				},
 			},
 			mustContain: []string{
@@ -54,7 +54,7 @@ func TestGenerateProfile(t *testing.T) {
 			complainMode: true,
 			abstract: &apparmorprofileapi.AppArmorAbstract{
 				Filesystem: &apparmorprofileapi.AppArmorFsRules{
-					ReadOnlyPaths: &[]string{"/etc/passwd"},
+					ReadOnlyPaths: []string{"/etc/passwd"},
 				},
 			},
 			mustContain: []string{

--- a/internal/pkg/daemon/profilerecorder/profilerecorder.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder.go
@@ -942,14 +942,14 @@ func (r *RecorderReconciler) generateAppArmorProfileAbstract(
 			sort.Strings(response.GetFiles().GetAllowedExecutables())
 			ExecutableAllowedExecCopy := make([]string, len(response.GetFiles().GetAllowedExecutables()))
 			copy(ExecutableAllowedExecCopy, response.GetFiles().GetAllowedExecutables())
-			abstract.Executable.AllowedExecutables = &ExecutableAllowedExecCopy
+			abstract.Executable.AllowedExecutables = ExecutableAllowedExecCopy
 		}
 
 		if len(response.GetFiles().GetAllowedLibraries()) != 0 {
 			sort.Strings(response.GetFiles().GetAllowedLibraries())
 			ExecutableAllowedLibCopy := make([]string, len(response.GetFiles().GetAllowedLibraries()))
 			copy(ExecutableAllowedLibCopy, response.GetFiles().GetAllowedLibraries())
-			abstract.Executable.AllowedLibraries = &ExecutableAllowedLibCopy
+			abstract.Executable.AllowedLibraries = ExecutableAllowedLibCopy
 		}
 	}
 
@@ -962,21 +962,21 @@ func (r *RecorderReconciler) generateAppArmorProfileAbstract(
 			sort.Strings(response.GetFiles().GetReadonlyPaths())
 			FileReadOnlyCopy := make([]string, len(response.GetFiles().GetReadonlyPaths()))
 			copy(FileReadOnlyCopy, response.GetFiles().GetReadonlyPaths())
-			files.ReadOnlyPaths = &FileReadOnlyCopy
+			files.ReadOnlyPaths = FileReadOnlyCopy
 		}
 
 		if len(response.GetFiles().GetWriteonlyPaths()) != 0 {
 			sort.Strings(response.GetFiles().GetWriteonlyPaths())
 			FileWriteOnlyCopy := make([]string, len(response.GetFiles().GetWriteonlyPaths()))
 			copy(FileWriteOnlyCopy, response.GetFiles().GetWriteonlyPaths())
-			files.WriteOnlyPaths = &FileWriteOnlyCopy
+			files.WriteOnlyPaths = FileWriteOnlyCopy
 		}
 
 		if len(response.GetFiles().GetReadwritePaths()) != 0 {
 			sort.Strings(response.GetFiles().GetReadwritePaths())
 			FileReadWriteCopy := make([]string, len(response.GetFiles().GetReadwritePaths()))
 			copy(FileReadWriteCopy, response.GetFiles().GetReadwritePaths())
-			files.ReadWritePaths = &FileReadWriteCopy
+			files.ReadWritePaths = FileReadWriteCopy
 		}
 
 		abstract.Filesystem = &files

--- a/internal/pkg/manager/recordingmerger/apparmor.go
+++ b/internal/pkg/manager/recordingmerger/apparmor.go
@@ -88,17 +88,17 @@ func (sp *mergeableAppArmorProfile) merge(other mergeableProfile) error {
 	return nil
 }
 
-func mergePaths(a, b *[]string) *[]string {
-	if a == nil {
+func mergePaths(a, b []string) []string {
+	if len(a) == 0 {
 		return b
 	}
 
-	if b == nil {
+	if len(b) == 0 {
 		return a
 	}
 
 	merged := newAppArmorPathSet(a)
-	for _, path := range *b {
+	for _, path := range b {
 		if !merged.Matches(path) {
 			merged.Add(path)
 		}
@@ -108,51 +108,44 @@ func mergePaths(a, b *[]string) *[]string {
 }
 
 func mergeFilesystem(base, additions *apparmorprofileapi.AppArmorAbstract) {
-	//nolint:nestif  // refactoring this makes it worse
 	if base.Filesystem != nil && additions.Filesystem != nil {
 		r := newAppArmorPathSet(base.Filesystem.ReadOnlyPaths)
 		w := newAppArmorPathSet(base.Filesystem.WriteOnlyPaths)
 		rw := newAppArmorPathSet(base.Filesystem.ReadWritePaths)
 
-		if additions.Filesystem.ReadWritePaths != nil {
-			for _, p := range *additions.Filesystem.ReadWritePaths {
-				if rw.Matches(p) {
-					// no changes necessary
-				} else if pat := r.PopMatching(p); pat != nil {
-					rw.Add(*pat)
-				} else if pat := w.PopMatching(p); pat != nil {
-					rw.Add(*pat)
-				} else {
-					rw.Add(p)
-				}
+		for _, p := range additions.Filesystem.ReadWritePaths {
+			if rw.Matches(p) {
+				// no changes necessary
+			} else if pat := r.PopMatching(p); pat != nil {
+				rw.Add(*pat)
+			} else if pat := w.PopMatching(p); pat != nil {
+				rw.Add(*pat)
+			} else {
+				rw.Add(p)
 			}
 		}
 
-		if additions.Filesystem.ReadOnlyPaths != nil {
-			for _, p := range *additions.Filesystem.ReadOnlyPaths {
-				if rw.Matches(p) {
-					// no changes necessary
-				} else if r.Matches(p) {
-					// no changes necessary
-				} else if pat := w.PopMatching(p); pat != nil {
-					rw.Add(*pat)
-				} else {
-					r.Add(p)
-				}
+		for _, p := range additions.Filesystem.ReadOnlyPaths {
+			if rw.Matches(p) {
+				// no changes necessary
+			} else if r.Matches(p) {
+				// no changes necessary
+			} else if pat := w.PopMatching(p); pat != nil {
+				rw.Add(*pat)
+			} else {
+				r.Add(p)
 			}
 		}
 
-		if additions.Filesystem.WriteOnlyPaths != nil {
-			for _, p := range *additions.Filesystem.WriteOnlyPaths {
-				if rw.Matches(p) {
-					// no changes necessary
-				} else if pat := r.PopMatching(p); pat != nil {
-					rw.Add(*pat)
-				} else if w.Matches(p) {
-					// no changes necessary
-				} else {
-					w.Add(p)
-				}
+		for _, p := range additions.Filesystem.WriteOnlyPaths {
+			if rw.Matches(p) {
+				// no changes necessary
+			} else if pat := r.PopMatching(p); pat != nil {
+				rw.Add(*pat)
+			} else if w.Matches(p) {
+				// no changes necessary
+			} else {
+				w.Add(p)
 			}
 		}
 
@@ -166,13 +159,11 @@ func mergeFilesystem(base, additions *apparmorprofileapi.AppArmorAbstract) {
 	}
 }
 
-func newAppArmorPathSet(patterns *[]string) appArmorPathSet {
+func newAppArmorPathSet(patterns []string) appArmorPathSet {
 	m := appArmorPathSet{}
 
-	if patterns != nil {
-		for _, p := range *patterns {
-			m.Add(p)
-		}
+	for _, p := range patterns {
+		m.Add(p)
 	}
 
 	return m
@@ -230,7 +221,7 @@ func (m *appArmorPathSet) Add(pattern string) {
 	})
 }
 
-func (m *appArmorPathSet) Patterns() *[]string {
+func (m *appArmorPathSet) Patterns() []string {
 	if len(m.paths) == 0 {
 		return nil
 	}
@@ -242,7 +233,7 @@ func (m *appArmorPathSet) Patterns() *[]string {
 
 	sort.Strings(ret)
 
-	return &ret
+	return ret
 }
 
 // Convert AppArmor globs (https://gitlab.com/apparmor/apparmor/-/wikis/QuickProfileLanguage#file-globbing)

--- a/internal/pkg/manager/recordingmerger/apparmor_test.go
+++ b/internal/pkg/manager/recordingmerger/apparmor_test.go
@@ -73,7 +73,7 @@ func TestAppArmorGlobToRegex(t *testing.T) {
 func Test_appArmorPathSet(t *testing.T) {
 	t.Parallel()
 
-	m := newAppArmorPathSet(&[]string{
+	m := newAppArmorPathSet([]string{
 		"/foo/*",
 		"/bar",
 	})
@@ -92,7 +92,7 @@ func Test_appArmorPathSet(t *testing.T) {
 	m.Add("/baz**")
 	require.True(t, m.Matches("/baz/qux"))
 
-	require.Equal(t, []string{"/bar", "/baz**"}, *m.Patterns())
+	require.Equal(t, []string{"/bar", "/baz**"}, m.Patterns())
 }
 
 func TestMergeFilesystem(t *testing.T) {
@@ -100,9 +100,9 @@ func TestMergeFilesystem(t *testing.T) {
 
 	base := &apparmorprofileapi.AppArmorAbstract{
 		Filesystem: &apparmorprofileapi.AppArmorFsRules{
-			ReadOnlyPaths:  &[]string{"/r/*"},
-			WriteOnlyPaths: &[]string{"/w/*"},
-			ReadWritePaths: &[]string{"/rw/*"},
+			ReadOnlyPaths:  []string{"/r/*"},
+			WriteOnlyPaths: []string{"/w/*"},
+			ReadWritePaths: []string{"/rw/*"},
 		},
 	}
 
@@ -119,50 +119,50 @@ func TestMergeFilesystem(t *testing.T) {
 		{
 			name: "matching",
 			additions: apparmorprofileapi.AppArmorFsRules{
-				ReadOnlyPaths:  &[]string{"/r/foo"},
-				WriteOnlyPaths: &[]string{"/w/bar"},
-				ReadWritePaths: &[]string{"/rw/baz"},
+				ReadOnlyPaths:  []string{"/r/foo"},
+				WriteOnlyPaths: []string{"/w/bar"},
+				ReadWritePaths: []string{"/rw/baz"},
 			},
 			merged: *base.Filesystem,
 		},
 		{
 			name: "subset",
 			additions: apparmorprofileapi.AppArmorFsRules{
-				ReadOnlyPaths:  &[]string{"/rw/foo"},
-				WriteOnlyPaths: &[]string{"/rw/bar"},
+				ReadOnlyPaths:  []string{"/rw/foo"},
+				WriteOnlyPaths: []string{"/rw/bar"},
 			},
 			merged: *base.Filesystem,
 		},
 		{
 			name: "additive",
 			additions: apparmorprofileapi.AppArmorFsRules{
-				ReadOnlyPaths:  &[]string{"/w/foo"},
-				WriteOnlyPaths: &[]string{"/r/bar"},
+				ReadOnlyPaths:  []string{"/w/foo"},
+				WriteOnlyPaths: []string{"/r/bar"},
 			},
 			merged: apparmorprofileapi.AppArmorFsRules{
-				ReadWritePaths: &[]string{"/r/*", "/rw/*", "/w/*"},
+				ReadWritePaths: []string{"/r/*", "/rw/*", "/w/*"},
 			},
 		},
 		{
 			name: "additive2",
 			additions: apparmorprofileapi.AppArmorFsRules{
-				ReadWritePaths: &[]string{"/r/foo", "/w/foo"},
+				ReadWritePaths: []string{"/r/foo", "/w/foo"},
 			},
 			merged: apparmorprofileapi.AppArmorFsRules{
-				ReadWritePaths: &[]string{"/r/*", "/rw/*", "/w/*"},
+				ReadWritePaths: []string{"/r/*", "/rw/*", "/w/*"},
 			},
 		},
 		{
 			name: "new",
 			additions: apparmorprofileapi.AppArmorFsRules{
-				ReadOnlyPaths:  &[]string{"/r2/foo"},
-				WriteOnlyPaths: &[]string{"/w2/bar"},
-				ReadWritePaths: &[]string{"/rw2/baz"},
+				ReadOnlyPaths:  []string{"/r2/foo"},
+				WriteOnlyPaths: []string{"/w2/bar"},
+				ReadWritePaths: []string{"/rw2/baz"},
 			},
 			merged: apparmorprofileapi.AppArmorFsRules{
-				ReadOnlyPaths:  &[]string{"/r/*", "/r2/foo"},
-				WriteOnlyPaths: &[]string{"/w/*", "/w2/bar"},
-				ReadWritePaths: &[]string{"/rw/*", "/rw2/baz"},
+				ReadOnlyPaths:  []string{"/r/*", "/r2/foo"},
+				WriteOnlyPaths: []string{"/w/*", "/w2/bar"},
+				ReadWritePaths: []string{"/rw/*", "/rw2/baz"},
 			},
 		},
 	}

--- a/internal/pkg/manager/recordingmerger/merge_utils_test.go
+++ b/internal/pkg/manager/recordingmerger/merge_utils_test.go
@@ -187,13 +187,13 @@ func TestMergeProfiles(t *testing.T) {
 						Spec: apparmorprofileapi.AppArmorProfileSpec{
 							Abstract: apparmorprofileapi.AppArmorAbstract{
 								Executable: &apparmorprofileapi.AppArmorExecutablesRules{
-									AllowedExecutables: &[]string{"execA", "execB"},
-									AllowedLibraries:   &[]string{"libA"},
+									AllowedExecutables: []string{"execA", "execB"},
+									AllowedLibraries:   []string{"libA"},
 								},
 								Filesystem: &apparmorprofileapi.AppArmorFsRules{
-									ReadOnlyPaths:  &[]string{"read1", "merged-rw1"},
-									WriteOnlyPaths: &[]string{"write1", "merged-rw2"},
-									ReadWritePaths: &[]string{"readwrite1"},
+									ReadOnlyPaths:  []string{"read1", "merged-rw1"},
+									WriteOnlyPaths: []string{"write1", "merged-rw2"},
+									ReadWritePaths: []string{"readwrite1"},
 								},
 								Network: &apparmorprofileapi.AppArmorNetworkRules{
 									AllowRaw: func() *bool {
@@ -215,11 +215,11 @@ func TestMergeProfiles(t *testing.T) {
 						Spec: apparmorprofileapi.AppArmorProfileSpec{
 							Abstract: apparmorprofileapi.AppArmorAbstract{
 								Executable: &apparmorprofileapi.AppArmorExecutablesRules{
-									AllowedExecutables: &[]string{"execA", "execC"},
+									AllowedExecutables: []string{"execA", "execC"},
 								},
 								Filesystem: &apparmorprofileapi.AppArmorFsRules{
-									WriteOnlyPaths: &[]string{"merged-rw1"},
-									ReadWritePaths: &[]string{"merged-rw2"},
+									WriteOnlyPaths: []string{"merged-rw1"},
+									ReadWritePaths: []string{"merged-rw2"},
 								},
 								Network: &apparmorprofileapi.AppArmorNetworkRules{
 									AllowRaw: func() *bool {
@@ -251,13 +251,13 @@ func TestMergeProfiles(t *testing.T) {
 
 				require.Equal(t, apparmorprofileapi.AppArmorAbstract{
 					Executable: &apparmorprofileapi.AppArmorExecutablesRules{
-						AllowedExecutables: &[]string{"execA", "execB", "execC"},
-						AllowedLibraries:   &[]string{"libA"},
+						AllowedExecutables: []string{"execA", "execB", "execC"},
+						AllowedLibraries:   []string{"libA"},
 					},
 					Filesystem: &apparmorprofileapi.AppArmorFsRules{
-						ReadOnlyPaths:  &[]string{"read1"},
-						WriteOnlyPaths: &[]string{"write1"},
-						ReadWritePaths: &[]string{"merged-rw1", "merged-rw2", "readwrite1"},
+						ReadOnlyPaths:  []string{"read1"},
+						WriteOnlyPaths: []string{"write1"},
+						ReadWritePaths: []string{"merged-rw1", "merged-rw2", "readwrite1"},
 					},
 					Network: &apparmorprofileapi.AppArmorNetworkRules{
 						AllowRaw: func() *bool {

--- a/test/spoc/e2e_spoc_test.go
+++ b/test/spoc/e2e_spoc_test.go
@@ -78,12 +78,12 @@ func recordAppArmorTest(t *testing.T) {
 			readme, err := filepath.Abs("../../README.md")
 			require.NoError(t, err)
 			require.NotNil(t, profile.Filesystem)
-			require.NotNil(t, profile.Filesystem.ReadOnlyPaths)
-			require.Contains(t, *profile.Filesystem.ReadOnlyPaths, readme)
+			require.NotEmpty(t, profile.Filesystem.ReadOnlyPaths)
+			require.Contains(t, profile.Filesystem.ReadOnlyPaths, readme)
 
 			count := 0
 
-			for _, s := range *profile.Filesystem.ReadOnlyPaths {
+			for _, s := range profile.Filesystem.ReadOnlyPaths {
 				if s == "/proc/@{pid}/limits" {
 					count++
 				}
@@ -99,8 +99,8 @@ func recordAppArmorTest(t *testing.T) {
 				"--file-write", "/dev/null",
 			)
 			require.NotNil(t, profile.Filesystem)
-			require.NotNil(t, profile.Filesystem.WriteOnlyPaths)
-			require.Contains(t, *profile.Filesystem.WriteOnlyPaths, "/dev/null")
+			require.NotEmpty(t, profile.Filesystem.WriteOnlyPaths)
+			require.Contains(t, profile.Filesystem.WriteOnlyPaths, "/dev/null")
 
 			runWithProfile(t, profile, "./demobinary", "--file-write", "/dev/null")
 		})
@@ -111,8 +111,8 @@ func recordAppArmorTest(t *testing.T) {
 				"--file-write", "/dev/null",
 			)
 			require.NotNil(t, profile.Filesystem)
-			require.NotNil(t, profile.Filesystem.ReadWritePaths)
-			require.Contains(t, *profile.Filesystem.ReadWritePaths, "/dev/null")
+			require.NotEmpty(t, profile.Filesystem.ReadWritePaths)
+			require.Contains(t, profile.Filesystem.ReadWritePaths, "/dev/null")
 
 			runWithProfile(t, profile, "./demobinary", "--file-read", "/dev/null", "--file-write", "/dev/null")
 		})
@@ -124,8 +124,8 @@ func recordAppArmorTest(t *testing.T) {
 			)
 
 			require.NotNil(t, profile.Filesystem)
-			require.NotNil(t, profile.Filesystem.WriteOnlyPaths)
-			require.Contains(t, *profile.Filesystem.WriteOnlyPaths, bpfrecorder.ReplaceVarianceInFilePath(f))
+			require.NotEmpty(t, profile.Filesystem.WriteOnlyPaths)
+			require.Contains(t, profile.Filesystem.WriteOnlyPaths, bpfrecorder.ReplaceVarianceInFilePath(f))
 
 			err := os.Remove(f)
 			require.NoError(t, err)
@@ -143,8 +143,8 @@ func recordAppArmorTest(t *testing.T) {
 				"--file-remove", fileToRemove.Name(),
 			)
 			require.NotNil(t, profile.Filesystem)
-			require.NotNil(t, profile.Filesystem.ReadWritePaths)
-			require.Contains(t, *profile.Filesystem.ReadWritePaths, bpfrecorder.ReplaceVarianceInFilePath(fileToRemove.Name()))
+			require.NotEmpty(t, profile.Filesystem.ReadWritePaths)
+			require.Contains(t, profile.Filesystem.ReadWritePaths, bpfrecorder.ReplaceVarianceInFilePath(fileToRemove.Name()))
 
 			fileToRemove2, err := os.CreateTemp(tempDir, "spoc-test")
 			require.NoError(t, err)
@@ -168,12 +168,12 @@ func recordAppArmorTest(t *testing.T) {
 			"--dir-create", dirs,
 		)
 		require.NotNil(t, profile.Filesystem)
-		require.NotNil(t, profile.Filesystem.ReadOnlyPaths)
-		require.NotNil(t, profile.Filesystem.ReadWritePaths)
-		require.Contains(t, *profile.Filesystem.ReadOnlyPaths, "/var/")
-		require.Contains(t, *profile.Filesystem.ReadOnlyPaths, "/usr/")
-		require.Contains(t, *profile.Filesystem.ReadWritePaths, bpfrecorder.ReplaceVarianceInFilePath(testDir1))
-		require.Contains(t, *profile.Filesystem.ReadWritePaths, bpfrecorder.ReplaceVarianceInFilePath(testDir2))
+		require.NotEmpty(t, profile.Filesystem.ReadOnlyPaths)
+		require.NotEmpty(t, profile.Filesystem.ReadWritePaths)
+		require.Contains(t, profile.Filesystem.ReadOnlyPaths, "/var/")
+		require.Contains(t, profile.Filesystem.ReadOnlyPaths, "/usr/")
+		require.Contains(t, profile.Filesystem.ReadWritePaths, bpfrecorder.ReplaceVarianceInFilePath(testDir1))
+		require.Contains(t, profile.Filesystem.ReadWritePaths, bpfrecorder.ReplaceVarianceInFilePath(testDir2))
 
 		runWithProfile(t, profile,
 			"./demobinary",
@@ -186,8 +186,8 @@ func recordAppArmorTest(t *testing.T) {
 			sockPath := filepath.Join(t.TempDir(), "test.sock")
 			profile := recordAppArmor(t, "./demobinary", "--net-unix", sockPath)
 			require.NotNil(t, profile.Filesystem)
-			require.NotNil(t, profile.Filesystem.ReadWritePaths)
-			require.Contains(t, *profile.Filesystem.ReadWritePaths, bpfrecorder.ReplaceVarianceInFilePath(sockPath))
+			require.NotEmpty(t, profile.Filesystem.ReadWritePaths)
+			require.Contains(t, profile.Filesystem.ReadWritePaths, bpfrecorder.ReplaceVarianceInFilePath(sockPath))
 
 			err := os.Remove(sockPath)
 			require.NoError(t, err)
@@ -224,16 +224,16 @@ func recordAppArmorTest(t *testing.T) {
 	})
 	t.Run("subprocess", func(t *testing.T) {
 		profile := recordAppArmor(t, "./demobinary", "./demobinary-child", "--file-read", "/dev/null")
-		require.Contains(t, (*profile.Executable.AllowedExecutables)[0], "/demobinary-child")
-		require.Contains(t, *profile.Filesystem.ReadOnlyPaths, "/dev/null")
+		require.Contains(t, profile.Executable.AllowedExecutables[0], "/demobinary-child")
+		require.Contains(t, profile.Filesystem.ReadOnlyPaths, "/dev/null")
 
 		profile = recordAppArmor(t, "./demobinary", "./demobinary", "--file-read", "/dev/null")
-		require.Contains(t, (*profile.Executable.AllowedExecutables)[0], "/demobinary")
-		require.Contains(t, *profile.Filesystem.ReadOnlyPaths, "/dev/null")
+		require.Contains(t, profile.Executable.AllowedExecutables[0], "/demobinary")
+		require.Contains(t, profile.Filesystem.ReadOnlyPaths, "/dev/null")
 
 		profile = recordAppArmor(t, "./demobinary", "./demobinary-child", "./demobinary-child", "--file-read", "/dev/null")
-		require.Contains(t, (*profile.Executable.AllowedExecutables)[0], "/demobinary-child")
-		require.Contains(t, *profile.Filesystem.ReadOnlyPaths, "/dev/null")
+		require.Contains(t, profile.Executable.AllowedExecutables[0], "/demobinary-child")
+		require.Contains(t, profile.Filesystem.ReadOnlyPaths, "/dev/null")
 	})
 	t.Run("huge pages", func(t *testing.T) {
 		page, err := syscall.Mmap(-1, 0, 8192,
@@ -247,7 +247,7 @@ func recordAppArmorTest(t *testing.T) {
 		}
 
 		profile := recordAppArmor(t, "./demobinary", "--hugepage")
-		require.Contains(t, *profile.Filesystem.ReadWritePaths, "/")
+		require.Contains(t, profile.Filesystem.ReadWritePaths, "/")
 		runWithProfile(t, profile, "./demobinary", "--hugepage")
 	})
 	t.Run("no-proc-start", func(t *testing.T) {


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Replace non-idiomatic `*[]string` pointer-to-slice fields with `[]string` in `AppArmorExecutablesRules` and `AppArmorFsRules`. In Go, slices are already reference types, so a pointer to a slice is unnecessary and complicates deepcopy and serialization.

Also fix comment typo "lost of allowed" to "list of allowed" in `AppArmorCapabilityRules`.

Changes:
- `AppArmorExecutablesRules.AllowedExecutables` and `AllowedLibraries`: `*[]string` to `[]string`
- `AppArmorFsRules.ReadOnlyPaths`, `WriteOnlyPaths`, `ReadWritePaths`: `*[]string` to `[]string`
- All consumers updated: recording merger, CLI recorder, profile recorder
- CRDs and deployment manifests regenerated

#### Which issue(s) this PR fixes:

Part of #3195

#### Does this PR have test?

Existing unit tests updated and passing.

#### Special notes for your reviewer:

This is a breaking API change for `AppArmorProfile`. The `*[]string` fields become `[]string`, which is wire-compatible (JSON serialization is identical) but changes the Go type signature.

#### Does this PR introduce a user-facing change?

```release-note
AppArmorProfile API: replace pointer-to-slice (`*[]string`) fields with plain slices (`[]string`) in executable and filesystem rules.
```