### PR TITLE
Webhook should overwrite an existing recording annotation on a pod

### DIFF
--- a/internal/pkg/webhooks/recording/recording.go
+++ b/internal/pkg/webhooks/recording/recording.go
@@ -235,12 +235,13 @@ func (p *podSeccompRecorder) updatePod(
 
 		if existingValue != value {
 			// Overwrite the existing value with the expected value to avoid that
-			// an attacker will spoof a profile recording into it's own controlled
+			// an attacker will spoof a profile recording into its own controlled
 			// profile instead of the one expected.
 			pod.Annotations[key] = value
+			podChanged = true
 			p.log.Info(
 				fmt.Sprintf(
-					"workload %s already has annotation %q is overwritten by %q.",
+					"workload %s already has annotation %q, overwriting with %q.",
 					podName,
 					existingValue,
 					value,

--- a/internal/pkg/webhooks/recording/recording.go
+++ b/internal/pkg/webhooks/recording/recording.go
@@ -239,6 +239,7 @@ func (p *podSeccompRecorder) updatePod(
 			// profile instead of the one expected.
 			pod.Annotations[key] = value
 			podChanged = true
+
 			p.log.Info(
 				fmt.Sprintf(
 					"workload %s already has annotation %q, overwriting with %q.",

--- a/internal/pkg/webhooks/recording/recording.go
+++ b/internal/pkg/webhooks/recording/recording.go
@@ -19,7 +19,6 @@ package recording
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -235,10 +234,13 @@ func (p *podSeccompRecorder) updatePod(
 		}
 
 		if existingValue != value {
-			p.log.Error(
-				errors.New("existing annotation"),
+			// Overwrite the existing value with the expected value to avoid that
+			// an attacker will spoof a profile recording into it's own controlled
+			// profile instead of the one expected.
+			pod.Annotations[key] = value
+			p.log.Info(
 				fmt.Sprintf(
-					"workload %s already has annotation %s (not mutating to %s).",
+					"workload %s already has annotation %q is overwritten by %q.",
 					podName,
 					existingValue,
 					value,

--- a/internal/pkg/webhooks/recording/recording_test.go
+++ b/internal/pkg/webhooks/recording/recording_test.go
@@ -377,7 +377,7 @@ func TestHandle(t *testing.T) {
 			},
 			assert: func(resp admission.Response) {
 				require.True(t, resp.Allowed)
-				require.Empty(t, resp.Patches)
+				require.Len(t, resp.Patches, 3) // 3 because pod + container security context and the annotation
 			},
 		},
 		{ // success pod deleted


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

The webhook should overwrite an existing profile recording annotation
with the expected profile name, instead of just skipping it. This can
allow an attacker to spoof the profile recording into its own profile is
one manually applies the recording annotation to the pod.


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Webhook always overwrite the values of existing profile recording annotation on a pod to avoid
profile recording spoofing.
```
