### PR TITLE
Add kubebuilder validation for ListenerPath in seccomprofile

### DIFF
--- a/api/seccompprofile/v1beta1/seccompprofile_types.go
+++ b/api/seccompprofile/v1beta1/seccompprofile_types.go
@@ -83,6 +83,7 @@ type SeccompProfileSpec struct {
 	Architectures []Arch `json:"architectures,omitempty"`
 	// path of UNIX domain socket to contact a seccomp agent for SCMP_ACT_NOTIFY
 	// +optional
+	// +kubebuilder:validation:Pattern=`^/var/run/security-profiles-operator/[a-zA-Z0-9_\-\.]+$`
 	ListenerPath string `json:"listenerPath,omitempty"`
 	// opaque data to pass to the seccomp agent
 	// +optional

--- a/deploy/base-crds/crds/seccompprofile.yaml
+++ b/deploy/base-crds/crds/seccompprofile.yaml
@@ -119,6 +119,7 @@ spec:
               listenerPath:
                 description: path of UNIX domain socket to contact a seccomp agent
                   for SCMP_ACT_NOTIFY
+                pattern: ^/var/run/security-profiles-operator/[a-zA-Z0-9_\-\.]+$
                 type: string
               syscalls:
                 description: |-

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -358,6 +358,7 @@ spec:
               listenerPath:
                 description: path of UNIX domain socket to contact a seccomp agent
                   for SCMP_ACT_NOTIFY
+                pattern: ^/var/run/security-profiles-operator/[a-zA-Z0-9_\-\.]+$
                 type: string
               syscalls:
                 description: |-

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -358,6 +358,7 @@ spec:
               listenerPath:
                 description: path of UNIX domain socket to contact a seccomp agent
                   for SCMP_ACT_NOTIFY
+                pattern: ^/var/run/security-profiles-operator/[a-zA-Z0-9_\-\.]+$
                 type: string
               syscalls:
                 description: |-

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -673,6 +673,7 @@ spec:
               listenerPath:
                 description: path of UNIX domain socket to contact a seccomp agent
                   for SCMP_ACT_NOTIFY
+                pattern: ^/var/run/security-profiles-operator/[a-zA-Z0-9_\-\.]+$
                 type: string
               syscalls:
                 description: |-

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -358,6 +358,7 @@ spec:
               listenerPath:
                 description: path of UNIX domain socket to contact a seccomp agent
                   for SCMP_ACT_NOTIFY
+                pattern: ^/var/run/security-profiles-operator/[a-zA-Z0-9_\-\.]+$
                 type: string
               syscalls:
                 description: |-

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -358,6 +358,7 @@ spec:
               listenerPath:
                 description: path of UNIX domain socket to contact a seccomp agent
                   for SCMP_ACT_NOTIFY
+                pattern: ^/var/run/security-profiles-operator/[a-zA-Z0-9_\-\.]+$
                 type: string
               syscalls:
                 description: |-

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -673,6 +673,7 @@ spec:
               listenerPath:
                 description: path of UNIX domain socket to contact a seccomp agent
                   for SCMP_ACT_NOTIFY
+                pattern: ^/var/run/security-profiles-operator/[a-zA-Z0-9_\-\.]+$
                 type: string
               syscalls:
                 description: |-


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Add kubebuilder validation to ListenerPath in seccomp profile configuration to avoid socket 
hijacking.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
