### PR TITLE
Drop the labels with unbounded cardinlity from prometheus counters

### DIFF
--- a/internal/pkg/daemon/metrics/grpc.go
+++ b/internal/pkg/daemon/metrics/grpc.go
@@ -100,7 +100,7 @@ func (m *Metrics) AuditInc(
 				r.GetNamespace(),
 				r.GetPod(),
 				r.GetContainer(),
-				r.GetExecutable(),
+				r.GetSeccompReq().GetSyscall(),
 			)
 		} else if r.GetSelinuxReq() != nil {
 			m.IncSelinuxProfileAudit(
@@ -108,7 +108,6 @@ func (m *Metrics) AuditInc(
 				r.GetNamespace(),
 				r.GetPod(),
 				r.GetContainer(),
-				r.GetExecutable(),
 				r.GetSelinuxReq().GetScontext(),
 				r.GetSelinuxReq().GetTcontext(),
 			)

--- a/internal/pkg/daemon/metrics/grpc.go
+++ b/internal/pkg/daemon/metrics/grpc.go
@@ -101,7 +101,6 @@ func (m *Metrics) AuditInc(
 				r.GetPod(),
 				r.GetContainer(),
 				r.GetExecutable(),
-				r.GetSeccompReq().GetSyscall(),
 			)
 		} else if r.GetSelinuxReq() != nil {
 			m.IncSelinuxProfileAudit(
@@ -119,11 +118,9 @@ func (m *Metrics) AuditInc(
 				r.GetNamespace(),
 				r.GetPod(),
 				r.GetContainer(),
-				r.GetExecutable(),
 				r.GetApparmorReq().GetProfile(),
 				r.GetApparmorReq().GetOperation(),
 				r.GetApparmorReq().GetApparmor(),
-				r.GetApparmorReq().GetName(),
 			)
 		}
 	}

--- a/internal/pkg/daemon/metrics/metrics.go
+++ b/internal/pkg/daemon/metrics/metrics.go
@@ -67,7 +67,6 @@ const (
 	metricsLabelTcontext       = "tcontext"
 	metricsLabelMountNamespace = "mount_namespace"
 	metricsLabelApparmor       = "apparmor"
-	metricsLabelName           = "name"
 
 	// HandlerPath is the default path for serving metrics.
 	HandlerPath = "/metrics-spod"
@@ -118,7 +117,6 @@ func New() *Metrics {
 				metricsLabelNamespace,
 				metricsLabelPod,
 				metricsLabelContainer,
-				metricsLabelExecutable,
 				metricsLabelSyscall,
 			},
 		),
@@ -161,7 +159,6 @@ func New() *Metrics {
 				metricsLabelNamespace,
 				metricsLabelPod,
 				metricsLabelContainer,
-				metricsLabelExecutable,
 				metricsLabelScontext,
 				metricsLabelTcontext,
 			},
@@ -312,7 +309,7 @@ func (m *Metrics) IncSelinuxProfileAudit(
 	node, namespace, pod, container, executable, scontext, tcontext string,
 ) {
 	m.metricSelinuxProfileAudit.WithLabelValues(
-		node, namespace, pod, container, executable, scontext, tcontext,
+		node, namespace, pod, container, scontext, tcontext,
 	).Inc()
 }
 

--- a/internal/pkg/daemon/metrics/metrics.go
+++ b/internal/pkg/daemon/metrics/metrics.go
@@ -306,7 +306,7 @@ func (m *Metrics) IncSelinuxProfileDelete() {
 // IncSelinuxProfileAudit increments the selinux profile audit counter for the
 // provided labels.
 func (m *Metrics) IncSelinuxProfileAudit(
-	node, namespace, pod, container, executable, scontext, tcontext string,
+	node, namespace, pod, container, scontext, tcontext string,
 ) {
 	m.metricSelinuxProfileAudit.WithLabelValues(
 		node, namespace, pod, container, scontext, tcontext,

--- a/internal/pkg/daemon/metrics/metrics.go
+++ b/internal/pkg/daemon/metrics/metrics.go
@@ -193,11 +193,9 @@ func New() *Metrics {
 				metricsLabelNamespace,
 				metricsLabelPod,
 				metricsLabelContainer,
-				metricsLabelExecutable,
 				metricsLabelProfile,
 				metricLabelOperation,
 				metricsLabelApparmor,
-				metricsLabelName,
 			},
 		),
 		metricAppArmorProfileError: prometheus.NewCounterVec(
@@ -273,10 +271,10 @@ func (m *Metrics) IncSeccompProfileDelete() {
 // IncSeccompProfileAudit increments the seccomp profile audit counter for the
 // provided labels.
 func (m *Metrics) IncSeccompProfileAudit(
-	node, namespace, pod, container, executable, syscall string,
+	node, namespace, pod, container, syscall string,
 ) {
 	m.metricSeccompProfileAudit.WithLabelValues(
-		node, namespace, pod, container, executable, syscall,
+		node, namespace, pod, container, syscall,
 	).Inc()
 }
 
@@ -339,10 +337,10 @@ func (m *Metrics) IncAppArmorProfileDelete() {
 // IncAppArmorProfileAudit increments the apparmor profile audit counter for the
 // provided labels.
 func (m *Metrics) IncAppArmorProfileAudit(
-	node, namespace, pod, container, executable, profile, operation, apparmor, name string,
+	node, namespace, pod, container, profile, operation, apparmor string,
 ) {
 	m.metricAppArmorProfileAudit.WithLabelValues(
-		node, namespace, pod, container, executable, profile, operation, apparmor, name,
+		node, namespace, pod, container, profile, operation, apparmor,
 	).Inc()
 
 	if apparmor == apparmorDeniedAction {

--- a/test/tc_log_enricher_test.go
+++ b/test/tc_log_enricher_test.go
@@ -137,7 +137,6 @@ spec:
 		metrics := e.runAndRetryPodCMD(curlSpodCMD)
 		e.Regexp(fmt.Sprintf(`(?m)security_profiles_operator_seccomp_profile_audit_total{`+
 			`container="%s",`+
-			`executable="/usr/sbin/nginx",`+
 			`namespace="%s",`+
 			`node=".*",`+
 			`pod="%s",`+


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

The "executable" and "name" labels have unbounded cardinality in the
prometheus counter which could cause memory exhaustion in both side
the spod exposing the metric and the Prometheus server.



<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Remove "executable" and "name" from Prometheus counter because they could have unbounded cardinality
and could lead to memory exhaustion.
```
