### PR TITLE
api: fix seccomp field types per K8s API conventions

### DIFF
--- a/api/seccompprofile/v1beta1/seccompprofile_types.go
+++ b/api/seccompprofile/v1beta1/seccompprofile_types.go
@@ -72,26 +72,33 @@ type SeccompProfileSpec struct {
 	// BaseProfileName is the name of base profile (in the same namespace) that
 	// will be unioned into this profile. Base profiles can be references as
 	// remote OCI artifacts as well when prefixed with `oci://`.
+	// +optional
 	BaseProfileName string `json:"baseProfileName,omitempty"`
 
 	// the default action for seccomp
+	// +required
 	DefaultAction Action `json:"defaultAction"`
 	// the architecture used for system calls
+	// +optional
 	Architectures []Arch `json:"architectures,omitempty"`
 	// path of UNIX domain socket to contact a seccomp agent for SCMP_ACT_NOTIFY
+	// +optional
 	ListenerPath string `json:"listenerPath,omitempty"`
 	// opaque data to pass to the seccomp agent
+	// +optional
 	ListenerMetadata string `json:"listenerMetadata,omitempty"`
 	// match a syscall in seccomp. While this property is OPTIONAL, some values
 	// of defaultAction are not useful without syscalls entries. For example,
 	// if defaultAction is SCMP_ACT_KILL and syscalls is empty or unset, the
 	// kernel will kill the container process on its first syscall
-	Syscalls []*Syscall `json:"syscalls,omitempty"`
+	// +optional
+	Syscalls []Syscall `json:"syscalls,omitempty"`
 
 	// Additional properties from OCI runtime spec
 
 	// list of flags to use with seccomp(2)
-	Flags []*Flag `json:"flags,omitempty"`
+	// +optional
+	Flags []Flag `json:"flags,omitempty"`
 }
 
 // +kubebuilder:validation:Enum=SCMP_ARCH_NATIVE;SCMP_ARCH_X86;SCMP_ARCH_X86_64;SCMP_ARCH_X32;SCMP_ARCH_ARM;SCMP_ARCH_AARCH64;SCMP_ARCH_MIPS;SCMP_ARCH_MIPS64;SCMP_ARCH_MIPS64N32;SCMP_ARCH_MIPSEL;SCMP_ARCH_MIPSEL64;SCMP_ARCH_MIPSEL64N32;SCMP_ARCH_PPC;SCMP_ARCH_PPC64;SCMP_ARCH_PPC64LE;SCMP_ARCH_S390;SCMP_ARCH_S390X;SCMP_ARCH_PARISC;SCMP_ARCH_PARISC64;SCMP_ARCH_RISCV64
@@ -107,39 +114,51 @@ type Flag string
 // Syscall defines a syscall in seccomp.
 type Syscall struct {
 	// the names of the syscalls
+	// +required
 	Names []string `json:"names"`
 	// the action for seccomp rules
+	// +required
 	Action Action `json:"action"`
 	// the errno return code to use. Some actions like SCMP_ACT_ERRNO and
 	// SCMP_ACT_TRACE allow to specify the errno code to return
-	ErrnoRet uint `json:"errnoRet,omitempty"`
+	// +optional
+	// +kubebuilder:validation:Minimum=0
+	ErrnoRet int32 `json:"errnoRet,omitempty"`
 	// the specific syscall in seccomp
+	// +optional
 	// +kubebuilder:validation:MaxItems=6
-	Args []*Arg `json:"args,omitempty"`
+	Args []Arg `json:"args,omitempty"`
 }
 
 // Arg defines the specific syscall in seccomp.
 type Arg struct {
 	// the index for syscall arguments in seccomp
+	// +required
 	// +kubebuilder:validation:Minimum=0
-	Index uint `json:"index"`
+	Index int32 `json:"index"`
 	// the value for syscall arguments in seccomp
+	// +optional
 	// +kubebuilder:validation:Minimum=0
-	Value uint64 `json:"value,omitempty"`
+	Value int64 `json:"value,omitempty"`
 	// the value for syscall arguments in seccomp
+	// +optional
 	// +kubebuilder:validation:Minimum=0
-	ValueTwo uint64 `json:"valueTwo,omitempty"`
+	ValueTwo int64 `json:"valueTwo,omitempty"`
 	// the operator for syscall arguments in seccomp
+	// +required
 	Op Operator `json:"op"`
 }
 
 // SeccompProfileStatus contains status of the deployed SeccompProfile.
 type SeccompProfileStatus struct {
 	profilebase.StatusBase `json:",inline"`
-	Path                   string   `json:"path,omitempty"`
-	ActiveWorkloads        []string `json:"activeWorkloads,omitempty"`
+	// +optional
+	Path string `json:"path,omitempty"`
+	// +optional
+	ActiveWorkloads []string `json:"activeWorkloads,omitempty"`
 	// The path that should be provided to the `securityContext.seccompProfile.localhostProfile`
 	// field of a Pod or container spec
+	// +optional
 	LocalhostProfile string `json:"localhostProfile,omitempty"`
 }
 

--- a/api/seccompprofile/v1beta1/zz_generated.deepcopy.go
+++ b/api/seccompprofile/v1beta1/zz_generated.deepcopy.go
@@ -109,25 +109,15 @@ func (in *SeccompProfileSpec) DeepCopyInto(out *SeccompProfileSpec) {
 	}
 	if in.Syscalls != nil {
 		in, out := &in.Syscalls, &out.Syscalls
-		*out = make([]*Syscall, len(*in))
+		*out = make([]Syscall, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(Syscall)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 	if in.Flags != nil {
 		in, out := &in.Flags, &out.Flags
-		*out = make([]*Flag, len(*in))
-		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(Flag)
-				**out = **in
-			}
-		}
+		*out = make([]Flag, len(*in))
+		copy(*out, *in)
 	}
 }
 
@@ -172,13 +162,9 @@ func (in *Syscall) DeepCopyInto(out *Syscall) {
 	}
 	if in.Args != nil {
 		in, out := &in.Args, &out.Args
-		*out = make([]*Arg, len(*in))
+		*out = make([]Arg, len(*in))
 		for i := range *in {
-			if (*in)[i] != nil {
-				in, out := &(*in)[i], &(*out)[i]
-				*out = new(Arg)
-				(*in).DeepCopyInto(*out)
-			}
+			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
 }

--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -79,7 +79,8 @@ type WebhookOptions struct {
 // SPODStatus defines the desired state of SPOD.
 type SPODSpec struct {
 	// Verbosity specifies the logging verbosity of the daemon.
-	Verbosity uint `json:"verbosity,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	Verbosity int32 `json:"verbosity,omitempty"`
 	// EnableProfiling tells the operator whether or not to enable profiling
 	// support for this SPOD instance.
 	EnableProfiling bool `json:"enableProfiling,omitempty"`

--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -365,7 +365,7 @@ func main() {
 	)
 
 	app.Flags = []cli.Flag{
-		&cli.UintFlag{
+		&cli.IntFlag{
 			Name:    "verbosity",
 			Aliases: []string{"V"},
 			Usage:   "the logging verbosity to be used",
@@ -414,14 +414,14 @@ func initLogging(ctx *cli.Context) error {
 	set := flag.NewFlagSet("logging", flag.ContinueOnError)
 	klog.InitFlags(set)
 
-	level := ctx.Uint("verbosity")
+	level := ctx.Int("verbosity")
 	if err := set.Parse([]string{fmt.Sprintf("-v=%d", level)}); err != nil {
 		return fmt.Errorf("parse verbosity flag: %w", err)
 	}
 
-	ctrl.SetLogger(ctrl.Log.V(int(level)))
+	ctrl.SetLogger(ctrl.Log.V(level))
 
-	if err := logConfig.Verbosity().Set(strconv.FormatUint(uint64(level), 10)); err != nil {
+	if err := logConfig.Verbosity().Set(strconv.FormatInt(int64(level), 10)); err != nil {
 		return fmt.Errorf("setting the verbosity flag to level %d: %w", level, err)
 	}
 

--- a/deploy/base-crds/crds/seccompprofile.yaml
+++ b/deploy/base-crds/crds/seccompprofile.yaml
@@ -149,6 +149,7 @@ spec:
                         properties:
                           index:
                             description: the index for syscall arguments in seccomp
+                            format: int32
                             minimum: 0
                             type: integer
                           op:
@@ -182,6 +183,8 @@ spec:
                       description: |-
                         the errno return code to use. Some actions like SCMP_ACT_ERRNO and
                         SCMP_ACT_TRACE allow to specify the errno code to return
+                      format: int32
+                      minimum: 0
                       type: integer
                     names:
                       description: the names of the syscalls

--- a/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
@@ -1243,6 +1243,8 @@ spec:
                 type: array
               verbosity:
                 description: Verbosity specifies the logging verbosity of the daemon.
+                format: int32
+                minimum: 0
                 type: integer
               webhookOptions:
                 description: |-

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -388,6 +388,7 @@ spec:
                         properties:
                           index:
                             description: the index for syscall arguments in seccomp
+                            format: int32
                             minimum: 0
                             type: integer
                           op:
@@ -421,6 +422,8 @@ spec:
                       description: |-
                         the errno return code to use. Some actions like SCMP_ACT_ERRNO and
                         SCMP_ACT_TRACE allow to specify the errno code to return
+                      format: int32
+                      minimum: 0
                       type: integer
                     names:
                       description: the names of the syscalls
@@ -1825,6 +1828,8 @@ spec:
                 type: array
               verbosity:
                 description: Verbosity specifies the logging verbosity of the daemon.
+                format: int32
+                minimum: 0
                 type: integer
               webhookOptions:
                 description: |-

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -388,6 +388,7 @@ spec:
                         properties:
                           index:
                             description: the index for syscall arguments in seccomp
+                            format: int32
                             minimum: 0
                             type: integer
                           op:
@@ -421,6 +422,8 @@ spec:
                       description: |-
                         the errno return code to use. Some actions like SCMP_ACT_ERRNO and
                         SCMP_ACT_TRACE allow to specify the errno code to return
+                      format: int32
+                      minimum: 0
                       type: integer
                     names:
                       description: the names of the syscalls
@@ -1825,6 +1828,8 @@ spec:
                 type: array
               verbosity:
                 description: Verbosity specifies the logging verbosity of the daemon.
+                format: int32
+                minimum: 0
                 type: integer
               webhookOptions:
                 description: |-

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -703,6 +703,7 @@ spec:
                         properties:
                           index:
                             description: the index for syscall arguments in seccomp
+                            format: int32
                             minimum: 0
                             type: integer
                           op:
@@ -736,6 +737,8 @@ spec:
                       description: |-
                         the errno return code to use. Some actions like SCMP_ACT_ERRNO and
                         SCMP_ACT_TRACE allow to specify the errno code to return
+                      format: int32
+                      minimum: 0
                       type: integer
                     names:
                       description: the names of the syscalls
@@ -2140,6 +2143,8 @@ spec:
                 type: array
               verbosity:
                 description: Verbosity specifies the logging verbosity of the daemon.
+                format: int32
+                minimum: 0
                 type: integer
               webhookOptions:
                 default:

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -388,6 +388,7 @@ spec:
                         properties:
                           index:
                             description: the index for syscall arguments in seccomp
+                            format: int32
                             minimum: 0
                             type: integer
                           op:
@@ -421,6 +422,8 @@ spec:
                       description: |-
                         the errno return code to use. Some actions like SCMP_ACT_ERRNO and
                         SCMP_ACT_TRACE allow to specify the errno code to return
+                      format: int32
+                      minimum: 0
                       type: integer
                     names:
                       description: the names of the syscalls
@@ -1825,6 +1828,8 @@ spec:
                 type: array
               verbosity:
                 description: Verbosity specifies the logging verbosity of the daemon.
+                format: int32
+                minimum: 0
                 type: integer
               webhookOptions:
                 default:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -388,6 +388,7 @@ spec:
                         properties:
                           index:
                             description: the index for syscall arguments in seccomp
+                            format: int32
                             minimum: 0
                             type: integer
                           op:
@@ -421,6 +422,8 @@ spec:
                       description: |-
                         the errno return code to use. Some actions like SCMP_ACT_ERRNO and
                         SCMP_ACT_TRACE allow to specify the errno code to return
+                      format: int32
+                      minimum: 0
                       type: integer
                     names:
                       description: the names of the syscalls
@@ -1825,6 +1828,8 @@ spec:
                 type: array
               verbosity:
                 description: Verbosity specifies the logging verbosity of the daemon.
+                format: int32
+                minimum: 0
                 type: integer
               webhookOptions:
                 description: |-

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -703,6 +703,7 @@ spec:
                         properties:
                           index:
                             description: the index for syscall arguments in seccomp
+                            format: int32
                             minimum: 0
                             type: integer
                           op:
@@ -736,6 +737,8 @@ spec:
                       description: |-
                         the errno return code to use. Some actions like SCMP_ACT_ERRNO and
                         SCMP_ACT_TRACE allow to specify the errno code to return
+                      format: int32
+                      minimum: 0
                       type: integer
                     names:
                       description: the names of the syscalls
@@ -2140,6 +2143,8 @@ spec:
                 type: array
               verbosity:
                 description: Verbosity specifies the logging verbosity of the daemon.
+                format: int32
+                minimum: 0
                 type: integer
               webhookOptions:
                 description: |-

--- a/internal/pkg/cli/recorder/recorder.go
+++ b/internal/pkg/cli/recorder/recorder.go
@@ -388,7 +388,7 @@ func (r *Recorder) buildProfile(writer io.Writer, names []string) error {
 	spec := seccompprofileapi.SeccompProfileSpec{
 		DefaultAction: seccompprofileapi.ActErrno,
 		Architectures: []seccompprofileapi.Arch{arch},
-		Syscalls: []*seccompprofileapi.Syscall{{
+		Syscalls: []seccompprofileapi.Syscall{{
 			Action: seccompprofileapi.ActAllow,
 			Names:  names,
 		}},

--- a/internal/pkg/daemon/profilerecorder/profilerecorder.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder.go
@@ -534,7 +534,7 @@ func (r *RecorderReconciler) collectLogSeccompProfile(
 	profileSpec := seccompprofileapi.SeccompProfileSpec{
 		DefaultAction: seccompprofileapi.ActErrno,
 		Architectures: []seccompprofileapi.Arch{arch},
-		Syscalls: []*seccompprofileapi.Syscall{{
+		Syscalls: []seccompprofileapi.Syscall{{
 			Action: seccompprofileapi.ActAllow,
 			Names:  response.GetSyscalls(),
 		}},
@@ -830,7 +830,7 @@ func (r *RecorderReconciler) collectSeccompBpfProfile(
 	profileSpec := seccompprofileapi.SeccompProfileSpec{
 		DefaultAction: seccompprofileapi.ActErrno,
 		Architectures: []seccompprofileapi.Arch{arch},
-		Syscalls: []*seccompprofileapi.Syscall{{
+		Syscalls: []seccompprofileapi.Syscall{{
 			Action: seccompprofileapi.ActAllow,
 			Names:  response.GetSyscalls(),
 		}},

--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -352,10 +352,10 @@ func (r *Reconciler) mergeBaseProfile(
 func (r *Reconciler) resolveSyscallsForProfile(
 	ctx context.Context,
 	sp *seccompprofileapi.SeccompProfile,
-	inputSyscalls []*seccompprofileapi.Syscall,
+	inputSyscalls []seccompprofileapi.Syscall,
 	l logr.Logger,
 	level uint8,
-) ([]*seccompprofileapi.Syscall, error) {
+) ([]seccompprofileapi.Syscall, error) {
 	const maxLevel = 15
 	if level >= maxLevel {
 		return nil, fmt.Errorf(

--- a/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
@@ -295,7 +295,7 @@ func TestAllowProfile(t *testing.T) {
 			allowedSeccompActions: []seccompprofileapi.Action{},
 			profile: &seccompprofileapi.SeccompProfile{
 				Spec: seccompprofileapi.SeccompProfileSpec{
-					Syscalls: []*seccompprofileapi.Syscall{
+					Syscalls: []seccompprofileapi.Syscall{
 						{
 							Action: seccompprofileapi.ActAllow,
 							Names:  []string{"a"},
@@ -313,7 +313,7 @@ func TestAllowProfile(t *testing.T) {
 			},
 			profile: &seccompprofileapi.SeccompProfile{
 				Spec: seccompprofileapi.SeccompProfileSpec{
-					Syscalls: []*seccompprofileapi.Syscall{
+					Syscalls: []seccompprofileapi.Syscall{
 						{
 							Action: seccompprofileapi.ActAllow,
 							Names:  []string{},
@@ -331,7 +331,7 @@ func TestAllowProfile(t *testing.T) {
 			},
 			profile: &seccompprofileapi.SeccompProfile{
 				Spec: seccompprofileapi.SeccompProfileSpec{
-					Syscalls: []*seccompprofileapi.Syscall{
+					Syscalls: []seccompprofileapi.Syscall{
 						{
 							Action: seccompprofileapi.ActAllow,
 							Names:  []string{"b"},
@@ -349,7 +349,7 @@ func TestAllowProfile(t *testing.T) {
 			},
 			profile: &seccompprofileapi.SeccompProfile{
 				Spec: seccompprofileapi.SeccompProfileSpec{
-					Syscalls: []*seccompprofileapi.Syscall{
+					Syscalls: []seccompprofileapi.Syscall{
 						{
 							Action: seccompprofileapi.ActAllow,
 							Names:  []string{"d"},
@@ -367,7 +367,7 @@ func TestAllowProfile(t *testing.T) {
 			},
 			profile: &seccompprofileapi.SeccompProfile{
 				Spec: seccompprofileapi.SeccompProfileSpec{
-					Syscalls: []*seccompprofileapi.Syscall{
+					Syscalls: []seccompprofileapi.Syscall{
 						{
 							Action: seccompprofileapi.ActAllow,
 							Names:  []string{"a"},
@@ -393,7 +393,7 @@ func TestAllowProfile(t *testing.T) {
 			},
 			profile: &seccompprofileapi.SeccompProfile{
 				Spec: seccompprofileapi.SeccompProfileSpec{
-					Syscalls: []*seccompprofileapi.Syscall{
+					Syscalls: []seccompprofileapi.Syscall{
 						{
 							Action: seccompprofileapi.ActErrno,
 							Names:  []string{"a"},
@@ -455,7 +455,7 @@ func TestAllowProfile(t *testing.T) {
 			allowedSeccompActions: []seccompprofileapi.Action{seccompprofileapi.ActErrno},
 			profile: &seccompprofileapi.SeccompProfile{
 				Spec: seccompprofileapi.SeccompProfileSpec{
-					Syscalls: []*seccompprofileapi.Syscall{
+					Syscalls: []seccompprofileapi.Syscall{
 						{
 							Action: seccompprofileapi.ActAllow,
 							Names:  []string{"a"},
@@ -597,14 +597,14 @@ func TestResolveSyscallsForProfile(t *testing.T) {
 	for _, tc := range []struct {
 		name    string
 		prepare func(mock *seccompprofilefakes.FakeImpl) *seccompprofileapi.SeccompProfile
-		assert  func([]*seccompprofileapi.Syscall, error)
+		assert  func([]seccompprofileapi.Syscall, error)
 	}{
 		{
 			name: "success no base profile",
 			prepare: func(mock *seccompprofilefakes.FakeImpl) *seccompprofileapi.SeccompProfile {
 				return &seccompprofileapi.SeccompProfile{}
 			},
-			assert: func(syscalls []*seccompprofileapi.Syscall, err error) {
+			assert: func(syscalls []seccompprofileapi.Syscall, err error) {
 				require.NoError(t, err)
 				require.Empty(t, syscalls)
 			},
@@ -617,7 +617,7 @@ func TestResolveSyscallsForProfile(t *testing.T) {
 					&seccompprofileapi.SeccompProfile{
 						Spec: seccompprofileapi.SeccompProfileSpec{
 							BaseProfileName: "test",
-							Syscalls: []*seccompprofileapi.Syscall{
+							Syscalls: []seccompprofileapi.Syscall{
 								{Names: []string{"second"}},
 							},
 						},
@@ -627,7 +627,7 @@ func TestResolveSyscallsForProfile(t *testing.T) {
 					1,
 					&seccompprofileapi.SeccompProfile{
 						Spec: seccompprofileapi.SeccompProfileSpec{
-							Syscalls: []*seccompprofileapi.Syscall{
+							Syscalls: []seccompprofileapi.Syscall{
 								{Names: []string{"third"}},
 							},
 						},
@@ -637,13 +637,13 @@ func TestResolveSyscallsForProfile(t *testing.T) {
 				return &seccompprofileapi.SeccompProfile{
 					Spec: seccompprofileapi.SeccompProfileSpec{
 						BaseProfileName: "test",
-						Syscalls: []*seccompprofileapi.Syscall{
+						Syscalls: []seccompprofileapi.Syscall{
 							{Names: []string{"first"}},
 						},
 					},
 				}
 			},
-			assert: func(syscalls []*seccompprofileapi.Syscall, err error) {
+			assert: func(syscalls []seccompprofileapi.Syscall, err error) {
 				require.NoError(t, err)
 				require.Len(t, syscalls, 3)
 				require.Len(t, syscalls[0].Names, 1)
@@ -661,14 +661,14 @@ func TestResolveSyscallsForProfile(t *testing.T) {
 				mock.PullResultSeccompProfileReturnsOnCall(0, &seccompprofileapi.SeccompProfile{
 					Spec: seccompprofileapi.SeccompProfileSpec{
 						BaseProfileName: config.OCIProfilePrefix + "test-1",
-						Syscalls: []*seccompprofileapi.Syscall{
+						Syscalls: []seccompprofileapi.Syscall{
 							{Names: []string{"second"}},
 						},
 					},
 				})
 				mock.PullResultSeccompProfileReturnsOnCall(1, &seccompprofileapi.SeccompProfile{
 					Spec: seccompprofileapi.SeccompProfileSpec{
-						Syscalls: []*seccompprofileapi.Syscall{
+						Syscalls: []seccompprofileapi.Syscall{
 							{Names: []string{"third"}},
 						},
 					},
@@ -677,13 +677,13 @@ func TestResolveSyscallsForProfile(t *testing.T) {
 				return &seccompprofileapi.SeccompProfile{
 					Spec: seccompprofileapi.SeccompProfileSpec{
 						BaseProfileName: config.OCIProfilePrefix + "test-0",
-						Syscalls: []*seccompprofileapi.Syscall{
+						Syscalls: []seccompprofileapi.Syscall{
 							{Names: []string{"first"}},
 						},
 					},
 				}
 			},
-			assert: func(syscalls []*seccompprofileapi.Syscall, err error) {
+			assert: func(syscalls []seccompprofileapi.Syscall, err error) {
 				require.NoError(t, err)
 				require.Len(t, syscalls, 3)
 				require.Len(t, syscalls[0].Names, 1)
@@ -705,7 +705,7 @@ func TestResolveSyscallsForProfile(t *testing.T) {
 					},
 				}
 			},
-			assert: func(syscalls []*seccompprofileapi.Syscall, err error) {
+			assert: func(syscalls []seccompprofileapi.Syscall, err error) {
 				require.Error(t, err)
 			},
 		},
@@ -720,7 +720,7 @@ func TestResolveSyscallsForProfile(t *testing.T) {
 					},
 				}
 			},
-			assert: func(syscalls []*seccompprofileapi.Syscall, err error) {
+			assert: func(syscalls []seccompprofileapi.Syscall, err error) {
 				require.Error(t, err)
 				require.ErrorIs(t, err, errTest)
 			},
@@ -738,13 +738,13 @@ func TestResolveSyscallsForProfile(t *testing.T) {
 				return &seccompprofileapi.SeccompProfile{
 					Spec: seccompprofileapi.SeccompProfileSpec{
 						BaseProfileName: config.OCIProfilePrefix + "test",
-						Syscalls: []*seccompprofileapi.Syscall{
+						Syscalls: []seccompprofileapi.Syscall{
 							{Names: []string{"first"}},
 						},
 					},
 				}
 			},
-			assert: func(syscalls []*seccompprofileapi.Syscall, err error) {
+			assert: func(syscalls []seccompprofileapi.Syscall, err error) {
 				require.Error(t, err)
 			},
 		},
@@ -759,7 +759,7 @@ func TestResolveSyscallsForProfile(t *testing.T) {
 					},
 				}
 			},
-			assert: func(syscalls []*seccompprofileapi.Syscall, err error) {
+			assert: func(syscalls []seccompprofileapi.Syscall, err error) {
 				require.ErrorIs(t, err, errTest)
 			},
 		},

--- a/internal/pkg/manager/recordingmerger/merge_utils_test.go
+++ b/internal/pkg/manager/recordingmerger/merge_utils_test.go
@@ -83,7 +83,7 @@ func TestMergeProfiles(t *testing.T) {
 						Spec: seccompprofile.SeccompProfileSpec{
 							BaseProfileName: "part1",
 							DefaultAction:   seccompprofile.ActAllow,
-							Syscalls: []*seccompprofile.Syscall{
+							Syscalls: []seccompprofile.Syscall{
 								{
 									Names:  []string{"a", "b", "c"},
 									Action: seccompprofile.Action("foo"),
@@ -98,7 +98,7 @@ func TestMergeProfiles(t *testing.T) {
 						Spec: seccompprofile.SeccompProfileSpec{
 							BaseProfileName: "part1",
 							DefaultAction:   seccompprofile.ActAllow,
-							Syscalls: []*seccompprofile.Syscall{
+							Syscalls: []seccompprofile.Syscall{
 								{
 									Names:  []string{"c", "e", "d"},
 									Action: seccompprofile.Action("foo"),

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -977,10 +977,10 @@ func configureSeLinuxTag(secContext *corev1.SecurityContext, seLinuxTag string) 
 	secContext.SELinuxOptions.Type = seLinuxTag
 }
 
-func verbosityEnv(value uint) corev1.EnvVar {
+func verbosityEnv(value int32) corev1.EnvVar {
 	return corev1.EnvVar{
 		Name:  config.VerbosityEnvKey,
-		Value: strconv.FormatUint(uint64(value), 10),
+		Value: strconv.FormatInt(int64(value), 10),
 	}
 }
 

--- a/internal/pkg/util/union_syscalls.go
+++ b/internal/pkg/util/union_syscalls.go
@@ -25,7 +25,7 @@ import (
 	seccompprofile "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"
 )
 
-func UnionSyscalls(syscalls, appliedSyscalls []*seccompprofile.Syscall) ([]*seccompprofile.Syscall, error) {
+func UnionSyscalls(syscalls, appliedSyscalls []seccompprofile.Syscall) ([]seccompprofile.Syscall, error) {
 	if err := mergo.Merge(
 		&syscalls,
 		appliedSyscalls,

--- a/internal/pkg/util/union_syscalls_test.go
+++ b/internal/pkg/util/union_syscalls_test.go
@@ -29,26 +29,26 @@ func TestUnionSyscalls(t *testing.T) {
 
 	cases := []struct {
 		name            string
-		baseSyscalls    []*v1beta1.Syscall
-		appliedSyscalls []*v1beta1.Syscall
-		want            []*v1beta1.Syscall
+		baseSyscalls    []v1beta1.Syscall
+		appliedSyscalls []v1beta1.Syscall
+		want            []v1beta1.Syscall
 	}{
 		{
 			name:            "BothEmpty",
-			baseSyscalls:    []*v1beta1.Syscall{},
-			appliedSyscalls: []*v1beta1.Syscall{},
-			want:            []*v1beta1.Syscall{},
+			baseSyscalls:    []v1beta1.Syscall{},
+			appliedSyscalls: []v1beta1.Syscall{},
+			want:            []v1beta1.Syscall{},
 		},
 		{
 			name:         "BaseEmpty",
-			baseSyscalls: []*v1beta1.Syscall{},
-			appliedSyscalls: []*v1beta1.Syscall{
+			baseSyscalls: []v1beta1.Syscall{},
+			appliedSyscalls: []v1beta1.Syscall{
 				{
 					Names:  []string{"a", "b", "c"},
 					Action: v1beta1.Action("foo"),
 				},
 			},
-			want: []*v1beta1.Syscall{
+			want: []v1beta1.Syscall{
 				{
 					Names:  []string{"a", "b", "c"},
 					Action: v1beta1.Action("foo"),
@@ -57,14 +57,14 @@ func TestUnionSyscalls(t *testing.T) {
 		},
 		{
 			name: "AppliedEmpty",
-			baseSyscalls: []*v1beta1.Syscall{
+			baseSyscalls: []v1beta1.Syscall{
 				{
 					Names:  []string{"a", "b", "c"},
 					Action: v1beta1.Action("foo"),
 				},
 			},
-			appliedSyscalls: []*v1beta1.Syscall{},
-			want: []*v1beta1.Syscall{
+			appliedSyscalls: []v1beta1.Syscall{},
+			want: []v1beta1.Syscall{
 				{
 					Names:  []string{"a", "b", "c"},
 					Action: v1beta1.Action("foo"),
@@ -73,48 +73,48 @@ func TestUnionSyscalls(t *testing.T) {
 		},
 		{
 			name: "Args",
-			baseSyscalls: []*v1beta1.Syscall{
+			baseSyscalls: []v1beta1.Syscall{
 				{
 					Names:  []string{"a", "b", "c"},
 					Action: v1beta1.Action("foo"),
-					Args:   []*v1beta1.Arg{{Index: 1, Value: 2}},
+					Args:   []v1beta1.Arg{{Index: 1, Value: 2}},
 				},
 			},
-			appliedSyscalls: []*v1beta1.Syscall{
+			appliedSyscalls: []v1beta1.Syscall{
 				{
 					Names:  []string{"a", "b", "c"},
 					Action: v1beta1.Action("foo"),
-					Args:   []*v1beta1.Arg{{Index: 2, Value: 3}},
+					Args:   []v1beta1.Arg{{Index: 2, Value: 3}},
 				},
 			},
-			want: []*v1beta1.Syscall{
+			want: []v1beta1.Syscall{
 				{
 					Names:  []string{"a", "b", "c"},
 					Action: v1beta1.Action("foo"),
-					Args:   []*v1beta1.Arg{{Index: 1, Value: 2}},
+					Args:   []v1beta1.Arg{{Index: 1, Value: 2}},
 				},
 				{
 					Names:  []string{"a", "b", "c"},
 					Action: v1beta1.Action("foo"),
-					Args:   []*v1beta1.Arg{{Index: 2, Value: 3}},
+					Args:   []v1beta1.Arg{{Index: 2, Value: 3}},
 				},
 			},
 		},
 		{
 			name: "UniqueActions",
-			baseSyscalls: []*v1beta1.Syscall{
+			baseSyscalls: []v1beta1.Syscall{
 				{
 					Names:  []string{"a", "b", "c"},
 					Action: v1beta1.Action("foo"),
 				},
 			},
-			appliedSyscalls: []*v1beta1.Syscall{
+			appliedSyscalls: []v1beta1.Syscall{
 				{
 					Names:  []string{"a", "b", "c"},
 					Action: v1beta1.Action("bar"),
 				},
 			},
-			want: []*v1beta1.Syscall{
+			want: []v1beta1.Syscall{
 				{
 					Names:  []string{"a", "b", "c"},
 					Action: v1beta1.Action("bar"),
@@ -127,19 +127,19 @@ func TestUnionSyscalls(t *testing.T) {
 		},
 		{
 			name: "OverlappingActionsWithUniqueNames",
-			baseSyscalls: []*v1beta1.Syscall{
+			baseSyscalls: []v1beta1.Syscall{
 				{
 					Names:  []string{"a", "c", "b"},
 					Action: v1beta1.Action("foo"),
 				},
 			},
-			appliedSyscalls: []*v1beta1.Syscall{
+			appliedSyscalls: []v1beta1.Syscall{
 				{
 					Names:  []string{"d", "f", "e"},
 					Action: v1beta1.Action("foo"),
 				},
 			},
-			want: []*v1beta1.Syscall{
+			want: []v1beta1.Syscall{
 				{
 					Names:  []string{"a", "b", "c"},
 					Action: v1beta1.Action("foo"),
@@ -152,7 +152,7 @@ func TestUnionSyscalls(t *testing.T) {
 		},
 		{
 			name: "OverlappingActionsWithOverlappingNames",
-			baseSyscalls: []*v1beta1.Syscall{
+			baseSyscalls: []v1beta1.Syscall{
 				{
 					Names:  []string{"a", "b", "c"},
 					Action: v1beta1.Action("foo"),
@@ -162,7 +162,7 @@ func TestUnionSyscalls(t *testing.T) {
 					Action: v1beta1.Action("bar"),
 				},
 			},
-			appliedSyscalls: []*v1beta1.Syscall{
+			appliedSyscalls: []v1beta1.Syscall{
 				{
 					Names:  []string{"b", "c", "d"},
 					Action: v1beta1.Action("foo"),
@@ -172,7 +172,7 @@ func TestUnionSyscalls(t *testing.T) {
 					Action: v1beta1.Action("bar"),
 				},
 			},
-			want: []*v1beta1.Syscall{
+			want: []v1beta1.Syscall{
 				{
 					Names:  []string{"x", "y", "z"},
 					Action: v1beta1.Action("bar"),


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

- Replace pointer-to-struct slice elements (`[]*Syscall`, `[]*Arg`, `[]*Flag`) with value slices (`[]Syscall`, `[]Arg`, `[]Flag`), removing non-idiomatic patterns that complicate deepcopy and serialization
- Replace `uint` and `uint64` fields with `int32`/`int64` per K8s API conventions (`Arg.Index`, `Arg.Value`, `Arg.ValueTwo`, `Syscall.ErrnoRet`, `SPODSpec.Verbosity`); K8s prohibits unsigned integers in APIs
- Add `+optional`/`+required` markers on all SeccompProfile fields (previously missing entirely)

#### Which issue(s) this PR fixes:

Part of #3195

#### Does this PR have test?

Existing unit tests updated to use value types and int fields.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Replace pointer slice elements with value types, unsigned integers with signed integers, and add optional/required markers on SeccompProfile API fields
```