### PR TITLE
fix: partial profiles never merged due to namespace filter

### DIFF
--- a/api/apparmorprofile/v1/apparmorprofile_types.go
+++ b/api/apparmorprofile/v1/apparmorprofile_types.go
@@ -170,9 +170,9 @@ func (sp *AppArmorProfile) SetImplementationStatus() {
 func (sp *AppArmorProfile) ListProfilesByRecording(
 	ctx context.Context,
 	cli client.Client,
-	recording string,
+	recording, recordingNamespace string,
 ) ([]metav1.Object, error) {
-	return profilebasev1.ListProfilesByRecording(ctx, cli, recording, sp.Namespace, &AppArmorProfileList{})
+	return profilebasev1.ListProfilesByRecording(ctx, cli, recording, recordingNamespace, &AppArmorProfileList{})
 }
 
 func (sp *AppArmorProfile) IsPartial() bool {

--- a/api/profilebase/v1/profilebase.go
+++ b/api/profilebase/v1/profilebase.go
@@ -35,7 +35,7 @@ const ProfilePartialLabel = "spo.x-k8s.io/partial"
 type SecurityProfileBase interface {
 	client.Object
 
-	ListProfilesByRecording(ctx context.Context, cli client.Client, recording string) ([]metav1.Object, error)
+	ListProfilesByRecording(ctx context.Context, cli client.Client, recording string, recordingNamespace string) ([]metav1.Object, error)
 	IsPartial() bool
 	IsDisabled() bool
 	IsReconcilable() bool
@@ -65,8 +65,10 @@ func ListProfilesByRecording(
 	if err := cli.List(
 		ctx,
 		list,
-		client.InNamespace(recordingNamespace),
-		client.MatchingLabels{profilerecordingv1.ProfileToRecordingLabel: recordingName}); err != nil {
+		client.MatchingLabels{
+			profilerecordingv1.ProfileToRecordingLabel:          recordingName,
+			profilerecordingv1.ProfileToRecordingNamespaceLabel: recordingNamespace,
+		}); err != nil {
 		return nil, fmt.Errorf("listing recorded profiles for %s: %w", recordingName, err)
 	}
 

--- a/api/profilebase/v1/profilebase.go
+++ b/api/profilebase/v1/profilebase.go
@@ -36,7 +36,8 @@ type SecurityProfileBase interface {
 	client.Object
 
 	ListProfilesByRecording(
-		ctx context.Context, cli client.Client, recording string, recordingNamespace string,
+		ctx context.Context, cli client.Client,
+		recording, recordingNamespace string,
 	) ([]metav1.Object, error)
 	IsPartial() bool
 	IsDisabled() bool

--- a/api/profilebase/v1/profilebase.go
+++ b/api/profilebase/v1/profilebase.go
@@ -35,7 +35,9 @@ const ProfilePartialLabel = "spo.x-k8s.io/partial"
 type SecurityProfileBase interface {
 	client.Object
 
-	ListProfilesByRecording(ctx context.Context, cli client.Client, recording string, recordingNamespace string) ([]metav1.Object, error)
+	ListProfilesByRecording(
+		ctx context.Context, cli client.Client, recording string, recordingNamespace string,
+	) ([]metav1.Object, error)
 	IsPartial() bool
 	IsDisabled() bool
 	IsReconcilable() bool

--- a/api/profilerecording/v1/profilerecording_types.go
+++ b/api/profilerecording/v1/profilerecording_types.go
@@ -51,6 +51,9 @@ const (
 const (
 	// ProfileToRecordingLabel is the name of the ProfileRecording CR that produced this profile.
 	ProfileToRecordingLabel = "spo.x-k8s.io/recording-id"
+	// ProfileToRecordingNamespaceLabel is the namespace of the ProfileRecording CR that produced this profile.
+	// Required to disambiguate cluster-scoped profiles from recordings with the same name in different namespaces.
+	ProfileToRecordingNamespaceLabel = "spo.x-k8s.io/recording-namespace"
 	// ProfileToContainerLabel is the name of the container that produced this profile.
 	ProfileToContainerLabel = "spo.x-k8s.io/container-id"
 	// RecordingHasUnmergedProfiles is a finalizer that indicates that the recording has partial policies. Its

--- a/api/seccompprofile/v1/seccompprofile_types.go
+++ b/api/seccompprofile/v1/seccompprofile_types.go
@@ -258,9 +258,9 @@ func (sp *SeccompProfile) GetProfileOperatorPath() string {
 func (sp *SeccompProfile) ListProfilesByRecording(
 	ctx context.Context,
 	cli client.Client,
-	recording string,
+	recording, recordingNamespace string,
 ) ([]metav1.Object, error) {
-	return profilebasev1.ListProfilesByRecording(ctx, cli, recording, sp.Namespace, &SeccompProfileList{})
+	return profilebasev1.ListProfilesByRecording(ctx, cli, recording, recordingNamespace, &SeccompProfileList{})
 }
 
 func (sp *SeccompProfile) IsPartial() bool {

--- a/api/selinuxprofile/v1/rawselinuxprofile_types.go
+++ b/api/selinuxprofile/v1/rawselinuxprofile_types.go
@@ -95,9 +95,9 @@ func (sp *RawSelinuxProfile) GetPolicyUsage() string {
 func (sp *RawSelinuxProfile) ListProfilesByRecording(
 	ctx context.Context,
 	cli client.Client,
-	recording string,
+	recording, recordingNamespace string,
 ) ([]metav1.Object, error) {
-	return profilebasev1.ListProfilesByRecording(ctx, cli, recording, sp.Namespace, &RawSelinuxProfileList{})
+	return profilebasev1.ListProfilesByRecording(ctx, cli, recording, recordingNamespace, &RawSelinuxProfileList{})
 }
 
 func (sp *RawSelinuxProfile) ValidatePolicy() error {

--- a/api/selinuxprofile/v1/selinuxprofile_types.go
+++ b/api/selinuxprofile/v1/selinuxprofile_types.go
@@ -185,9 +185,9 @@ func (sp *SelinuxProfile) GetPolicyUsage() string {
 func (sp *SelinuxProfile) ListProfilesByRecording(
 	ctx context.Context,
 	cli client.Client,
-	recording string,
+	recording, recordingNamespace string,
 ) ([]metav1.Object, error) {
-	return profilebasev1.ListProfilesByRecording(ctx, cli, recording, sp.Namespace, &SelinuxProfileList{})
+	return profilebasev1.ListProfilesByRecording(ctx, cli, recording, recordingNamespace, &SelinuxProfileList{})
 }
 
 func (sp *SelinuxProfile) IsPartial() bool {

--- a/examples/apparmorprofile-sleep-complain-mode.yaml
+++ b/examples/apparmorprofile-sleep-complain-mode.yaml
@@ -5,6 +5,7 @@ metadata:
     spo.x-k8s.io/container-id: test-pod
     spo.x-k8s.io/profile-id: AppArmorProfile-test-recording-test-pod
     spo.x-k8s.io/recording-id: test-recording
+    spo.x-k8s.io/recording-namespace: security-profiles-operator
   name: test-recording-test-pod
 spec:
   mode: Complain

--- a/examples/apparmorprofile-sleep-crun.yaml
+++ b/examples/apparmorprofile-sleep-crun.yaml
@@ -5,6 +5,7 @@ metadata:
     spo.x-k8s.io/container-id: test-pod
     spo.x-k8s.io/profile-id: AppArmorProfile-test-recording-test-pod
     spo.x-k8s.io/recording-id: test-recording
+    spo.x-k8s.io/recording-namespace: security-profiles-operator
   name: test-recording-test-pod
 spec:
   abstract:

--- a/examples/apparmorprofile-sleep-runc.yaml
+++ b/examples/apparmorprofile-sleep-runc.yaml
@@ -5,6 +5,7 @@ metadata:
     spo.x-k8s.io/container-id: test-pod
     spo.x-k8s.io/profile-id: AppArmorProfile-test-recording-test-pod
     spo.x-k8s.io/recording-id: test-recording
+    spo.x-k8s.io/recording-namespace: security-profiles-operator
   name: test-recording-test-pod
 spec:
   abstract:

--- a/internal/pkg/daemon/profilerecorder/profilerecorder.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder.go
@@ -1304,8 +1304,9 @@ func profileLabels(
 	}
 
 	labels := map[string]string{
-		profilerecordingapi.ProfileToRecordingLabel: recordingName,
-		profilerecordingapi.ProfileToContainerLabel: cntName,
+		profilerecordingapi.ProfileToRecordingLabel:          recordingName,
+		profilerecordingapi.ProfileToContainerLabel:          cntName,
+		profilerecordingapi.ProfileToRecordingNamespaceLabel: namespace,
 	}
 
 	partial, err := profilePartial(ctx, r, recordingName, namespace)

--- a/internal/pkg/manager/recordingmerger/merge_utils.go
+++ b/internal/pkg/manager/recordingmerger/merge_utils.go
@@ -39,7 +39,8 @@ func mergedObjectMeta(profileName, recordingName, namespace string) *metav1.Obje
 		Name:      profileName,
 		Namespace: namespace,
 		Labels: map[string]string{
-			profilerecordingapi.ProfileToRecordingLabel: recordingName,
+			profilerecordingapi.ProfileToRecordingLabel:          recordingName,
+			profilerecordingapi.ProfileToRecordingNamespaceLabel: namespace,
 		},
 	}
 }

--- a/internal/pkg/manager/recordingmerger/merge_utils.go
+++ b/internal/pkg/manager/recordingmerger/merge_utils.go
@@ -85,10 +85,10 @@ func listPartialProfiles(
 	if err := cli.List(
 		ctx,
 		list,
-		client.InNamespace(recording.Namespace),
 		client.MatchingLabels{
-			profilerecordingapi.ProfileToRecordingLabel: recording.Name,
-			profilebase.ProfilePartialLabel:             "true",
+			profilerecordingapi.ProfileToRecordingLabel:          recording.Name,
+			profilerecordingapi.ProfileToRecordingNamespaceLabel: recording.Namespace,
+			profilebase.ProfilePartialLabel:                      "true",
 		}); err != nil {
 		return nil, fmt.Errorf("listing partial profiles for %s: %w", recording.Name, err)
 	}
@@ -162,10 +162,10 @@ func deletePartialProfiles(
 	return cli.DeleteAllOf(
 		ctx,
 		prf,
-		client.InNamespace(recording.Namespace),
 		client.MatchingLabels{
-			profilerecordingapi.ProfileToRecordingLabel: recording.Name,
-			profilebase.ProfilePartialLabel:             "true",
+			profilerecordingapi.ProfileToRecordingLabel:          recording.Name,
+			profilerecordingapi.ProfileToRecordingNamespaceLabel: recording.Namespace,
+			profilebase.ProfilePartialLabel:                      "true",
 		})
 }
 

--- a/internal/pkg/nodestatus/nodestatus.go
+++ b/internal/pkg/nodestatus/nodestatus.go
@@ -335,7 +335,10 @@ func handleRecordingFinalizer(ctx context.Context, c client.Client, pol profileb
 	}
 
 	// if there are other policies recorded by the same recording, we don't need to do anything either
-	otherPolicies, err := pol.ListProfilesByRecording(ctx, c, polLabels[profilerecordingapi.ProfileToRecordingLabel], polLabels[profilerecordingapi.ProfileToRecordingNamespaceLabel])
+	otherPolicies, err := pol.ListProfilesByRecording(ctx, c,
+		polLabels[profilerecordingapi.ProfileToRecordingLabel],
+		polLabels[profilerecordingapi.ProfileToRecordingNamespaceLabel],
+	)
 	if err != nil {
 		return fmt.Errorf("listing profiles by recording: %w", err)
 	}
@@ -374,7 +377,10 @@ func handleRecordingFinalizer(ctx context.Context, c client.Client, pol profileb
 	}
 
 	profilerecording := &profilerecordingapi.ProfileRecording{}
-	recordingName := util.NamespacedName(polLabels[profilerecordingapi.ProfileToRecordingLabel], polLabels[profilerecordingapi.ProfileToRecordingNamespaceLabel])
+	recordingName := util.NamespacedName(
+		polLabels[profilerecordingapi.ProfileToRecordingLabel],
+		polLabels[profilerecordingapi.ProfileToRecordingNamespaceLabel],
+	)
 
 	err = c.Get(ctx, recordingName, profilerecording)
 	if kerrors.IsNotFound(err) {

--- a/internal/pkg/nodestatus/nodestatus.go
+++ b/internal/pkg/nodestatus/nodestatus.go
@@ -335,7 +335,7 @@ func handleRecordingFinalizer(ctx context.Context, c client.Client, pol profileb
 	}
 
 	// if there are other policies recorded by the same recording, we don't need to do anything either
-	otherPolicies, err := pol.ListProfilesByRecording(ctx, c, polLabels[profilerecordingapi.ProfileToRecordingLabel])
+	otherPolicies, err := pol.ListProfilesByRecording(ctx, c, polLabels[profilerecordingapi.ProfileToRecordingLabel], polLabels[profilerecordingapi.ProfileToRecordingNamespaceLabel])
 	if err != nil {
 		return fmt.Errorf("listing profiles by recording: %w", err)
 	}
@@ -374,7 +374,7 @@ func handleRecordingFinalizer(ctx context.Context, c client.Client, pol profileb
 	}
 
 	profilerecording := &profilerecordingapi.ProfileRecording{}
-	recordingName := util.NamespacedName(polLabels[profilerecordingapi.ProfileToRecordingLabel], pol.GetNamespace())
+	recordingName := util.NamespacedName(polLabels[profilerecordingapi.ProfileToRecordingLabel], polLabels[profilerecordingapi.ProfileToRecordingNamespaceLabel])
 
 	err = c.Get(ctx, recordingName, profilerecording)
 	if kerrors.IsNotFound(err) {

--- a/internal/pkg/nodestatus/nodestatus.go
+++ b/internal/pkg/nodestatus/nodestatus.go
@@ -330,15 +330,19 @@ func handleRecordingFinalizer(ctx context.Context, c client.Client, pol profileb
 	// if this policy was not recorded, we don't need to do anything. This also covers the upgrade
 	// case because the finalizer is only added when the policy is recorded with the new version
 	polLabels := pol.GetLabels()
-	if polLabels == nil || polLabels[profilerecordingapi.ProfileToRecordingLabel] == "" {
+	if polLabels == nil {
+		return nil
+	}
+
+	recordingName := polLabels[profilerecordingapi.ProfileToRecordingLabel]
+	recordingNamespace := polLabels[profilerecordingapi.ProfileToRecordingNamespaceLabel]
+
+	if recordingName == "" || recordingNamespace == "" {
 		return nil
 	}
 
 	// if there are other policies recorded by the same recording, we don't need to do anything either
-	otherPolicies, err := pol.ListProfilesByRecording(ctx, c,
-		polLabels[profilerecordingapi.ProfileToRecordingLabel],
-		polLabels[profilerecordingapi.ProfileToRecordingNamespaceLabel],
-	)
+	otherPolicies, err := pol.ListProfilesByRecording(ctx, c, recordingName, recordingNamespace)
 	if err != nil {
 		return fmt.Errorf("listing profiles by recording: %w", err)
 	}
@@ -377,12 +381,8 @@ func handleRecordingFinalizer(ctx context.Context, c client.Client, pol profileb
 	}
 
 	profilerecording := &profilerecordingapi.ProfileRecording{}
-	recordingName := util.NamespacedName(
-		polLabels[profilerecordingapi.ProfileToRecordingLabel],
-		polLabels[profilerecordingapi.ProfileToRecordingNamespaceLabel],
-	)
 
-	err = c.Get(ctx, recordingName, profilerecording)
+	err = c.Get(ctx, util.NamespacedName(recordingName, recordingNamespace), profilerecording)
 	if kerrors.IsNotFound(err) {
 		return nil // should not happen, but if it does, we don't need to do anything
 	} else if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:
`SeccompProfile`, `SelinuxProfile`, and `AppArmorProfile` are all cluster-scoped resources. The `listPartialProfiles` and `deletePartialProfiles` functions were passing `client.InNamespace()` when listing/deleting them, which silently prevented profile merging from ever running when a `ProfileRecording` with `mergeStrategy: containers` was deleted.

Due to a known controller-runtime inconsistency (kubernetes-sigs/controller-runtime#988), `List()` and `DeleteAllOf()` behave differently when `InNamespace` is used with cluster-scoped resources. `List()` returns empty results with no error, while `DeleteAllOf()` ignores the namespace and deletes cluster-wide.

Additionally, the `spo.x-k8s.io/recording-id` label only stored the recording name, not its namespace, meaning recordings with the same name in different namespaces would share and interfere with each other's partial profiles. A new label `spo.x-k8s.io/recording-namespace` is introduced and added to profiles at creation time, and used as an additional filter during merge and delete.
#### Which issue(s) this PR fixes:
None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

The `client.InNamespace()` removal from `deletePartialProfiles` is also necessary: without the namespace label filter, `DeleteAllOf()` would have deleted partial profiles belonging to same-named recordings in other namespaces.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Fixed issue with profile merging for recordings caused by namespace filtering of cluster-scoped profiles.
action required: Partial profiles created prior to this release are completely orphaned. They will not be merged or deleted even after upgrading because they lack the `spo.x-k8s.io/recording-namespace` label. If you have partial profiles created prior to this release, delete them manually: `kubectl delete selinuxprofiles,seccompprofiles,apparmorprofiles -l 'spo.x-k8s.io/partial=true,!spo.x-k8s.io/recording-namespace'`
```

