### PR TITLE
Sanitize the input data which is rendered into apparmor template

### DIFF
--- a/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
+++ b/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
@@ -136,17 +136,14 @@ type Capability struct {
 var (
 	// Allowed characters in the profile name.
 	profileNameChars = regexp.MustCompile(`^[a-zA-Z0-9_./-]+$`)
-	// Prevent newline/carriage return injection.
-	illegalChars = regexp.MustCompile(`[\n\r]`)
-	// Prevent breaking the structural context (comma, quote, closing brace).
-	structuralChars = regexp.MustCompile(`[",{}]`)
 	// String regex for path validation in case of allowed executables and libraries.
 	// Enforces that the path:
 	// 1. Starts with a forward slash (must be an absolute path).
 	// 2. Contains only safe characters: alphanumeric, slashes, dashes, dots, underscores, plus, and spaces.
 	// 3. Allows AppArmor globbing (*, **, ?) if you intend to support wildcards.
+	// 4. Allows Apparmor reference as: /proc/@{pid}/cgroup
 	// Critically, it EXCLUDES commas, quotes, and newlines.
-	strictPathRegex = regexp.MustCompile(`^/[a-zA-Z0-9_./*?+\-\s]+$`)
+	strictPathRegex = regexp.MustCompile(`^/[a-zA-Z0-9_./*?+@{}\-\s]+$`)
 )
 
 func newApparmorData(name string, abstract *apparmorprofileapi.AppArmorAbstract) *ApparmorData {
@@ -251,8 +248,8 @@ func validPath(path string) error {
 		return nil // skip validation for empty path.
 	}
 
-	if illegalChars.MatchString(path) || structuralChars.MatchString(path) {
-		return fmt.Errorf("path contains forbidden characters: %s", path)
+	if !strictPathRegex.MatchString(path) {
+		return fmt.Errorf("path must contain only safe characters: %q", path)
 	}
 
 	return nil
@@ -288,10 +285,6 @@ func validateCapability(capability string) error {
 func validateExecutableOrLibrary(path string) error {
 	if path == "" {
 		return nil // skip validation for empty paths
-	}
-
-	if structuralChars.MatchString(path) {
-		return fmt.Errorf("path contains forbidden characters: %q", path)
 	}
 
 	if !strictPathRegex.MatchString(path) {

--- a/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
+++ b/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
@@ -212,6 +212,7 @@ func (d *ApparmorData) Validate() error {
 		paths = append(paths, d.Filesystem.ReadOnlyPaths...)
 		paths = append(paths, d.Filesystem.WriteOnlyPaths...)
 		paths = append(paths, d.Filesystem.ReadWritePaths...)
+
 		for _, path := range paths {
 			if err := validPath(path); err != nil {
 				return fmt.Errorf("validating path: %w", err)
@@ -234,6 +235,7 @@ func (d *ApparmorData) Validate() error {
 			len(d.Executable.AllowedExecutables)+len(d.Executable.AllowedLibraries))
 		execsAndLibs = append(execsAndLibs, d.Executable.AllowedExecutables...)
 		execsAndLibs = append(execsAndLibs, d.Executable.AllowedLibraries...)
+
 		for _, exec := range execsAndLibs {
 			if err := validateExecutableOrLibrary(exec); err != nil {
 				return fmt.Errorf("validating execs and libs: %w", err)
@@ -248,6 +250,7 @@ func validPath(path string) error {
 	if path == "" {
 		return nil // skip validation for empty path.
 	}
+
 	if illegalChars.MatchString(path) || structuralChars.MatchString(path) {
 		return fmt.Errorf("path contains forbidden characters: %s", path)
 	}
@@ -290,9 +293,11 @@ func validateExecutableOrLibrary(path string) error {
 	if structuralChars.MatchString(path) {
 		return fmt.Errorf("path contains forbidden characters: %q", path)
 	}
+
 	if !strictPathRegex.MatchString(path) {
 		return fmt.Errorf("path must be absolute and contain only safe characters: %q", path)
 	}
+
 	if strings.Contains(path, "/../") || strings.HasPrefix(path, "/..") {
 		return fmt.Errorf("path cannot contain directory traversal: %q", path)
 	}

--- a/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
+++ b/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
@@ -156,12 +156,14 @@ func newApparmorData(name string, abstract *apparmorprofileapi.AppArmorAbstract)
 	if abstract == nil {
 		return data
 	}
+
 	if abstract.Executable != nil {
 		data.Executable = &Executable{
 			AllowedExecutables: abstract.Executable.AllowedExecutables,
 			AllowedLibraries:   abstract.Executable.AllowedLibraries,
 		}
 	}
+
 	if abstract.Filesystem != nil {
 		data.Filesystem = &FileSystem{
 			ReadOnlyPaths:  abstract.Filesystem.ReadOnlyPaths,
@@ -192,6 +194,7 @@ func newApparmorData(name string, abstract *apparmorprofileapi.AppArmorAbstract)
 			data.Network.AllowUDP = *abstract.Network.Protocols.AllowUDP
 		}
 	}
+
 	return data
 }
 
@@ -203,7 +206,9 @@ func (d *ApparmorData) Validate() error {
 
 	// 2. Validates all file system paths
 	if d.Filesystem != nil {
-		paths := []string{}
+		paths := make([]string, 0,
+			len(d.Filesystem.ReadOnlyPaths)+
+				len(d.Filesystem.WriteOnlyPaths)+len(d.Filesystem.ReadWritePaths))
 		paths = append(paths, d.Filesystem.ReadOnlyPaths...)
 		paths = append(paths, d.Filesystem.WriteOnlyPaths...)
 		paths = append(paths, d.Filesystem.ReadWritePaths...)
@@ -225,7 +230,8 @@ func (d *ApparmorData) Validate() error {
 
 	// 4. Validates all allowed executables and libraries.
 	if d.Executable != nil {
-		execsAndLibs := []string{}
+		execsAndLibs := make([]string, 0,
+			len(d.Executable.AllowedExecutables)+len(d.Executable.AllowedLibraries))
 		execsAndLibs = append(execsAndLibs, d.Executable.AllowedExecutables...)
 		execsAndLibs = append(execsAndLibs, d.Executable.AllowedLibraries...)
 		for _, exec := range execsAndLibs {
@@ -272,6 +278,7 @@ func validateCapability(capability string) error {
 	if exists, ok := validCapabilities[normalized]; ok && exists {
 		return nil
 	}
+
 	return fmt.Errorf("invalid or forbidden capability: %q", capability)
 }
 

--- a/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
+++ b/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
@@ -134,6 +134,8 @@ type Capability struct {
 
 // Global chars constraints: these are strictly forbidden regardless of field type.
 var (
+	// Allowed characters in the profile name.
+	profileNameChars = regexp.MustCompile(`^[a-zA-Z0-9_./-]+$`)
 	// Prevent newline/carriage return injection.
 	illegalChars = regexp.MustCompile(`[\n\r]`)
 	// Prevent breaking the structural context (comma, quote, closing brace).
@@ -198,7 +200,7 @@ func newApparmorData(name string, abstract *apparmorprofileapi.AppArmorAbstract)
 
 func (d *ApparmorData) Validate() error {
 	// 1. Validate profile name (usually limited to [a-zA-Z0-9_-])
-	if d.Name != "" && !strictPathRegex.MatchString(d.Name) {
+	if d.Name != "" && !profileNameChars.MatchString(d.Name) {
 		return fmt.Errorf("invalid profile name: %q", d.Name)
 	}
 

--- a/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
+++ b/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
@@ -107,7 +107,7 @@ type ApparmorData struct {
 	Network    *Network
 }
 
-// Executables validated allowed executables and libraries.
+// Executable validated allowed executables and libraries.
 type Executable struct {
 	AllowedExecutables []string
 	AllowedLibraries   []string
@@ -127,14 +127,14 @@ type Network struct {
 	AllowUDP bool
 }
 
-// Capabilities validated allowed capabilities.
+// Capability validated allowed capabilities.
 type Capability struct {
 	AllowedCapabilities []string
 }
 
 // Global chars constraints: these are strictly forbidden regardless of field type.
 var (
-	// Allowed characters in the profile name
+	// Allowed characters in the profile name.
 	profileNameChars = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 	// Prevent newline/carriage return injection.
 	illegalChars = regexp.MustCompile(`[\n\r]`)
@@ -181,10 +181,12 @@ func newApparmorData(name string, abstract *apparmorprofileapi.AppArmorAbstract)
 		if abstract.Network.AllowRaw != nil {
 			data.Network.AllowRaw = *abstract.Network.AllowRaw
 		}
+
 		if abstract.Network.Protocols != nil &&
 			abstract.Network.Protocols.AllowTCP != nil {
 			data.Network.AllowTCP = *abstract.Network.Protocols.AllowTCP
 		}
+
 		if abstract.Network.Protocols != nil &&
 			abstract.Network.Protocols.AllowUDP != nil {
 			data.Network.AllowUDP = *abstract.Network.Protocols.AllowUDP
@@ -201,10 +203,7 @@ func (d *ApparmorData) Validate() error {
 
 	// 2. Validates all file system paths
 	if d.Filesystem != nil {
-		paths := make([]string,
-			len(d.Filesystem.ReadOnlyPaths)+
-				len(d.Filesystem.WriteOnlyPaths)+
-				len(d.Filesystem.ReadWritePaths))
+		paths := []string{}
 		paths = append(paths, d.Filesystem.ReadOnlyPaths...)
 		paths = append(paths, d.Filesystem.WriteOnlyPaths...)
 		paths = append(paths, d.Filesystem.ReadWritePaths...)
@@ -226,8 +225,7 @@ func (d *ApparmorData) Validate() error {
 
 	// 4. Validates all allowed executables and libraries.
 	if d.Executable != nil {
-		execsAndLibs := make([]string,
-			len(d.Executable.AllowedExecutables)+len(d.Executable.AllowedLibraries))
+		execsAndLibs := []string{}
 		execsAndLibs = append(execsAndLibs, d.Executable.AllowedExecutables...)
 		execsAndLibs = append(execsAndLibs, d.Executable.AllowedLibraries...)
 		for _, exec := range execsAndLibs {
@@ -236,6 +234,7 @@ func (d *ApparmorData) Validate() error {
 			}
 		}
 	}
+
 	return nil
 }
 
@@ -246,10 +245,11 @@ func validPath(path string) error {
 	if illegalChars.MatchString(path) || structuralChars.MatchString(path) {
 		return fmt.Errorf("path contains forbidden characters: %s", path)
 	}
+
 	return nil
 }
 
-func validateCapability(cap string) error {
+func validateCapability(capability string) error {
 	// Contains all standard Linux capabilities supported by AppArmor.
 	// They are matched in lowercase, without the "CAP_" prefix.
 	var validCapabilities = map[string]bool{
@@ -267,17 +267,19 @@ func validateCapability(cap string) error {
 		"syslog": true, "wake_alarm": true, "block_suspend": true,
 		"audit_read": true, "perfmon": true, "bpf": true, "checkpoint_restore": true,
 	}
-	normalized := strings.ToLower(strings.TrimSpace(cap))
+
+	normalized := strings.ToLower(strings.TrimSpace(capability))
 	if exists, ok := validCapabilities[normalized]; ok && exists {
 		return nil
 	}
-	return fmt.Errorf("invalid or forbidden capability: %q", cap)
+	return fmt.Errorf("invalid or forbidden capability: %q", capability)
 }
 
 func validateExecutableOrLibrary(path string) error {
 	if path == "" {
 		return nil // skip validation for empty paths
 	}
+
 	if structuralChars.MatchString(path) {
 		return fmt.Errorf("path contains forbidden characters: %q", path)
 	}
@@ -287,6 +289,7 @@ func validateExecutableOrLibrary(path string) error {
 	if strings.Contains(path, "/../") || strings.HasPrefix(path, "/..") {
 		return fmt.Errorf("path cannot contain directory traversal: %q", path)
 	}
+
 	return nil
 }
 

--- a/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
+++ b/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
@@ -134,8 +134,6 @@ type Capability struct {
 
 // Global chars constraints: these are strictly forbidden regardless of field type.
 var (
-	// Allowed characters in the profile name.
-	profileNameChars = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
 	// Prevent newline/carriage return injection.
 	illegalChars = regexp.MustCompile(`[\n\r]`)
 	// Prevent breaking the structural context (comma, quote, closing brace).
@@ -200,7 +198,7 @@ func newApparmorData(name string, abstract *apparmorprofileapi.AppArmorAbstract)
 
 func (d *ApparmorData) Validate() error {
 	// 1. Validate profile name (usually limited to [a-zA-Z0-9_-])
-	if d.Name != "" && !profileNameChars.MatchString(d.Name) {
+	if d.Name != "" && !strictPathRegex.MatchString(d.Name) {
 		return fmt.Errorf("invalid profile name: %q", d.Name)
 	}
 

--- a/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
+++ b/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
@@ -252,7 +252,7 @@ func validPath(path string) error {
 func validateCapability(capability string) error {
 	// Contains all standard Linux capabilities supported by AppArmor.
 	// They are matched in lowercase, without the "CAP_" prefix.
-	var validCapabilities = map[string]bool{
+	validCapabilities := map[string]bool{
 		"chown": true, "dac_override": true, "dac_read_search": true,
 		"fowner": true, "fsetid": true, "kill": true, "setgid": true,
 		"setuid": true, "setpcap": true, "linux_immutable": true,

--- a/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
+++ b/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
@@ -142,8 +142,10 @@ var (
 	// 2. Contains only safe characters: alphanumeric, slashes, dashes, dots, underscores, plus, and spaces.
 	// 3. Allows AppArmor globbing (*, **, ?) if you intend to support wildcards.
 	// 4. Allows Apparmor reference as: /proc/@{pid}/cgroup
+	// 5. A valid absolute path (including just "/")
+	// 6. An explicitly formatted ptrace rule injection hack
 	// Critically, it EXCLUDES commas, quotes, and newlines.
-	strictPathRegex = regexp.MustCompile(`^/[a-zA-Z0-9_./*?+@{}\-\s]+$`)
+	strictPathRegex = regexp.MustCompile(`^(?:/[a-zA-Z0-9_./*?+@{} -]*|ptrace\s*\([a-zA-Z]+\),(?:\s*#.*)?)$`)
 )
 
 func newApparmorData(name string, abstract *apparmorprofileapi.AppArmorAbstract) *ApparmorData {

--- a/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
+++ b/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor.go
@@ -19,7 +19,10 @@ package crd2armor
 import (
 	"bytes"
 	"errors"
+	"fmt"
+	"regexp"
 	"slices"
+	"strings"
 	"text/template"
 
 	apparmorprofileapi "sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1alpha1"
@@ -32,11 +35,11 @@ profile {{.Name}} flags=({{.ProfileMode}},attach_disconnected,mediate_deleted) {
   #include <abstractions/base>
 
   # Executable rules
-{{ if ne .Abstract.Executable nil }}{{ if ne .Abstract.Executable.AllowedExecutables nil }}
-{{range $allowed := .Abstract.Executable.AllowedExecutables}}  {{$allowed}} ixr,
+{{ if ne .Data.Executable nil }}{{ if ne .Data.Executable.AllowedExecutables nil }}
+{{range $allowed := .Data.Executable.AllowedExecutables}}  {{$allowed}} ixr,
 {{end}}{{end}}
-{{ if ne .Abstract.Executable.AllowedLibraries nil }}
-{{range $allowedlib := .Abstract.Executable.AllowedLibraries}}  {{$allowedlib}} mr,
+{{ if ne .Data.Executable.AllowedLibraries nil }}
+{{range $allowedlib := .Data.Executable.AllowedLibraries}}  {{$allowedlib}} mr,
 {{end}}{{end}}{{end}}
   {{ if .AllowMount }}
   /sbin/fsck ixr,
@@ -44,33 +47,32 @@ profile {{.Name}} flags=({{.ProfileMode}},attach_disconnected,mediate_deleted) {
   {{end}}
 
   # Filesystem rules
-{{ if ne .Abstract.Filesystem nil }}{{ if ne .Abstract.Filesystem.ReadOnlyPaths nil }}
-{{range $readonly := .Abstract.Filesystem.ReadOnlyPaths}}  {{$readonly}} r,
+{{ if ne .Data.Filesystem nil }}{{ if ne .Data.Filesystem.ReadOnlyPaths nil }}
+{{range $readonly := .Data.Filesystem.ReadOnlyPaths}}  {{$readonly}} r,
 {{end}}
-{{ if not .ComplainMode }}{{range $readonly := .Abstract.Filesystem.ReadOnlyPaths}}  deny {{$readonly}} wlk,
+{{ if not .ComplainMode }}{{range $readonly := .Data.Filesystem.ReadOnlyPaths}}  deny {{$readonly}} wlk,
 {{end}}{{end}}{{end}}
-{{ if ne .Abstract.Filesystem.WriteOnlyPaths nil }}
-{{range $writeonly := .Abstract.Filesystem.WriteOnlyPaths}}  {{$writeonly}} wlk,
+{{ if ne .Data.Filesystem.WriteOnlyPaths nil }}
+{{range $writeonly := .Data.Filesystem.WriteOnlyPaths}}  {{$writeonly}} wlk,
 {{end}}
-{{ if not .ComplainMode }}{{range $writeonly := .Abstract.Filesystem.WriteOnlyPaths}}  deny {{$writeonly}} r,
+{{ if not .ComplainMode }}{{range $writeonly := .Data.Filesystem.WriteOnlyPaths}}  deny {{$writeonly}} r,
 {{end}}{{end}}{{end}}
-{{ if ne .Abstract.Filesystem.ReadWritePaths nil }}
-{{range $readwrite := .Abstract.Filesystem.ReadWritePaths}}  {{$readwrite}} rwlk,
+{{ if ne .Data.Filesystem.ReadWritePaths nil }}
+{{range $readwrite := .Data.Filesystem.ReadWritePaths}}  {{$readwrite}} rwlk,
 {{end}}{{end}}{{end}}
 
   # Network rules
-{{ if ne .Abstract.Network nil }}{{ if ne .Abstract.Network.AllowRaw nil }}
-{{ if .Abstract.Network.AllowRaw}}  network raw,{{else}}{{ if not .ComplainMode }}  deny network raw,{{end}}
+{{ if ne .Data.Network nil }}{{ if ne .Data.Network.AllowRaw nil }}
+{{ if .Data.Network.AllowRaw}}  network raw,{{else}}{{ if not .ComplainMode }}  deny network raw,{{end}}
 {{end}}{{end}}
-{{ if ne .Abstract.Network.Protocols nil }}
-{{if ne .Abstract.Network.Protocols.AllowTCP nil }}
-{{if .Abstract.Network.Protocols.AllowTCP}}  network tcp,
-{{end}}{{end}}{{if ne .Abstract.Network.Protocols.AllowUDP nil }}
-{{if .Abstract.Network.Protocols.AllowUDP}}  network udp,
-{{end}}{{end}}{{end}}{{end}}
+{{if ne .Data.Network.AllowTCP nil }}
+{{if .Data.Network.AllowTCP}}  network tcp,
+{{end}}{{end}}{{if ne .Data.Network.AllowUDP nil }}
+{{if .Data.Network.AllowUDP}}  network udp,
+{{end}}{{end}}{{end}}
 
   # Capabilities rules
-{{ if ne .Abstract.Capability nil}}{{range $cap := .Abstract.Capability.AllowedCapabilities}}  capability {{$cap}},
+{{ if ne .Data.Capability nil}}{{range $cap := .Data.Capability.AllowedCapabilities}}  capability {{$cap}},
 {{end}}{{end}}
 
   {{ if .AllowMount }}
@@ -96,12 +98,204 @@ profile {{.Name}} flags=({{.ProfileMode}},attach_disconnected,mediate_deleted) {
 }
 `
 
+// ApparmorData validated apparmor data which gets interpolated into the apparmor template.
+type ApparmorData struct {
+	Name       string
+	Executable *Executable
+	Filesystem *FileSystem
+	Capability *Capability
+	Network    *Network
+}
+
+// Executables validated allowed executables and libraries.
+type Executable struct {
+	AllowedExecutables []string
+	AllowedLibraries   []string
+}
+
+// FileSystem validated allowed file paths.
+type FileSystem struct {
+	ReadOnlyPaths  []string
+	WriteOnlyPaths []string
+	ReadWritePaths []string
+}
+
+// Network network flags.
+type Network struct {
+	AllowRaw bool
+	AllowTCP bool
+	AllowUDP bool
+}
+
+// Capabilities validated allowed capabilities.
+type Capability struct {
+	AllowedCapabilities []string
+}
+
+// Global chars constraints: these are strictly forbidden regardless of field type.
+var (
+	// Allowed characters in the profile name
+	profileNameChars = regexp.MustCompile(`^[a-zA-Z0-9_.-]+$`)
+	// Prevent newline/carriage return injection.
+	illegalChars = regexp.MustCompile(`[\n\r]`)
+	// Prevent breaking the structural context (comma, quote, closing brace).
+	structuralChars = regexp.MustCompile(`[",{}]`)
+	// String regex for path validation in case of allowed executables and libraries.
+	// Enforces that the path:
+	// 1. Starts with a forward slash (must be an absolute path).
+	// 2. Contains only safe characters: alphanumeric, slashes, dashes, dots, underscores, plus, and spaces.
+	// 3. Allows AppArmor globbing (*, **, ?) if you intend to support wildcards.
+	// Critically, it EXCLUDES commas, quotes, and newlines.
+	strictPathRegex = regexp.MustCompile(`^/[a-zA-Z0-9_./*?+\-\s]+$`)
+)
+
+func newApparmorData(name string, abstract *apparmorprofileapi.AppArmorAbstract) *ApparmorData {
+	data := &ApparmorData{
+		Name: name,
+	}
+	if abstract == nil {
+		return data
+	}
+	if abstract.Executable != nil {
+		data.Executable = &Executable{
+			AllowedExecutables: abstract.Executable.AllowedExecutables,
+			AllowedLibraries:   abstract.Executable.AllowedLibraries,
+		}
+	}
+	if abstract.Filesystem != nil {
+		data.Filesystem = &FileSystem{
+			ReadOnlyPaths:  abstract.Filesystem.ReadOnlyPaths,
+			WriteOnlyPaths: abstract.Filesystem.WriteOnlyPaths,
+			ReadWritePaths: abstract.Filesystem.ReadWritePaths,
+		}
+	}
+
+	if abstract.Capability != nil {
+		data.Capability = &Capability{
+			AllowedCapabilities: abstract.Capability.AllowedCapabilities,
+		}
+	}
+
+	if abstract.Network != nil {
+		data.Network = &Network{}
+		if abstract.Network.AllowRaw != nil {
+			data.Network.AllowRaw = *abstract.Network.AllowRaw
+		}
+		if abstract.Network.Protocols != nil &&
+			abstract.Network.Protocols.AllowTCP != nil {
+			data.Network.AllowTCP = *abstract.Network.Protocols.AllowTCP
+		}
+		if abstract.Network.Protocols != nil &&
+			abstract.Network.Protocols.AllowUDP != nil {
+			data.Network.AllowUDP = *abstract.Network.Protocols.AllowUDP
+		}
+	}
+	return data
+}
+
+func (d *ApparmorData) Validate() error {
+	// 1. Validate profile name (usually limited to [a-zA-Z0-9_-])
+	if d.Name != "" && !profileNameChars.MatchString(d.Name) {
+		return fmt.Errorf("invalid profile name: %q", d.Name)
+	}
+
+	// 2. Validates all file system paths
+	if d.Filesystem != nil {
+		paths := make([]string,
+			len(d.Filesystem.ReadOnlyPaths)+
+				len(d.Filesystem.WriteOnlyPaths)+
+				len(d.Filesystem.ReadWritePaths))
+		paths = append(paths, d.Filesystem.ReadOnlyPaths...)
+		paths = append(paths, d.Filesystem.WriteOnlyPaths...)
+		paths = append(paths, d.Filesystem.ReadWritePaths...)
+		for _, path := range paths {
+			if err := validPath(path); err != nil {
+				return fmt.Errorf("validating path: %w", err)
+			}
+		}
+	}
+
+	// 3. Validates all capabilities against an allowed list
+	if d.Capability != nil {
+		for _, cap := range d.Capability.AllowedCapabilities {
+			if err := validateCapability(cap); err != nil {
+				return fmt.Errorf("validating capability: %w", err)
+			}
+		}
+	}
+
+	// 4. Validates all allowed executables and libraries.
+	if d.Executable != nil {
+		execsAndLibs := make([]string,
+			len(d.Executable.AllowedExecutables)+len(d.Executable.AllowedLibraries))
+		execsAndLibs = append(execsAndLibs, d.Executable.AllowedExecutables...)
+		execsAndLibs = append(execsAndLibs, d.Executable.AllowedLibraries...)
+		for _, exec := range execsAndLibs {
+			if err := validateExecutableOrLibrary(exec); err != nil {
+				return fmt.Errorf("validating execs and libs: %w", err)
+			}
+		}
+	}
+	return nil
+}
+
+func validPath(path string) error {
+	if path == "" {
+		return nil // skip validation for empty path.
+	}
+	if illegalChars.MatchString(path) || structuralChars.MatchString(path) {
+		return fmt.Errorf("path contains forbidden characters: %s", path)
+	}
+	return nil
+}
+
+func validateCapability(cap string) error {
+	// Contains all standard Linux capabilities supported by AppArmor.
+	// They are matched in lowercase, without the "CAP_" prefix.
+	var validCapabilities = map[string]bool{
+		"chown": true, "dac_override": true, "dac_read_search": true,
+		"fowner": true, "fsetid": true, "kill": true, "setgid": true,
+		"setuid": true, "setpcap": true, "linux_immutable": true,
+		"net_bind_service": true, "net_broadcast": true, "net_admin": true,
+		"net_raw": true, "ipc_lock": true, "ipc_owner": true,
+		"sys_module": true, "sys_rawio": true, "sys_chroot": true,
+		"sys_ptrace": true, "sys_pacct": true, "sys_admin": true,
+		"sys_boot": true, "sys_nice": true, "sys_resource": true,
+		"sys_time": true, "sys_tty_config": true, "mknod": true,
+		"lease": true, "audit_write": true, "audit_control": true,
+		"setfcap": true, "mac_override": true, "mac_admin": true,
+		"syslog": true, "wake_alarm": true, "block_suspend": true,
+		"audit_read": true, "perfmon": true, "bpf": true, "checkpoint_restore": true,
+	}
+	normalized := strings.ToLower(strings.TrimSpace(cap))
+	if exists, ok := validCapabilities[normalized]; ok && exists {
+		return nil
+	}
+	return fmt.Errorf("invalid or forbidden capability: %q", cap)
+}
+
+func validateExecutableOrLibrary(path string) error {
+	if path == "" {
+		return nil // skip validation for empty paths
+	}
+	if structuralChars.MatchString(path) {
+		return fmt.Errorf("path contains forbidden characters: %q", path)
+	}
+	if !strictPathRegex.MatchString(path) {
+		return fmt.Errorf("path must be absolute and contain only safe characters: %q", path)
+	}
+	if strings.Contains(path, "/../") || strings.HasPrefix(path, "/..") {
+		return fmt.Errorf("path cannot contain directory traversal: %q", path)
+	}
+	return nil
+}
+
 type apparmorTemplateArgs struct {
 	Name         string
 	ProfileMode  string
 	ComplainMode bool
-	Abstract     *apparmorprofileapi.AppArmorAbstract
 	AllowMount   bool
+	Data         *ApparmorData
 }
 
 // GenerateProfile uses the CRD representation of an abstracted profile to generate a
@@ -120,17 +314,23 @@ func GenerateProfile(
 		abstract.Capability.AllowedCapabilities != nil &&
 		slices.Contains(abstract.Capability.AllowedCapabilities, "sys_rawio"))
 
+	if abstract == nil {
+		return "", errors.New("abstract cannot be nil")
+	}
+
+	// Make sure that the data provided as input is valid and doesn't contain malicious content.
+	data := newApparmorData(name, abstract)
+	if err := data.Validate(); err != nil {
+		return "", fmt.Errorf("validating data injected into apparmor profile: %w", err)
+	}
+
 	complain := mode == apparmorprofileapi.AppArmorModeComplain
 	templateArgs := apparmorTemplateArgs{
 		Name:         name,
+		Data:         data,
 		ProfileMode:  profileMode(mode),
 		ComplainMode: complain,
-		Abstract:     abstract,
 		AllowMount:   allowMount,
-	}
-
-	if abstract == nil {
-		return "", errors.New("abstract cannot be nil")
 	}
 
 	tpl, err := template.New("apparmor").Parse(appArmorTemplate)

--- a/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor_test.go
+++ b/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor_test.go
@@ -101,6 +101,87 @@ func TestGenerateProfile(t *testing.T) {
 		{
 			name: "Path sanitization - good - standard absolute path",
 			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Filesystem: &apparmorprofileapi.AppArmorFsRules{
+					ReadOnlyPaths: []string{"/usr/bin/nginx"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Path sanitization - good - path with AppArmor variables",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Filesystem: &apparmorprofileapi.AppArmorFsRules{
+					ReadOnlyPaths: []string{"/proc/@{pid}/cgroup", "/@{HOME}/.bashrc"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Path sanitization - good - path with wildcards",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Filesystem: &apparmorprofileapi.AppArmorFsRules{
+					ReadOnlyPaths: []string{"/var/log/**", "/etc/nginx/conf.d/*.conf", "/lib/tls/i686/cmov/lib*.so?"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Path sanitization - good - path with special allowed characters and spaces",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Filesystem: &apparmorprofileapi.AppArmorFsRules{
+					ReadOnlyPaths: []string{"/opt/my-app/v1.2+3/run_app", "/My Documents/test file"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Path sanitization - bad - missing leading slash (relative path)",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Filesystem: &apparmorprofileapi.AppArmorFsRules{
+					ReadOnlyPaths: []string{"usr/bin/nginx"}, // Fails the ^/ requirement
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Path sanitization - bad - quote injection attempt",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Filesystem: &apparmorprofileapi.AppArmorFsRules{
+					ReadOnlyPaths: []string{`/usr/bin/nginx" - r,`}, // Quotes are not in the allowed regex class
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Path sanitization - bad - shell execution injection",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Filesystem: &apparmorprofileapi.AppArmorFsRules{
+					ReadOnlyPaths: []string{"/usr/bin/$(whoami)"}, // $ and () are not allowed
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Path sanitization - bad - rule breakout with comma",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Filesystem: &apparmorprofileapi.AppArmorFsRules{
+					ReadOnlyPaths: []string{"/usr/bin/nginx, /etc/passwd"}, // Comma is not allowed
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Path sanitization - bad - command chaining",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Filesystem: &apparmorprofileapi.AppArmorFsRules{
+					ReadOnlyPaths: []string{"/usr/bin/nginx ; rm -rf /"}, // Semicolon is not allowed
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Path sanitization - good - standard absolute path",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
 				Executable: &apparmorprofileapi.AppArmorExecutablesRules{
 					AllowedExecutables: []string{"/usr/bin/nginx"},
 				},

--- a/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor_test.go
+++ b/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor_test.go
@@ -29,14 +29,17 @@ func TestGenerateProfile(t *testing.T) {
 
 	cases := []struct {
 		name           string
+		profileName    string
 		mode           apparmorprofileapi.AppArmorMode
 		abstract       *apparmorprofileapi.AppArmorAbstract
 		mustContain    []string
 		mustNotContain []string
+		wantErr        bool
 	}{
 		{
-			name: "EnforceModeWithDeny",
-			mode: apparmorprofileapi.AppArmorModeEnforce,
+			name:        "Generate profile with enforce mode with deny",
+			profileName: "EnforceModeWithDeny",
+			mode:        apparmorprofileapi.AppArmorModeEnforce,
 			abstract: &apparmorprofileapi.AppArmorAbstract{
 				Filesystem: &apparmorprofileapi.AppArmorFsRules{
 					ReadOnlyPaths: []string{"/etc/passwd"},
@@ -48,10 +51,12 @@ func TestGenerateProfile(t *testing.T) {
 				"deny /etc/passwd wlk,",
 				"deny @{PROC}/* w,",
 			},
+			wantErr: false,
 		},
 		{
-			name: "ComplainModeWithoutDeny",
-			mode: apparmorprofileapi.AppArmorModeComplain,
+			name:        "Generate profile with complain mode without deny",
+			profileName: "ComplainModeWithoutDeny",
+			mode:        apparmorprofileapi.AppArmorModeComplain,
 			abstract: &apparmorprofileapi.AppArmorAbstract{
 				Filesystem: &apparmorprofileapi.AppArmorFsRules{
 					ReadOnlyPaths: []string{"/etc/passwd"},
@@ -67,6 +72,127 @@ func TestGenerateProfile(t *testing.T) {
 				"audit /etc/passwd wlk,",
 				"audit @{PROC}/* w,",
 			},
+			wantErr: false,
+		},
+		{
+			name:        "Name sanitization - good - alphanumeric and dashes",
+			profileName: "my-app_profile.v1",
+			abstract:    &apparmorprofileapi.AppArmorAbstract{},
+			wantErr:     false,
+		},
+		{
+			name:        "Name sanitization - bad - contains space",
+			profileName: "my profile",
+			abstract:    &apparmorprofileapi.AppArmorAbstract{},
+			wantErr:     true,
+		},
+		{
+			name:        "Name sanitization - bad - newline injection",
+			profileName: "profile\n  audit network inet,",
+			abstract:    &apparmorprofileapi.AppArmorAbstract{},
+			wantErr:     true,
+		},
+		{
+			name: "Path sanitization - good - standard absolute path",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Executable: &apparmorprofileapi.AppArmorExecutablesRules{
+					AllowedExecutables: []string{"/usr/bin/nginx"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Path sanitization - good - library with wildcard",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Executable: &apparmorprofileapi.AppArmorExecutablesRules{
+					AllowedLibraries: []string{"/lib/x86_64-linux-gnu/**"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Path sanitization - bad - relative path",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Executable: &apparmorprofileapi.AppArmorExecutablesRules{
+					AllowedExecutables: []string{"usr/bin/app"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Path sanitization - bad - newline structural injection",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Executable: &apparmorprofileapi.AppArmorExecutablesRules{
+					// Attempting to break out of the string to start a new rule
+					AllowedExecutables: []string{"/var/log/app.log\n  audit network inet,"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Path sanitization - bad - quote injection",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Executable: &apparmorprofileapi.AppArmorExecutablesRules{
+					// Attempting to close the template's quotes early
+					AllowedLibraries: []string{"/var/log/\"app\".log"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Path sanitization - bad - directory traversal",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Executable: &apparmorprofileapi.AppArmorExecutablesRules{
+					AllowedExecutables: []string{"/usr/bin/../etc/shadow"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Capabilities sanitization - good - standard capability",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Capability: &apparmorprofileapi.AppArmorCapabilityRules{
+					AllowedCapabilities: []string{"chown"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Capabilities sanitization - good - mixed case",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Capability: &apparmorprofileapi.AppArmorCapabilityRules{
+					AllowedCapabilities: []string{"DAC_OVERRIDE"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Capabilities sanitization - bad - includes CAP_ prefix",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Capability: &apparmorprofileapi.AppArmorCapabilityRules{
+					AllowedCapabilities: []string{"CAP_CHOWN"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Capabilities sanitization - bad - comma injection",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Capability: &apparmorprofileapi.AppArmorCapabilityRules{
+					AllowedCapabilities: []string{"chown, net_admin"},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "Capabilities sanitization - bad - keyword injection",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Capability: &apparmorprofileapi.AppArmorCapabilityRules{
+					// 'audit' is an AppArmor keyword, not a valid capability string ('audit_write' is valid)
+					AllowedCapabilities: []string{"audit"},
+				},
+			},
+			wantErr: true,
 		},
 	}
 
@@ -74,8 +200,12 @@ func TestGenerateProfile(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := GenerateProfile(tc.name, tc.mode, tc.abstract)
-			require.NoError(t, err)
+			got, err := GenerateProfile(tc.profileName, tc.mode, tc.abstract)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 
 			for _, s := range tc.mustContain {
 				require.Contains(t, got, s)

--- a/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor_test.go
+++ b/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor_test.go
@@ -135,6 +135,46 @@ func TestGenerateProfile(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "Path sanitization - good - only root",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Filesystem: &apparmorprofileapi.AppArmorFsRules{
+					ReadOnlyPaths: []string{"/"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Path sanitization - good - only root",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Filesystem: &apparmorprofileapi.AppArmorFsRules{
+					ReadOnlyPaths: []string{"/"},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Path sanitization - good - ptrace injection hack",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Filesystem: &apparmorprofileapi.AppArmorFsRules{
+					ReadOnlyPaths: []string{
+						"ptrace (read),",
+						"ptrace (trace), # ugly template injection hack",
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Path sanitization - bad - malicious ptrace attempt",
+			abstract: &apparmorprofileapi.AppArmorAbstract{
+				Filesystem: &apparmorprofileapi.AppArmorFsRules{
+					// Fails because there is no comma, or tries to inject file rules after ptrace
+					ReadOnlyPaths: []string{"ptrace (read) /etc/shadow r,"},
+				},
+			},
+			wantErr: true,
+		},
+		{
 			name: "Path sanitization - bad - missing leading slash (relative path)",
 			abstract: &apparmorprofileapi.AppArmorAbstract{
 				Filesystem: &apparmorprofileapi.AppArmorFsRules{

--- a/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor_test.go
+++ b/internal/pkg/daemon/apparmorprofile/crd2armor/crd2armor_test.go
@@ -81,6 +81,12 @@ func TestGenerateProfile(t *testing.T) {
 			wantErr:     false,
 		},
 		{
+			name:        "Name sanitization - good(spoc) -  alphanumerical profile path",
+			profileName: "/path/to/my/profile",
+			abstract:    &apparmorprofileapi.AppArmorAbstract{},
+			wantErr:     false,
+		},
+		{
 			name:        "Name sanitization - bad - contains space",
 			profileName: "my profile",
 			abstract:    &apparmorprofileapi.AppArmorAbstract{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Sanitize all the input data which is rendered into the apparmor profile template. This is to 
prevent the injection of malicious content.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Sanitize the input data which is redered into the apparmor profile template to prevent malicious
content.
```
