### PR TITLE
fix: add default selinux options so allowedSystemProfiles is applied

### DIFF
--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -166,6 +166,7 @@ type SPODSelinuxConfig struct {
 	TypeTag string `json:"typeTag,omitempty"`
 	// options defines options specific to the SELinux functionality.
 	// +optional
+	// +default={}
 	Options SelinuxOptions `json:"options,omitzero,omitempty"`
 }
 

--- a/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
@@ -1266,6 +1266,7 @@ spec:
                       controller will not be started. Defaults to true when SELinux is enabled.
                     type: boolean
                   options:
+                    default: {}
                     description: options defines options specific to the SELinux functionality.
                     properties:
                       allowedSystemProfiles:

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -1970,6 +1970,7 @@ spec:
                       controller will not be started. Defaults to true when SELinux is enabled.
                     type: boolean
                   options:
+                    default: {}
                     description: options defines options specific to the SELinux functionality.
                     properties:
                       allowedSystemProfiles:

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1970,6 +1970,7 @@ spec:
                       controller will not be started. Defaults to true when SELinux is enabled.
                     type: boolean
                   options:
+                    default: {}
                     description: options defines options specific to the SELinux functionality.
                     properties:
                       allowedSystemProfiles:

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -2362,6 +2362,7 @@ spec:
                       controller will not be started. Defaults to true when SELinux is enabled.
                     type: boolean
                   options:
+                    default: {}
                     description: options defines options specific to the SELinux functionality.
                     properties:
                       allowedSystemProfiles:

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -1970,6 +1970,7 @@ spec:
                       controller will not be started. Defaults to true when SELinux is enabled.
                     type: boolean
                   options:
+                    default: {}
                     description: options defines options specific to the SELinux functionality.
                     properties:
                       allowedSystemProfiles:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1970,6 +1970,7 @@ spec:
                       controller will not be started. Defaults to true when SELinux is enabled.
                     type: boolean
                   options:
+                    default: {}
                     description: options defines options specific to the SELinux functionality.
                     properties:
                       allowedSystemProfiles:

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -2362,6 +2362,7 @@ spec:
                       controller will not be started. Defaults to true when SELinux is enabled.
                     type: boolean
                   options:
+                    default: {}
                     description: options defines options specific to the SELinux functionality.
                     properties:
                       allowedSystemProfiles:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`allowedSystemProfiles` was never getting its default value `["container"]` when deploying via Helm. Kubernetes only applies child defaults if the parent object is present, since `selinux.options` is absent from the helm template, the API server never applied the child default.

Fix: add `+kubebuilder:default={}` on `Options` so the API server creates the parent and applies the child default.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Fixed `allowedSystemProfiles` default (`["container"]`) not being applied when installing via Helm.
```
