### PR TITLE
api: add AppArmorProfile to ProfileBinding kinds

### DIFF
--- a/api/profilebinding/v1alpha1/profilebinding_types.go
+++ b/api/profilebinding/v1alpha1/profilebinding_types.go
@@ -23,9 +23,10 @@ import (
 type ProfileBindingKind string
 
 const (
-	ProfileBindingKindSeccompProfile ProfileBindingKind = "SeccompProfile"
-	ProfileBindingKindSelinuxProfile ProfileBindingKind = "SelinuxProfile"
-	SelectAllContainersImage         string             = "*"
+	ProfileBindingKindSeccompProfile  ProfileBindingKind = "SeccompProfile"
+	ProfileBindingKindSelinuxProfile  ProfileBindingKind = "SelinuxProfile"
+	ProfileBindingKindAppArmorProfile ProfileBindingKind = "AppArmorProfile"
+	SelectAllContainersImage          string             = "*"
 )
 
 // ProfileBindingSpec defines the desired state of ProfileBinding.
@@ -40,7 +41,7 @@ type ProfileBindingSpec struct {
 // ProfileRef contains information that points to the profile being used.
 type ProfileRef struct {
 	// Kind of object to be bound.
-	// +kubebuilder:validation:Enum=SeccompProfile;SelinuxProfile
+	// +kubebuilder:validation:Enum=SeccompProfile;SelinuxProfile;AppArmorProfile
 	Kind ProfileBindingKind `json:"kind"`
 	// Name of the profile within the current namespace to which to bind the selected pods.
 	Name string `json:"name"`

--- a/deploy/base-crds/crds/profilebinding.yaml
+++ b/deploy/base-crds/crds/profilebinding.yaml
@@ -52,6 +52,7 @@ spec:
                     enum:
                     - SeccompProfile
                     - SelinuxProfile
+                    - AppArmorProfile
                     type: string
                   name:
                     description: Name of the profile within the current namespace

--- a/deploy/base/role.yaml
+++ b/deploy/base/role.yaml
@@ -360,6 +360,16 @@ rules:
 - apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
+  - apparmorprofiles
+  - seccompprofiles
+  - selinuxprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - security-profiles-operator.x-k8s.io
+  resources:
   - profilebindings
   - profilerecordings
   verbs:
@@ -388,15 +398,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - security-profiles-operator.x-k8s.io
-  resources:
-  - seccompprofiles
-  - selinuxprofiles
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -54,6 +54,7 @@ spec:
                     enum:
                     - SeccompProfile
                     - SelinuxProfile
+                    - AppArmorProfile
                     type: string
                   name:
                     description: Name of the profile within the current namespace

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -433,6 +433,16 @@ rules:
 - apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
+  - apparmorprofiles
+  - seccompprofiles
+  - selinuxprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - security-profiles-operator.x-k8s.io
+  resources:
   - profilebindings
   - profilerecordings
   verbs:
@@ -461,15 +471,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - security-profiles-operator.x-k8s.io
-  resources:
-  - seccompprofiles
-  - selinuxprofiles
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -54,6 +54,7 @@ spec:
                     enum:
                     - SeccompProfile
                     - SelinuxProfile
+                    - AppArmorProfile
                     type: string
                   name:
                     description: Name of the profile within the current namespace
@@ -2849,6 +2850,16 @@ rules:
 - apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
+  - apparmorprofiles
+  - seccompprofiles
+  - selinuxprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - security-profiles-operator.x-k8s.io
+  resources:
   - profilebindings
   - profilerecordings
   verbs:
@@ -2877,15 +2888,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - security-profiles-operator.x-k8s.io
-  resources:
-  - seccompprofiles
-  - selinuxprofiles
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -248,6 +248,7 @@ spec:
                     enum:
                     - SeccompProfile
                     - SelinuxProfile
+                    - AppArmorProfile
                     type: string
                   name:
                     description: Name of the profile within the current namespace
@@ -2781,6 +2782,16 @@ rules:
 - apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
+  - apparmorprofiles
+  - seccompprofiles
+  - selinuxprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - security-profiles-operator.x-k8s.io
+  resources:
   - profilebindings
   - profilerecordings
   verbs:
@@ -2809,15 +2820,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - security-profiles-operator.x-k8s.io
-  resources:
-  - seccompprofiles
-  - selinuxprofiles
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -54,6 +54,7 @@ spec:
                     enum:
                     - SeccompProfile
                     - SelinuxProfile
+                    - AppArmorProfile
                     type: string
                   name:
                     description: Name of the profile within the current namespace
@@ -2854,6 +2855,16 @@ rules:
 - apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
+  - apparmorprofiles
+  - seccompprofiles
+  - selinuxprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - security-profiles-operator.x-k8s.io
+  resources:
   - profilebindings
   - profilerecordings
   verbs:
@@ -2882,15 +2893,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - security-profiles-operator.x-k8s.io
-  resources:
-  - seccompprofiles
-  - selinuxprofiles
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -54,6 +54,7 @@ spec:
                     enum:
                     - SeccompProfile
                     - SelinuxProfile
+                    - AppArmorProfile
                     type: string
                   name:
                     description: Name of the profile within the current namespace
@@ -2849,6 +2850,16 @@ rules:
 - apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
+  - apparmorprofiles
+  - seccompprofiles
+  - selinuxprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - security-profiles-operator.x-k8s.io
+  resources:
   - profilebindings
   - profilerecordings
   verbs:
@@ -2877,15 +2888,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - security-profiles-operator.x-k8s.io
-  resources:
-  - seccompprofiles
-  - selinuxprofiles
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -248,6 +248,7 @@ spec:
                     enum:
                     - SeccompProfile
                     - SelinuxProfile
+                    - AppArmorProfile
                     type: string
                   name:
                     description: Name of the profile within the current namespace
@@ -2765,6 +2766,16 @@ rules:
 - apiGroups:
   - security-profiles-operator.x-k8s.io
   resources:
+  - apparmorprofiles
+  - seccompprofiles
+  - selinuxprofiles
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - security-profiles-operator.x-k8s.io
+  resources:
   - profilebindings
   - profilerecordings
   verbs:
@@ -2793,15 +2804,6 @@ rules:
   - get
   - patch
   - update
-- apiGroups:
-  - security-profiles-operator.x-k8s.io
-  resources:
-  - seccompprofiles
-  - selinuxprofiles
-  verbs:
-  - get
-  - list
-  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -36,6 +36,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	apparmorprofileapi "sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1alpha1"
 	profilebindingv1alpha1 "sigs.k8s.io/security-profiles-operator/api/profilebinding/v1alpha1"
 	seccompprofileapi "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"
 	selinuxprofileapi "sigs.k8s.io/security-profiles-operator/api/selinuxprofile/v1alpha2"
@@ -102,6 +103,7 @@ func initContainerMap(m *sync.Map, spec *corev1.PodSpec) {
 // +kubebuilder:rbac:groups=security-profiles-operator.x-k8s.io,resources=profilebindings/finalizers,verbs=delete;get;update;patch
 // +kubebuilder:rbac:groups=security-profiles-operator.x-k8s.io,resources=seccompprofiles,verbs=get;list;watch
 // +kubebuilder:rbac:groups=security-profiles-operator.x-k8s.io,resources=selinuxprofiles,verbs=get;list;watch
+// +kubebuilder:rbac:groups=security-profiles-operator.x-k8s.io,resources=apparmorprofiles,verbs=get;list;watch
 
 //nolint:lll // required for kubebuilder
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create
@@ -168,13 +170,6 @@ func (p *podBinder) updatePod(
 
 	for i := range profilebindings {
 		profileKind := profilebindings[i].Spec.ProfileRef.Kind
-		if profileKind != profilebindingv1alpha1.ProfileBindingKindSeccompProfile {
-			if profileKind != profilebindingv1alpha1.ProfileBindingKindSelinuxProfile {
-				p.log.Info(fmt.Sprintf("profile kind %s not yet supported", profileKind))
-
-				continue
-			}
-		}
 
 		profileName := profilebindings[i].Spec.ProfileRef.Name
 
@@ -192,12 +187,17 @@ func (p *podBinder) updatePod(
 
 		var err error
 
-		if profileKind == profilebindingv1alpha1.ProfileBindingKindSeccompProfile {
+		switch profileKind {
+		case profilebindingv1alpha1.ProfileBindingKindSeccompProfile:
 			bindProfile, err = p.getSeccompProfile(ctx, namespacedName)
-		}
-
-		if profileKind == profilebindingv1alpha1.ProfileBindingKindSelinuxProfile {
+		case profilebindingv1alpha1.ProfileBindingKindSelinuxProfile:
 			bindProfile, err = p.getSelinuxProfile(ctx, namespacedName)
+		case profilebindingv1alpha1.ProfileBindingKindAppArmorProfile:
+			bindProfile, err = p.getAppArmorProfile(ctx, namespacedName)
+		default:
+			p.log.Info(fmt.Sprintf("profile kind %s not supported", profileKind))
+
+			continue
 		}
 
 		if err != nil {
@@ -299,6 +299,29 @@ func (p *podBinder) getSelinuxProfile(
 	return selinuxProfile, err
 }
 
+func (p *podBinder) getAppArmorProfile(
+	ctx context.Context,
+	key types.NamespacedName,
+) (appArmorProfile *apparmorprofileapi.AppArmorProfile, err error) {
+	err = util.Retry(
+		func() (retryErr error) {
+			appArmorProfile, retryErr = p.GetAppArmorProfile(ctx, key)
+			if retryErr != nil {
+				return fmt.Errorf("getting profile: %w", retryErr)
+			}
+
+			if appArmorProfile.Status.Status == "" {
+				return fmt.Errorf("getting profile: %w", ErrProfWithoutStatus)
+			}
+
+			return nil
+		}, func(inErr error) bool {
+			return errors.Is(inErr, ErrProfWithoutStatus) || kerrors.IsNotFound(inErr)
+		})
+	//nolint:wrapcheck // already wrapped
+	return appArmorProfile, err
+}
+
 func (p *podBinder) addSecurityContext(
 	c *corev1.Container, bindProfile any,
 ) bool {
@@ -309,6 +332,8 @@ func (p *podBinder) addSecurityContext(
 		podChanged = p.addSeccompContext(c, v)
 	case *selinuxprofileapi.SelinuxProfile:
 		podChanged = p.addSelinuxContext(c, v)
+	case *apparmorprofileapi.AppArmorProfile:
+		podChanged = p.addAppArmorContext(c, v)
 	default:
 		p.log.Info("Unexpected Profile Type")
 
@@ -365,6 +390,30 @@ func (p *podBinder) addSelinuxContext(
 	return podChanged
 }
 
+func (p *podBinder) addAppArmorContext(
+	c *corev1.Container, appArmorProfile *apparmorprofileapi.AppArmorProfile,
+) bool {
+	podChanged := false
+	profileName := appArmorProfile.GetProfileName()
+	aa := corev1.AppArmorProfile{
+		Type:             corev1.AppArmorProfileTypeLocalhost,
+		LocalhostProfile: &profileName,
+	}
+
+	if c.SecurityContext == nil {
+		c.SecurityContext = &corev1.SecurityContext{}
+	}
+
+	if c.SecurityContext.AppArmorProfile != nil {
+		p.log.Info("cannot override existing apparmor profile for pod or container")
+	} else {
+		c.SecurityContext.AppArmorProfile = &aa
+		podChanged = true
+	}
+
+	return podChanged
+}
+
 func (p *podBinder) addPodSecurityContext(
 	pod *corev1.Pod, bindProfile any,
 ) bool {
@@ -375,6 +424,8 @@ func (p *podBinder) addPodSecurityContext(
 		podChanged = p.addPodSeccompContext(pod, v)
 	case *selinuxprofileapi.SelinuxProfile:
 		podChanged = p.addPodSelinuxContext(pod, v)
+	case *apparmorprofileapi.AppArmorProfile:
+		podChanged = p.addPodAppArmorContext(pod, v)
 	default:
 		p.log.Info("Unexpected Profile Type")
 
@@ -425,6 +476,30 @@ func (p *podBinder) addPodSelinuxContext(
 		p.log.Info("cannot override existing selinux profile for pod or container")
 	} else {
 		pod.Spec.SecurityContext.SELinuxOptions = &sl
+		podChanged = true
+	}
+
+	return podChanged
+}
+
+func (p *podBinder) addPodAppArmorContext(
+	pod *corev1.Pod, appArmorProfile *apparmorprofileapi.AppArmorProfile,
+) bool {
+	podChanged := false
+	profileName := appArmorProfile.GetProfileName()
+	aa := corev1.AppArmorProfile{
+		Type:             corev1.AppArmorProfileTypeLocalhost,
+		LocalhostProfile: &profileName,
+	}
+
+	if pod.Spec.SecurityContext == nil {
+		pod.Spec.SecurityContext = &corev1.PodSecurityContext{}
+	}
+
+	if pod.Spec.SecurityContext.AppArmorProfile != nil {
+		p.log.Info("cannot override existing apparmor profile for pod or container")
+	} else {
+		pod.Spec.SecurityContext.AppArmorProfile = &aa
 		podChanged = true
 	}
 

--- a/internal/pkg/webhooks/binding/binding_test.go
+++ b/internal/pkg/webhooks/binding/binding_test.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	apparmorprofileapi "sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1alpha1"
 	profilebasev1alpha1 "sigs.k8s.io/security-profiles-operator/api/profilebase/v1alpha1"
 	"sigs.k8s.io/security-profiles-operator/api/profilebinding/v1alpha1"
 	seccompprofileapi "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"
@@ -92,6 +93,7 @@ func TestHandle(t *testing.T) {
 				require.Equal(t, http.StatusBadRequest, int(resp.Result.Code))
 			},
 		},
+		//nolint:dupl // test duplicates are fine
 		{ // success pod changed
 			prepare: func(mock *bindingfakes.FakeImpl) {
 				mock.ListProfileBindingsReturns(&v1alpha1.ProfileBindingList{
@@ -252,6 +254,154 @@ func TestHandle(t *testing.T) {
 				require.Len(t, resp.Patches, 1)
 			},
 		},
+		//nolint:dupl // test duplicates are fine
+		{ // apparmor success pod changed
+			prepare: func(mock *bindingfakes.FakeImpl) {
+				mock.ListProfileBindingsReturns(&v1alpha1.ProfileBindingList{
+					Items: []v1alpha1.ProfileBinding{
+						{
+							Spec: v1alpha1.ProfileBindingSpec{
+								ProfileRef: v1alpha1.ProfileRef{
+									Kind: v1alpha1.ProfileBindingKindAppArmorProfile,
+								},
+								Image: "foo",
+							},
+						},
+					},
+				}, nil)
+				mock.DecodePodReturns(testPod.DeepCopy(), nil)
+				mock.GetAppArmorProfileReturns(&apparmorprofileapi.AppArmorProfile{
+					Status: apparmorprofileapi.AppArmorProfileStatus{
+						StatusBase: profilebasev1alpha1.StatusBase{
+							Status: secprofnodestatusv1alpha1.ProfileStateInstalled,
+						},
+					},
+				}, nil)
+			},
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{
+						Raw: func() []byte {
+							b, err := json.Marshal(testPod.DeepCopy())
+							require.NoError(t, err)
+
+							return b
+						}(),
+					},
+				},
+			},
+			assert: func(resp admission.Response) {
+				require.True(t, resp.Allowed)
+				require.Len(t, resp.Patches, 1)
+			},
+		},
+		{ // apparmor success pod changed with * image
+			prepare: func(mock *bindingfakes.FakeImpl) {
+				mock.ListProfileBindingsReturns(&v1alpha1.ProfileBindingList{
+					Items: []v1alpha1.ProfileBinding{
+						{
+							Spec: v1alpha1.ProfileBindingSpec{
+								ProfileRef: v1alpha1.ProfileRef{
+									Kind: v1alpha1.ProfileBindingKindAppArmorProfile,
+								},
+								Image: v1alpha1.SelectAllContainersImage,
+							},
+						},
+					},
+				}, nil)
+				mock.DecodePodReturns(testPod.DeepCopy(), nil)
+				mock.GetAppArmorProfileReturns(&apparmorprofileapi.AppArmorProfile{
+					Status: apparmorprofileapi.AppArmorProfileStatus{
+						StatusBase: profilebasev1alpha1.StatusBase{
+							Status: secprofnodestatusv1alpha1.ProfileStateInstalled,
+						},
+					},
+				}, nil)
+			},
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{
+						Raw: func() []byte {
+							b, err := json.Marshal(testPod.DeepCopy())
+							require.NoError(t, err)
+
+							return b
+						}(),
+					},
+				},
+			},
+			assert: func(resp admission.Response) {
+				require.True(t, resp.Allowed)
+				require.Len(t, resp.Patches, 1)
+			},
+		},
+		{ // failure get apparmor profile errored
+			prepare: func(mock *bindingfakes.FakeImpl) {
+				mock.ListProfileBindingsReturns(&v1alpha1.ProfileBindingList{
+					Items: []v1alpha1.ProfileBinding{
+						{
+							Spec: v1alpha1.ProfileBindingSpec{
+								ProfileRef: v1alpha1.ProfileRef{
+									Kind: v1alpha1.ProfileBindingKindAppArmorProfile,
+								},
+							},
+						},
+					},
+				}, nil)
+				mock.DecodePodReturns(testPod.DeepCopy(), nil)
+				mock.GetAppArmorProfileReturns(nil, errTest)
+			},
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{
+						Raw: func() []byte {
+							b, err := json.Marshal(testPod.DeepCopy())
+							require.NoError(t, err)
+
+							return b
+						}(),
+					},
+				},
+			},
+			assert: func(resp admission.Response) {
+				require.Equal(t, http.StatusInternalServerError, int(resp.Result.Code))
+			},
+		},
+		//nolint:dupl // test duplicates are fine
+		{ // failure get apparmor profile without status
+			prepare: func(mock *bindingfakes.FakeImpl) {
+				mock.ListProfileBindingsReturns(&v1alpha1.ProfileBindingList{
+					Items: []v1alpha1.ProfileBinding{
+						{
+							Spec: v1alpha1.ProfileBindingSpec{
+								ProfileRef: v1alpha1.ProfileRef{
+									Kind: v1alpha1.ProfileBindingKindAppArmorProfile,
+								},
+							},
+						},
+					},
+				}, nil)
+				mock.DecodePodReturns(testPod.DeepCopy(), nil)
+				mock.GetAppArmorProfileReturns(&apparmorprofileapi.AppArmorProfile{
+					Status: apparmorprofileapi.AppArmorProfileStatus{},
+				}, nil)
+			},
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{
+						Raw: func() []byte {
+							b, err := json.Marshal(testPod.DeepCopy())
+							require.NoError(t, err)
+
+							return b
+						}(),
+					},
+				},
+			},
+			assert: func(resp admission.Response) {
+				require.Equal(t, http.StatusInternalServerError, int(resp.Result.Code))
+			},
+		},
 		{ // success unsupported kind
 			prepare: func(mock *bindingfakes.FakeImpl) {
 				mock.ListProfileBindingsReturns(&v1alpha1.ProfileBindingList{
@@ -291,6 +441,7 @@ func TestHandle(t *testing.T) {
 				require.Empty(t, resp.Patches)
 			},
 		},
+		//nolint:dupl // test duplicates are fine
 		{ // failure get seccomp profile malicious
 			prepare: func(mock *bindingfakes.FakeImpl) {
 				mock.ListProfileBindingsReturns(&v1alpha1.ProfileBindingList{

--- a/internal/pkg/webhooks/binding/bindingfakes/fake_impl.go
+++ b/internal/pkg/webhooks/binding/bindingfakes/fake_impl.go
@@ -26,7 +26,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-	"sigs.k8s.io/security-profiles-operator/api/profilebinding/v1alpha1"
+	"sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1alpha1"
+	v1alpha1a "sigs.k8s.io/security-profiles-operator/api/profilebinding/v1alpha1"
 	"sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"
 	"sigs.k8s.io/security-profiles-operator/api/selinuxprofile/v1alpha2"
 )
@@ -43,6 +44,20 @@ type FakeImpl struct {
 	}
 	decodePodReturnsOnCall map[int]struct {
 		result1 *v1.Pod
+		result2 error
+	}
+	GetAppArmorProfileStub        func(context.Context, types.NamespacedName) (*v1alpha1.AppArmorProfile, error)
+	getAppArmorProfileMutex       sync.RWMutex
+	getAppArmorProfileArgsForCall []struct {
+		arg1 context.Context
+		arg2 types.NamespacedName
+	}
+	getAppArmorProfileReturns struct {
+		result1 *v1alpha1.AppArmorProfile
+		result2 error
+	}
+	getAppArmorProfileReturnsOnCall map[int]struct {
+		result1 *v1alpha1.AppArmorProfile
 		result2 error
 	}
 	GetSeccompProfileStub        func(context.Context, types.NamespacedName) (*v1beta1.SeccompProfile, error)
@@ -73,18 +88,18 @@ type FakeImpl struct {
 		result1 *v1alpha2.SelinuxProfile
 		result2 error
 	}
-	ListProfileBindingsStub        func(context.Context, ...client.ListOption) (*v1alpha1.ProfileBindingList, error)
+	ListProfileBindingsStub        func(context.Context, ...client.ListOption) (*v1alpha1a.ProfileBindingList, error)
 	listProfileBindingsMutex       sync.RWMutex
 	listProfileBindingsArgsForCall []struct {
 		arg1 context.Context
 		arg2 []client.ListOption
 	}
 	listProfileBindingsReturns struct {
-		result1 *v1alpha1.ProfileBindingList
+		result1 *v1alpha1a.ProfileBindingList
 		result2 error
 	}
 	listProfileBindingsReturnsOnCall map[int]struct {
-		result1 *v1alpha1.ProfileBindingList
+		result1 *v1alpha1a.ProfileBindingList
 		result2 error
 	}
 	UpdateResourceStub        func(context.Context, logr.Logger, client.Object, string) error
@@ -179,6 +194,71 @@ func (fake *FakeImpl) DecodePodReturnsOnCall(i int, result1 *v1.Pod, result2 err
 	}
 	fake.decodePodReturnsOnCall[i] = struct {
 		result1 *v1.Pod
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) GetAppArmorProfile(arg1 context.Context, arg2 types.NamespacedName) (*v1alpha1.AppArmorProfile, error) {
+	fake.getAppArmorProfileMutex.Lock()
+	ret, specificReturn := fake.getAppArmorProfileReturnsOnCall[len(fake.getAppArmorProfileArgsForCall)]
+	fake.getAppArmorProfileArgsForCall = append(fake.getAppArmorProfileArgsForCall, struct {
+		arg1 context.Context
+		arg2 types.NamespacedName
+	}{arg1, arg2})
+	stub := fake.GetAppArmorProfileStub
+	fakeReturns := fake.getAppArmorProfileReturns
+	fake.recordInvocation("GetAppArmorProfile", []interface{}{arg1, arg2})
+	fake.getAppArmorProfileMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) GetAppArmorProfileCallCount() int {
+	fake.getAppArmorProfileMutex.RLock()
+	defer fake.getAppArmorProfileMutex.RUnlock()
+	return len(fake.getAppArmorProfileArgsForCall)
+}
+
+func (fake *FakeImpl) GetAppArmorProfileCalls(stub func(context.Context, types.NamespacedName) (*v1alpha1.AppArmorProfile, error)) {
+	fake.getAppArmorProfileMutex.Lock()
+	defer fake.getAppArmorProfileMutex.Unlock()
+	fake.GetAppArmorProfileStub = stub
+}
+
+func (fake *FakeImpl) GetAppArmorProfileArgsForCall(i int) (context.Context, types.NamespacedName) {
+	fake.getAppArmorProfileMutex.RLock()
+	defer fake.getAppArmorProfileMutex.RUnlock()
+	argsForCall := fake.getAppArmorProfileArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeImpl) GetAppArmorProfileReturns(result1 *v1alpha1.AppArmorProfile, result2 error) {
+	fake.getAppArmorProfileMutex.Lock()
+	defer fake.getAppArmorProfileMutex.Unlock()
+	fake.GetAppArmorProfileStub = nil
+	fake.getAppArmorProfileReturns = struct {
+		result1 *v1alpha1.AppArmorProfile
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) GetAppArmorProfileReturnsOnCall(i int, result1 *v1alpha1.AppArmorProfile, result2 error) {
+	fake.getAppArmorProfileMutex.Lock()
+	defer fake.getAppArmorProfileMutex.Unlock()
+	fake.GetAppArmorProfileStub = nil
+	if fake.getAppArmorProfileReturnsOnCall == nil {
+		fake.getAppArmorProfileReturnsOnCall = make(map[int]struct {
+			result1 *v1alpha1.AppArmorProfile
+			result2 error
+		})
+	}
+	fake.getAppArmorProfileReturnsOnCall[i] = struct {
+		result1 *v1alpha1.AppArmorProfile
 		result2 error
 	}{result1, result2}
 }
@@ -313,7 +393,7 @@ func (fake *FakeImpl) GetSelinuxProfileReturnsOnCall(i int, result1 *v1alpha2.Se
 	}{result1, result2}
 }
 
-func (fake *FakeImpl) ListProfileBindings(arg1 context.Context, arg2 ...client.ListOption) (*v1alpha1.ProfileBindingList, error) {
+func (fake *FakeImpl) ListProfileBindings(arg1 context.Context, arg2 ...client.ListOption) (*v1alpha1a.ProfileBindingList, error) {
 	fake.listProfileBindingsMutex.Lock()
 	ret, specificReturn := fake.listProfileBindingsReturnsOnCall[len(fake.listProfileBindingsArgsForCall)]
 	fake.listProfileBindingsArgsForCall = append(fake.listProfileBindingsArgsForCall, struct {
@@ -339,7 +419,7 @@ func (fake *FakeImpl) ListProfileBindingsCallCount() int {
 	return len(fake.listProfileBindingsArgsForCall)
 }
 
-func (fake *FakeImpl) ListProfileBindingsCalls(stub func(context.Context, ...client.ListOption) (*v1alpha1.ProfileBindingList, error)) {
+func (fake *FakeImpl) ListProfileBindingsCalls(stub func(context.Context, ...client.ListOption) (*v1alpha1a.ProfileBindingList, error)) {
 	fake.listProfileBindingsMutex.Lock()
 	defer fake.listProfileBindingsMutex.Unlock()
 	fake.ListProfileBindingsStub = stub
@@ -352,28 +432,28 @@ func (fake *FakeImpl) ListProfileBindingsArgsForCall(i int) (context.Context, []
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeImpl) ListProfileBindingsReturns(result1 *v1alpha1.ProfileBindingList, result2 error) {
+func (fake *FakeImpl) ListProfileBindingsReturns(result1 *v1alpha1a.ProfileBindingList, result2 error) {
 	fake.listProfileBindingsMutex.Lock()
 	defer fake.listProfileBindingsMutex.Unlock()
 	fake.ListProfileBindingsStub = nil
 	fake.listProfileBindingsReturns = struct {
-		result1 *v1alpha1.ProfileBindingList
+		result1 *v1alpha1a.ProfileBindingList
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeImpl) ListProfileBindingsReturnsOnCall(i int, result1 *v1alpha1.ProfileBindingList, result2 error) {
+func (fake *FakeImpl) ListProfileBindingsReturnsOnCall(i int, result1 *v1alpha1a.ProfileBindingList, result2 error) {
 	fake.listProfileBindingsMutex.Lock()
 	defer fake.listProfileBindingsMutex.Unlock()
 	fake.ListProfileBindingsStub = nil
 	if fake.listProfileBindingsReturnsOnCall == nil {
 		fake.listProfileBindingsReturnsOnCall = make(map[int]struct {
-			result1 *v1alpha1.ProfileBindingList
+			result1 *v1alpha1a.ProfileBindingList
 			result2 error
 		})
 	}
 	fake.listProfileBindingsReturnsOnCall[i] = struct {
-		result1 *v1alpha1.ProfileBindingList
+		result1 *v1alpha1a.ProfileBindingList
 		result2 error
 	}{result1, result2}
 }

--- a/internal/pkg/webhooks/binding/impl.go
+++ b/internal/pkg/webhooks/binding/impl.go
@@ -26,6 +26,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
+	apparmorprofileapi "sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1alpha1"
 	"sigs.k8s.io/security-profiles-operator/api/profilebinding/v1alpha1"
 	seccompprofileapi "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"
 	selinuxprofileapi "sigs.k8s.io/security-profiles-operator/api/selinuxprofile/v1alpha2"
@@ -46,6 +47,7 @@ type impl interface {
 	DecodePod(admission.Request) (*corev1.Pod, error)
 	GetSeccompProfile(context.Context, types.NamespacedName) (*seccompprofileapi.SeccompProfile, error)
 	GetSelinuxProfile(context.Context, types.NamespacedName) (*selinuxprofileapi.SelinuxProfile, error)
+	GetAppArmorProfile(context.Context, types.NamespacedName) (*apparmorprofileapi.AppArmorProfile, error)
 }
 
 func (d *defaultImpl) ListProfileBindings(
@@ -109,4 +111,15 @@ func (d *defaultImpl) GetSelinuxProfile(
 	}
 
 	return selinuxProfile, nil
+}
+
+func (d *defaultImpl) GetAppArmorProfile(
+	ctx context.Context, key types.NamespacedName,
+) (*apparmorprofileapi.AppArmorProfile, error) {
+	appArmorProfile := &apparmorprofileapi.AppArmorProfile{}
+	if err := d.client.Get(ctx, key, appArmorProfile); err != nil {
+		return nil, fmt.Errorf("get apparmor profile: %w", err)
+	}
+
+	return appArmorProfile, nil
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Add `AppArmorProfile` as a supported `ProfileBindingKind` alongside `SeccompProfile` and `SelinuxProfile`. This enables binding AppArmor profiles to pods via the ProfileBinding webhook.

Changes:
- Add `ProfileBindingKindAppArmorProfile` constant
- Extend kubebuilder validation enum to include `AppArmorProfile`
- Add AppArmor profile lookup, container and pod security context injection in the binding webhook
- Regenerate CRDs and deployment manifests

#### Which issue(s) this PR fixes:

Part of #3195

#### Does this PR introduce a user-facing change?

```release-note
Add AppArmorProfile as a supported ProfileBinding kind
```