### PR TITLE
Cap the maximum number of recorded files and the file length in eBpf recorder to avoid OOM

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
@@ -183,16 +183,18 @@ func (b *AppArmorRecorder) handleFileEvent(fileEvent *bpfEvent) {
 	}
 
 	// Enforce a limit on max tracked files to avoid OOM.
-	if len(b.recordedFiles[mid]) > maxTrackedPaths {
-		b.logger.Info("Max tracked file reached. Profile will be truncated to avoid OOM",
-			"mntns", mid, "limit", maxTrackedPaths)
+	if len(b.recordedFiles[mid]) >= maxTrackedPaths {
+		b.logger.Info("Max tracked files reached. Profile will be truncated to avoid OOM",
+			"level", "warn", "mntns", mid, "limit", maxTrackedPaths)
 
 		return
 	}
 
 	// Cap path length to prevent single-string memory bloat
 	if len(fileName) > maxPathLength {
-		fileName = fileName[:maxPathLength]
+		b.logger.Info("Skipping file with excessively long path",
+			"level", "warn", "length", len(fileName), "mntns", mid)
+		return
 	}
 
 	path, ok := b.recordedFiles[mid][fileName]

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
@@ -185,7 +185,7 @@ func (b *AppArmorRecorder) handleFileEvent(fileEvent *bpfEvent) {
 	// Enforce a limit on max tracked files to avoid OOM.
 	if len(b.recordedFiles[mid]) >= maxTrackedPaths {
 		b.logger.Info("Max tracked files reached. Profile will be truncated to avoid OOM",
-			"level", "warn", "mntns", mid, "limit", maxTrackedPaths)
+			"mntns", mid, "limit", maxTrackedPaths)
 
 		return
 	}
@@ -193,7 +193,7 @@ func (b *AppArmorRecorder) handleFileEvent(fileEvent *bpfEvent) {
 	// Cap path length to prevent single-string memory bloat
 	if len(fileName) > maxPathLength {
 		b.logger.Info("Skipping file with excessively long path",
-			"level", "warn", "length", len(fileName), "mntns", mid)
+			"length", len(fileName), "mntns", mid)
 
 		return
 	}

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
@@ -194,6 +194,7 @@ func (b *AppArmorRecorder) handleFileEvent(fileEvent *bpfEvent) {
 	if len(fileName) > maxPathLength {
 		b.logger.Info("Skipping file with excessively long path",
 			"level", "warn", "length", len(fileName), "mntns", mid)
+
 		return
 	}
 

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
@@ -21,7 +21,6 @@ package bpfrecorder
 import (
 	"errors"
 	"fmt"
-	"log"
 	"path/filepath"
 	"regexp"
 	"slices"
@@ -40,6 +39,13 @@ const (
 	sockDgram    uint64 = 2
 	sockRaw      uint64 = 3
 	sockTypeMask uint64 = 0xF
+
+	// maxTrackedPaths limits the number of unique paths recorded per mount namespace
+	// to prevent memory exhaustion (OOM) attacks from malicious workloads.
+	maxTrackedPaths = 10000
+
+	// maxPathLength enforces a ceiling on the string size stored in the map.
+	maxPathLength = 4096
 )
 
 var appArmorHooks = []string{
@@ -162,17 +168,29 @@ func (b *AppArmorRecorder) handleFileEvent(fileEvent *bpfEvent) {
 	fileName := fileDataToString(&fileEvent.Data)
 	fileName = ReplaceVarianceInFilePath(fileName)
 
-	log.Printf("File access: %s, flags=%d pid=%d mntns=%d\n", fileName, fileEvent.Flags, fileEvent.Pid, fileEvent.Mntns)
+	b.logger.Info("File access", "filename",
+		fileName, "flags", fileEvent.Flags, "pid", fileEvent.Pid, "mntns", fileEvent.Mntns)
 
 	if shouldExcludeFile(fileName) {
-		log.Printf("Excluded File: %s", fileName)
-
+		b.logger.Info("Exclude file", "filename", fileName)
 		return
 	}
 
 	mid := mntnsID(fileEvent.Mntns)
 	if _, ok := b.recordedFiles[mid]; !ok {
 		b.recordedFiles[mid] = map[string]*fileAccess{}
+	}
+
+	// Enforce a limit on max tracked files to avoid OOM.
+	if len(b.recordedFiles[mid]) > maxTrackedPaths {
+		b.logger.Info("Max tracked file reached. Profile will be truncated to avoid OOM",
+			"mntns", mid, "limit", maxTrackedPaths)
+		return
+	}
+
+	// Cap path length to prevent single-string memory bloat
+	if len(fileName) > maxPathLength {
+		fileName = fileName[:maxPathLength]
 	}
 
 	path, ok := b.recordedFiles[mid][fileName]
@@ -221,11 +239,11 @@ func (b *AppArmorRecorder) handleCapabilityEvent(capEvent *bpfEvent) {
 		return
 	}
 
-	log.Printf(
-		"Requested capability: %s with pid=%d, mntns=%d\n",
-		capabilityToString(requestedCap),
-		capEvent.Pid,
-		capEvent.Mntns,
+	b.logger.Info(
+		"Requested capability",
+		"capability", capabilityToString(requestedCap),
+		"pid", capEvent.Pid,
+		"mntns", capEvent.Mntns,
 	)
 
 	b.recordedCapabilities[mid] = append(b.recordedCapabilities[mid], requestedCap)
@@ -246,7 +264,8 @@ func (b *AppArmorRecorder) clearMntns(event *bpfEvent) {
 	defer b.lockRecordedSocketsUse.Unlock()
 
 	mntns := mntnsID(event.Mntns)
-	log.Printf("Clearing mntns: %d\n", mntns)
+
+	b.logger.Info("Clearing", "mntns", mntns)
 	delete(b.recordedFiles, mntns)
 	delete(b.recordedCapabilities, mntns)
 	delete(b.recordedSocketsUse, mntns)

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
@@ -173,6 +173,7 @@ func (b *AppArmorRecorder) handleFileEvent(fileEvent *bpfEvent) {
 
 	if shouldExcludeFile(fileName) {
 		b.logger.Info("Exclude file", "filename", fileName)
+
 		return
 	}
 
@@ -185,6 +186,7 @@ func (b *AppArmorRecorder) handleFileEvent(fileEvent *bpfEvent) {
 	if len(b.recordedFiles[mid]) > maxTrackedPaths {
 		b.logger.Info("Max tracked file reached. Profile will be truncated to avoid OOM",
 			"mntns", mid, "limit", maxTrackedPaths)
+
 		return
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Cap the maximum number of recorded files and the file path length in the eBPF recorder to avoid OOM.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Cap the maximum recorded files and the file legth to avoid OOM in eBpf recorder.
```
