### PR TITLE
Fix greedy operator in audit regexes

### DIFF
--- a/internal/pkg/daemon/enricher/auditsource/audit.go
+++ b/internal/pkg/daemon/enricher/auditsource/audit.go
@@ -96,21 +96,19 @@ func (a *AuditdSource) TailErr() error {
 // type IDs are defined at https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/audit.h
 var (
 	seccompLineRegex = regexp.MustCompile(
-		// Non-greedy spacing, exact boundaries for audit IDs, and [^"]* for quoted exe.
-		`(type=SECCOMP|audit:\S+type=1326).*?audit\(([^)]+)\).*?pid=(\d+).*?exe="([^"]*)".*?syscall=(\d+).*`,
+		// Fixed audit:.*?type prefix to allow spaces.
+		`(type=SECCOMP|audit:.*?type=1326).*?audit\(([^)]+)\).*?pid=(\d+).*?exe="([^"]*)".*?syscall=(\d+).*`,
 	)
 	selinuxLineRegex = regexp.MustCompile(
-		// \S+ for unquoted context fields to prevent greedy swallowing.
-		`type=AVC.*?audit\(([^)]+)\).*?\{\s*([^}]+)\s*\}.*?pid=(\d+).*?scontext=(\S+).*?tcontext=(\S+).*?tclass=(\w+).*`,
+		// Fixed \{\s*(.*?)\s*\} to drop trailing spaces inside the perm brackets.
+		`type=AVC.*?audit\(([^)]+)\).*?\{\s*(.*?)\s*\}.*?pid=(\d+).*?scontext=(\S+).*?tcontext=(\S+).*?tclass=(\w+).*`,
 	)
 	apparmorLineRegex = regexp.MustCompile(
 		//nolint:lll // no need to wrap regex
-		// Every quoted field uses [^"]* to strictly stop at the closing quote.
-		// Note: The optional `info` field is safely skipped by the non-greedy `.*?` separator before `profile=`.
-		`(type=APPARMOR|audit:\S+type=1400).*?audit\(([^)]+)\).*?apparmor="([^"]*)".*?operation="([^"]*)".*?profile="([^"]*)".*?name="([^"]*)".*?pid=(\d+).*?comm="([^"]*)"\s*(.*)`,
+		// Fixed audit:.*?type prefix to allow spaces.
+		`(type=APPARMOR|audit:.*?type=1400).*?audit\(([^)]+)\).*?apparmor="([^"]*)".*?operation="([^"]*)".*?profile="([^"]*)".*?name="([^"]*)".*?pid=(\d+).*?comm="([^"]*)"\s*(.*)`,
 	)
 
-	// Removed the greedy .* and fixed the capture groups to strictly capture digits.
 	uidGidRegex = regexp.MustCompile(`.*?\suid=(\d+).*?\sgid=(\d+).*`)
 )
 

--- a/internal/pkg/daemon/enricher/auditsource/audit.go
+++ b/internal/pkg/daemon/enricher/auditsource/audit.go
@@ -96,17 +96,22 @@ func (a *AuditdSource) TailErr() error {
 // type IDs are defined at https://elixir.bootlin.com/linux/latest/source/include/uapi/linux/audit.h
 var (
 	seccompLineRegex = regexp.MustCompile(
-		`(type=SECCOMP|audit:.+type=1326).+audit\((.+)\).+pid=(\b\d+\b).+exe="(.+)".+syscall=(\b\d+\b).*`,
+		// Non-greedy spacing, exact boundaries for audit IDs, and [^"]* for quoted exe.
+		`(type=SECCOMP|audit:\S+type=1326).*?audit\(([^)]+)\).*?pid=(\d+).*?exe="([^"]*)".*?syscall=(\d+).*`,
 	)
 	selinuxLineRegex = regexp.MustCompile(
-		`type=AVC.+audit\((.+)\).+{ (.+) }.+pid=(\b\d+\b).*scontext=(.+) tcontext=(.+) tclass=(\b\w+\b).*`,
+		// \S+ for unquoted context fields to prevent greedy swallowing.
+		`type=AVC.*?audit\(([^)]+)\).*?\{\s*([^}]+)\s*\}.*?pid=(\d+).*?scontext=(\S+).*?tcontext=(\S+).*?tclass=(\w+).*`,
 	)
 	apparmorLineRegex = regexp.MustCompile(
 		//nolint:lll // no need to wrap regex
-		`(type=APPARMOR|audit:.+type=1400).+audit\((.+)\).+apparmor="(.+)".+operation="([a-zA-Z0-9\/\-\_]+)"\s(?:info.+)?profile="(.+)".+name="(.+)".+pid=(\b\d+\b).+comm="([a-zA-Z0-9\/\-\_]+)"\s?(.*)?`,
+		// Every quoted field uses [^"]* to strictly stop at the closing quote.
+		// Note: The optional `info` field is safely skipped by the non-greedy `.*?` separator before `profile=`.
+		`(type=APPARMOR|audit:\S+type=1400).*?audit\(([^)]+)\).*?apparmor="([^"]*)".*?operation="([^"]*)".*?profile="([^"]*)".*?name="([^"]*)".*?pid=(\d+).*?comm="([^"]*)"\s*(.*)`,
 	)
 
-	uidGidRegex = regexp.MustCompile(`.*\suid=([\d+]).*\sgid=([\d+]).*`)
+	// Removed the greedy .* and fixed the capture groups to strictly capture digits.
+	uidGidRegex = regexp.MustCompile(`.*?\suid=(\d+).*?\sgid=(\d+).*`)
 )
 
 var (


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

#### What this PR does / why we need it:

Audit line regex(s) uses a greedy operator `.+` which matches as much as
possible, meaning an attacker can inject fake fields inside a quoted
workload name, and the greedy operator will shallow the real fields and
match the attacker's injected fields instead.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note

NONE
```
