### PR TITLE
Avoid overwrtiging existing apparmor profiles

### DIFF
--- a/internal/pkg/daemon/apparmorprofile/apparmor.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmor.go
@@ -21,15 +21,18 @@ import (
 )
 
 type aaProfileManager struct {
-	loadProfile   func(_ logr.Logger, _, _ string) (bool, error)
-	removeProfile func(_ logr.Logger, _ string) error
-	logger        logr.Logger
+	loadProfile       func(_ logr.Logger, _, _ string) (bool, error)
+	removeProfile     func(_ logr.Logger, _ string) error
+	checkProfileExist func(_ logr.Logger, _ string) bool
+
+	logger logr.Logger
 }
 
 func NewAppArmorProfileManager(logger logr.Logger) ProfileManager {
 	return &aaProfileManager{
-		loadProfile:   loadProfile,
-		removeProfile: removeProfile,
-		logger:        logger,
+		loadProfile:       loadProfile,
+		removeProfile:     removeProfile,
+		checkProfileExist: checkProfileExist,
+		logger:            logger,
 	}
 }

--- a/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
@@ -45,6 +45,7 @@ const (
 	targetProfileDir       string = "/etc/apparmor.d/"
 
 	errInvalidCustomResourceType string = "invalid CRD kind"
+	errProfileExists             string = "profile exists"
 )
 
 func (a *aaProfileManager) Enabled() bool {
@@ -82,6 +83,14 @@ func (a *aaProfileManager) InstallProfile(bp profilebasev1alpha1.StatusBaseUser)
 		return false, errors.New(errInvalidCustomResourceType)
 	}
 
+	// Avoid overwriting an existing profile first time when a new profile is installed.
+	// We check if already a profile with the same name already exists, and if so we bail
+	// out. This is to prevent an attack vector when someone wants to overwrite a well-known
+	// profile existing into a cluster node.
+	if profile.Generation == 1 && checkProfileExist(a.logger, profile.GetProfileName()) {
+		return false, errors.New(errProfileExists)
+	}
+
 	policy, err := crd2armor.GenerateProfile(profile.GetProfileName(), profile.Spec.ComplainMode, &profile.Spec.Abstract)
 	if err != nil {
 		return false, fmt.Errorf("generating raw apparmor profile: %w", err)
@@ -96,6 +105,20 @@ func (a *aaProfileManager) CustomResourceTypeName() string {
 
 func profileFilename(profileName string) string {
 	return strings.Trim(strings.ReplaceAll(profileName, "/", "."), ".")
+}
+
+// checkProfileExists checks if an profile is already loaded into the kernel
+func checkProfileExist(logger logr.Logger, profileName string) bool {
+	apparmor := aa.NewAppArmor(aa.WithLogger(logger))
+	loaded, err := apparmor.PolicyLoaded(profileName)
+	if err != nil {
+		logger.Info("cannot check policy status to detect if profile exists: %w", err)
+		return false
+	}
+	if loaded {
+		return true
+	}
+	return false
 }
 
 func loadProfile(logger logr.Logger, name, content string) (bool, error) {

--- a/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
@@ -107,17 +107,21 @@ func profileFilename(profileName string) string {
 	return strings.Trim(strings.ReplaceAll(profileName, "/", "."), ".")
 }
 
-// checkProfileExists checks if an profile is already loaded into the kernel
+// checkProfileExists checks if an profile is already loaded into the kernel.
 func checkProfileExist(logger logr.Logger, profileName string) bool {
 	apparmor := aa.NewAppArmor(aa.WithLogger(logger))
+
 	loaded, err := apparmor.PolicyLoaded(profileName)
 	if err != nil {
-		logger.Info("cannot check policy status to detect if profile exists: %w", err)
+		logger.Info("cannot check policy status: assumes profile doesn't exist",
+			"profile-name", profileName)
+
 		return false
 	}
 	if loaded {
 		return true
 	}
+
 	return false
 }
 

--- a/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
@@ -118,6 +118,7 @@ func checkProfileExist(logger logr.Logger, profileName string) bool {
 
 		return false
 	}
+
 	if loaded {
 		return true
 	}

--- a/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
@@ -87,7 +87,7 @@ func (a *aaProfileManager) InstallProfile(bp profilebasev1alpha1.StatusBaseUser)
 	// We check if already a profile with the same name already exists, and if so we bail
 	// out. This is to prevent an attack vector when someone wants to overwrite a well-known
 	// profile existing into a cluster node.
-	if profile.Generation == 1 && checkProfileExist(a.logger, profile.GetProfileName()) {
+	if profile.Generation == 1 && a.checkProfileExist(a.logger, profile.GetProfileName()) {
 		return false, errors.New(errProfileExists)
 	}
 

--- a/internal/pkg/daemon/apparmorprofile/apparmor_test.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmor_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
 	"sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1alpha1"
 	profilebasev1alpha1 "sigs.k8s.io/security-profiles-operator/api/profilebase/v1alpha1"
 	sec "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"

--- a/internal/pkg/daemon/apparmorprofile/apparmor_test.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmor_test.go
@@ -56,7 +56,7 @@ func TestInstallProfile(t *testing.T) {
 			name: "overwrite profile CRD",
 			sut: aaProfileManager{
 				loadProfile:       func(_ logr.Logger, _, _ string) (bool, error) { return false, nil },
-				checkProfileExist: func(_ logr.Logger, _ string) bool { return false },
+				checkProfileExist: func(_ logr.Logger, _ string) bool { return true },
 			},
 			profile: &v1alpha1.AppArmorProfile{ObjectMeta: metav1.ObjectMeta{
 				Generation: 1,

--- a/internal/pkg/daemon/apparmorprofile/apparmor_test.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmor_test.go
@@ -24,9 +24,8 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/require"
-	"sigs.k8s.io/controller-runtime/pkg/log"
-
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1alpha1"
 	profilebasev1alpha1 "sigs.k8s.io/security-profiles-operator/api/profilebase/v1alpha1"
 	sec "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"

--- a/internal/pkg/daemon/apparmorprofile/apparmor_test.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmor_test.go
@@ -26,12 +26,14 @@ import (
 	"github.com/stretchr/testify/require"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1alpha1"
 	profilebasev1alpha1 "sigs.k8s.io/security-profiles-operator/api/profilebase/v1alpha1"
 	sec "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"
 )
 
-var errInvalidCRD = errors.New("invalid CRD kind")
+var errInvalidCRD = errors.New(errInvalidCustomResourceType)
+var errApparmorProfileExists = errors.New(errProfileExists)
 
 func TestInstallProfile(t *testing.T) {
 	t.Parallel()
@@ -50,8 +52,22 @@ func TestInstallProfile(t *testing.T) {
 			wantErr: errInvalidCRD,
 		},
 		{
-			name:    "valid profile CRD",
-			sut:     aaProfileManager{loadProfile: func(_ logr.Logger, _, _ string) (bool, error) { return false, nil }},
+			name: "overwrite profile CRD",
+			sut: aaProfileManager{
+				loadProfile:       func(_ logr.Logger, _, _ string) (bool, error) { return false, nil },
+				checkProfileExist: func(_ logr.Logger, _ string) bool { return false },
+			},
+			profile: &v1alpha1.AppArmorProfile{ObjectMeta: metav1.ObjectMeta{
+				Generation: 1,
+			}},
+			wantErr: errApparmorProfileExists,
+		},
+		{
+			name: "valid profile CRD",
+			sut: aaProfileManager{
+				loadProfile:       func(_ logr.Logger, _, _ string) (bool, error) { return false, nil },
+				checkProfileExist: func(_ logr.Logger, _ string) bool { return false },
+			},
 			profile: &v1alpha1.AppArmorProfile{},
 		},
 	}

--- a/internal/pkg/daemon/apparmorprofile/apparmor_test.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmor_test.go
@@ -32,8 +32,10 @@ import (
 	sec "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1beta1"
 )
 
-var errInvalidCRD = errors.New(errInvalidCustomResourceType)
-var errApparmorProfileExists = errors.New(errProfileExists)
+var (
+	errInvalidCRD            = errors.New(errInvalidCustomResourceType)
+	errApparmorProfileExists = errors.New(errProfileExists)
+)
 
 func TestInstallProfile(t *testing.T) {
 	t.Parallel()

--- a/internal/pkg/daemon/apparmorprofile/apparmor_unsupported.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmor_unsupported.go
@@ -47,3 +47,7 @@ func loadProfile(logr.Logger, string, string) (bool, error) {
 func removeProfile(logr.Logger, string) error {
 	return errAppArmorNotSupported
 }
+
+func checkProfileExist(logr.Logger, string) bool {
+	return false
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This adds a measure in place to avoid overwriting existing apparmor profiles when a new profile
is first installed by checking the `Generation` field of the CRD. In this way, it always to 
update existing profiles which were already installed by the security-profiles operator.

This is a measure to prevent that an attacker will overwrite an existing profile which is already
loaded into the node to alter its permissions.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add a measure in place to avoid overwriting existing apparmor profile when a profile is first 
intalled.
```
