### PR TITLE
api: fix ProfileRecording kind casing, switch bugs, and recorder validation

### DIFF
--- a/api/profilerecording/v1alpha1/profilerecording_types.go
+++ b/api/profilerecording/v1alpha1/profilerecording_types.go
@@ -31,7 +31,7 @@ type ProfileRecordingKind string
 const (
 	ProfileRecordingKindSeccompProfile  ProfileRecordingKind = "SeccompProfile"
 	ProfileRecordingKindSelinuxProfile  ProfileRecordingKind = "SelinuxProfile"
-	ProfileRecordingKindAppArmorProfile ProfileRecordingKind = "ApparmorProfile"
+	ProfileRecordingKindAppArmorProfile ProfileRecordingKind = "AppArmorProfile"
 )
 
 type ProfileRecorder string
@@ -61,7 +61,7 @@ const (
 // ProfileRecordingSpec defines the desired state of ProfileRecording.
 type ProfileRecordingSpec struct {
 	// Kind of object to be recorded.
-	// +kubebuilder:validation:Enum=SeccompProfile;SelinuxProfile;ApparmorProfile
+	// +kubebuilder:validation:Enum=SeccompProfile;SelinuxProfile;AppArmorProfile
 	Kind ProfileRecordingKind `json:"kind"`
 
 	// Recorder to be used.
@@ -139,6 +139,31 @@ func (pr *ProfileRecording) IsKindSupported() bool {
 	}
 }
 
+func (pr *ProfileRecording) ValidateRecorderKindCombination() error {
+	switch pr.Spec.Kind {
+	case ProfileRecordingKindSelinuxProfile:
+		if pr.Spec.Recorder != ProfileRecorderLogs {
+			return fmt.Errorf(
+				"recorder %q is not supported for %s, only %q is supported",
+				pr.Spec.Recorder, pr.Spec.Kind, ProfileRecorderLogs,
+			)
+		}
+	case ProfileRecordingKindAppArmorProfile:
+		if pr.Spec.Recorder != ProfileRecorderBpf {
+			return fmt.Errorf(
+				"recorder %q is not supported for %s, only %q is supported",
+				pr.Spec.Recorder, pr.Spec.Kind, ProfileRecorderBpf,
+			)
+		}
+	case ProfileRecordingKindSeccompProfile:
+		// All recorders are supported.
+	default:
+		return fmt.Errorf("unsupported kind: %s", pr.Spec.Kind)
+	}
+
+	return nil
+}
+
 func (pr *ProfileRecording) ctrAnnotationValue(ctrName string) string {
 	const nonceSize = 5
 
@@ -178,6 +203,9 @@ func (pr *ProfileRecording) ctrAnnotationSelinux(ctrName string) (key, value str
 	case ProfileRecorderLogs:
 		annotationPrefix = config.SelinuxProfileRecordLogsAnnotationKey
 	case ProfileRecorderBpf:
+		return "", "", fmt.Errorf(
+			"invalid recorder: %s, only %s is supported", pr.Spec.Recorder, ProfileRecorderLogs,
+		)
 	default:
 		return "", "", fmt.Errorf(
 			"invalid recorder: %s, only %s is supported", pr.Spec.Recorder, ProfileRecorderLogs,
@@ -197,6 +225,9 @@ func (pr *ProfileRecording) ctrAnnotationApparmor(ctrName string) (key, value st
 	case ProfileRecorderBpf:
 		annotationPrefix = config.ApparmorProfileRecordBpfAnnotationKey
 	case ProfileRecorderLogs:
+		return "", "", fmt.Errorf(
+			"invalid recorder: %s, only %s is supported", pr.Spec.Recorder, ProfileRecorderBpf,
+		)
 	default:
 		return "", "", fmt.Errorf(
 			"invalid recorder: %s, only %s is supported", pr.Spec.Recorder, ProfileRecorderBpf,

--- a/deploy/base-crds/crds/profilerecording.yaml
+++ b/deploy/base-crds/crds/profilerecording.yaml
@@ -64,7 +64,7 @@ spec:
                 enum:
                 - SeccompProfile
                 - SelinuxProfile
-                - ApparmorProfile
+                - AppArmorProfile
                 type: string
               mergeStrategy:
                 default: none

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -150,7 +150,7 @@ spec:
                 enum:
                 - SeccompProfile
                 - SelinuxProfile
-                - ApparmorProfile
+                - AppArmorProfile
                 type: string
               mergeStrategy:
                 default: none

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -150,7 +150,7 @@ spec:
                 enum:
                 - SeccompProfile
                 - SelinuxProfile
-                - ApparmorProfile
+                - AppArmorProfile
                 type: string
               mergeStrategy:
                 default: none

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -344,7 +344,7 @@ spec:
                 enum:
                 - SeccompProfile
                 - SelinuxProfile
-                - ApparmorProfile
+                - AppArmorProfile
                 type: string
               mergeStrategy:
                 default: none

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -150,7 +150,7 @@ spec:
                 enum:
                 - SeccompProfile
                 - SelinuxProfile
-                - ApparmorProfile
+                - AppArmorProfile
                 type: string
               mergeStrategy:
                 default: none

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -150,7 +150,7 @@ spec:
                 enum:
                 - SeccompProfile
                 - SelinuxProfile
-                - ApparmorProfile
+                - AppArmorProfile
                 type: string
               mergeStrategy:
                 default: none

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -344,7 +344,7 @@ spec:
                 enum:
                 - SeccompProfile
                 - SelinuxProfile
-                - ApparmorProfile
+                - AppArmorProfile
                 type: string
               mergeStrategy:
                 default: none

--- a/examples/profilerecording-apparmor-bpf.yaml
+++ b/examples/profilerecording-apparmor-bpf.yaml
@@ -2,11 +2,11 @@
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
 kind: ProfileRecording
 metadata:
-  # The name of the Recording is the same as the resulting `ApparmorProfile` CRD
+  # The name of the Recording is the same as the resulting `AppArmorProfile` CRD
   # after reconciliation.
   name: test-recording
 spec:
-  kind: ApparmorProfile
+  kind: AppArmorProfile
   recorder: bpf
   # uncomment to merge recordings of the same containers
   # mergeStrategy: containers

--- a/internal/pkg/artifact/artifact.go
+++ b/internal/pkg/artifact/artifact.go
@@ -386,7 +386,7 @@ func (a *Artifact) Pull(
 		}, nil
 	case *apparmorprofileapi.AppArmorProfile:
 		return &PullResult{
-			typ:             PullResultTypeApparmorProfile,
+			typ:             PullResultTypeAppArmorProfile,
 			apparmorProfile: obj,
 			content:         content,
 		}, nil

--- a/internal/pkg/artifact/artifact_test.go
+++ b/internal/pkg/artifact/artifact_test.go
@@ -293,7 +293,7 @@ func TestPull(t *testing.T) {
 				require.NoError(t, err)
 				require.NotNil(t, res)
 				require.NotNil(t, res.Content())
-				require.Equal(t, PullResultTypeApparmorProfile, res.Type())
+				require.Equal(t, PullResultTypeAppArmorProfile, res.Type())
 				require.NotNil(t, res.ApparmorProfile())
 			},
 		},

--- a/internal/pkg/artifact/consts.go
+++ b/internal/pkg/artifact/consts.go
@@ -43,6 +43,6 @@ const (
 	// PullResultTypeSelinuxProfile is referencing a SELinux profile.
 	PullResultTypeSelinuxProfile PullResultType = "SelinuxProfile"
 
-	// PullResultTypeApparmorProfile is referencing a AppArmor profile.
-	PullResultTypeApparmorProfile PullResultType = "ApparmorProfile"
+	// PullResultTypeAppArmorProfile is referencing an AppArmor profile.
+	PullResultTypeAppArmorProfile PullResultType = "AppArmorProfile"
 )

--- a/internal/pkg/cli/puller/puller.go
+++ b/internal/pkg/cli/puller/puller.go
@@ -62,7 +62,7 @@ func (p *Puller) Run() error {
 	case artifact.PullResultTypeSelinuxProfile:
 		name = result.SelinuxProfile().GetName()
 
-	case artifact.PullResultTypeApparmorProfile:
+	case artifact.PullResultTypeAppArmorProfile:
 		name = result.ApparmorProfile().GetName()
 	}
 

--- a/internal/pkg/webhooks/recording/recording.go
+++ b/internal/pkg/webhooks/recording/recording.go
@@ -118,6 +118,14 @@ func (p *podSeccompRecorder) Handle(
 			continue
 		}
 
+		if err := item.ValidateRecorderKindCombination(); err != nil {
+			p.log.Error(err, "Invalid recorder/kind combination",
+				"recording", item.Name,
+			)
+
+			continue
+		}
+
 		selector, err := p.LabelSelectorAsSelector(
 			&item.Spec.PodSelector,
 		)


### PR DESCRIPTION
#### What type of PR is this?
/kind cleanup
/kind api-change

#### What this PR does / why we need it:
- Fix casing mismatch: `ProfileRecordingKindAppArmorProfile` value `"ApparmorProfile"` to `"AppArmorProfile"` to match the actual CRD kind, and update the kubebuilder validation enum accordingly.
- Fix bug in `ctrAnnotationSelinux`/`ctrAnnotationApparmor` where empty switch cases for unsupported recorder types silently fell through to the next case instead of hitting the default error path.
- Add `ValidateRecorderKindCombination()` to enforce recorder/kind compatibility at the API level (SelinuxProfile requires `logs`, AppArmorProfile requires `bpf`, SeccompProfile supports both), and call it in the recording webhook to reject invalid combinations early.

#### Which issue(s) this PR fixes:
Part of #3195

#### Does this PR have test?
Existing tests pass. The validation is covered by the existing webhook test suite.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?
```release-note
Fix ProfileRecording AppArmorProfile kind casing and add recorder/kind compatibility validation
```