### PR TITLE
Combine the pid with the start time of the process when caching the container ID

### DIFF
--- a/internal/pkg/util/containers.go
+++ b/internal/pkg/util/containers.go
@@ -108,7 +108,6 @@ func ContainerIDForPID(cache *ttlcache.Cache[string, string], pid int) (string, 
 
 // getProcessStartTimeTicks return the start time for a process.
 func getProcessStartTimeTicks(pid int, procStatReader procStatReader) (string, error) {
-	//stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
 	stat, err := procStatReader(pid)
 	if err != nil {
 		return "", fmt.Errorf("reading proc start time for %d pid: %w", pid, err)

--- a/internal/pkg/util/containers.go
+++ b/internal/pkg/util/containers.go
@@ -110,6 +110,7 @@ func getProcessStartTime(pid int) (string, error) {
 	// The comm field (field 2) is in parentheses and can contain spaces,
 	// so split after the last ")" to get reliable field indices.
 	raw := string(stat)
+
 	i := strings.LastIndexByte(raw, ')')
 	if i < 0 || i+2 >= len(raw) {
 		return "", fmt.Errorf("invalid proc stat format for pid: %d", pid)
@@ -120,5 +121,6 @@ func getProcessStartTime(pid int) (string, error) {
 	if len(fields) < 20 {
 		return "", fmt.Errorf("invalid proc stat format for pid: %d", pid)
 	}
+
 	return fields[19], nil
 }

--- a/internal/pkg/util/containers.go
+++ b/internal/pkg/util/containers.go
@@ -42,22 +42,28 @@ var (
 	// cgroup does not contain any container ID.
 	ErrContainerIDNotFound = errors.New("unable to find container ID in cgroup path")
 
-	// ErrContainerIDSearchFailed is the error returned with a reason by
+	// errContainerIDSearchFailed is the error returned with a reason by
 	// ContainerIDForPID if it fails to parse the container ID from the logs.
-	ErrContainerIDSearchFailed = errors.New("failed looking for container ID")
+	errContainerIDSearchFailed = errors.New("failed looking for container ID")
 )
+
+// procStatReader closure function to read the /proc/<pid>stat which allows for
+// more testability.
+type procStatReader func(pid int) ([]byte, error)
 
 // ContainerIDForPID tries to find the 64 digit container ID for the provided
 // PID by using its cgroup. It supports caching via the cache argument.
 func ContainerIDForPID(cache *ttlcache.Cache[string, string], pid int) (string, error) {
-	stat, err := getProcessStartTime(pid)
+	startTime, err := getProcessStartTimeTicks(pid, func(pid int) ([]byte, error) {
+		return os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	})
 	if err != nil {
 		return "", fmt.Errorf("reading proc start time: %w", err)
 	}
 
 	// Combine the pid with the process start time as a cache key to avoid "fork-bomb"
 	// attack which reuses a PID for a different container within the cache TTL.
-	cacheKey := strconv.Itoa(pid) + "_" + stat
+	cacheKey := strconv.Itoa(pid) + "_" + startTime
 
 	// Check the cache first
 	item := cache.Get(cacheKey)
@@ -94,15 +100,16 @@ func ContainerIDForPID(cache *ttlcache.Cache[string, string], pid int) (string, 
 	}
 	// Check if not finding a container ID was caused by any scanning errors.
 	if err := scanner.Err(); err != nil {
-		return "", fmt.Errorf("%w: %w", ErrContainerIDSearchFailed, err)
+		return "", fmt.Errorf("%w: %w", errContainerIDSearchFailed, err)
 	}
 
 	return "", ErrContainerIDNotFound
 }
 
-// getProcessStartTime return the start time for a process.
-func getProcessStartTime(pid int) (string, error) {
-	stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+// getProcessStartTimeTicks return the start time for a process.
+func getProcessStartTimeTicks(pid int, procStatReader procStatReader) (string, error) {
+	//stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	stat, err := procStatReader(pid)
 	if err != nil {
 		return "", fmt.Errorf("reading proc start time for %d pid: %w", pid, err)
 	}

--- a/internal/pkg/util/containers.go
+++ b/internal/pkg/util/containers.go
@@ -24,6 +24,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/jellydator/ttlcache/v3"
 )
@@ -40,13 +41,24 @@ var (
 	// ErrContainerIDNotFound is the error returned by ContainerIDForPID if the
 	// cgroup does not contain any container ID.
 	ErrContainerIDNotFound = errors.New("unable to find container ID in cgroup path")
+
+	ErrContainerIDSearchFailed = errors.New("failed looking for container ID")
 )
 
 // ContainerIDForPID tries to find the 64 digit container ID for the provided
 // PID by using its cgroup. It supports caching via the cache argument.
 func ContainerIDForPID(cache *ttlcache.Cache[string, string], pid int) (string, error) {
+	stat, err := getProcessStartTime(pid)
+	if err != nil {
+		return "", fmt.Errorf("reading proc start time: %w", err)
+	}
+
+	// Combine the pid with the process start time as a cache key to avoid "fork-bomb"
+	// attack which reuse a PID for a different container within the cache TTL.
+	cacheKey := strconv.Itoa(pid) + "_" + stat
+
 	// Check the cache first
-	item := cache.Get(strconv.Itoa(pid))
+	item := cache.Get(cacheKey)
 	if item != nil {
 		return item.Value(), nil
 	}
@@ -73,11 +85,28 @@ func ContainerIDForPID(cache *ttlcache.Cache[string, string], pid int) (string, 
 			// Using the last container ID in the cgroup path to support "docker in docker" use cases
 			containerID := containerIDs[len(containerIDs)-1]
 			// Update the cache
-			cache.Set(strconv.Itoa(pid), containerID, ttlcache.DefaultTTL)
+			cache.Set(cacheKey, containerID, ttlcache.DefaultTTL)
 
 			return containerID, nil
 		}
 	}
+	// Check if not finding a container ID was caused by any scanning errors.
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("%w: %w", ErrContainerIDSearchFailed, err)
+	}
 
 	return "", ErrContainerIDNotFound
+}
+
+// getProcessStartTime return the start time for a process.
+func getProcessStartTime(pid int) (string, error) {
+	stat, err := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+	if err != nil {
+		return "", fmt.Errorf("reading proc start time for %d pid: %w", pid, err)
+	}
+	fields := strings.Fields(string(stat))
+	if len(fields) < 22 {
+		return "", fmt.Errorf("invalid proc stat format for pid: %d", pid)
+	}
+	return fields[21], nil
 }

--- a/internal/pkg/util/containers.go
+++ b/internal/pkg/util/containers.go
@@ -42,6 +42,8 @@ var (
 	// cgroup does not contain any container ID.
 	ErrContainerIDNotFound = errors.New("unable to find container ID in cgroup path")
 
+	// ErrContainerIDSearchFailed is the error returned with a reason by
+	// ContainerIDForPID if it fails to parse the container ID from the logs.
 	ErrContainerIDSearchFailed = errors.New("failed looking for container ID")
 )
 
@@ -54,7 +56,7 @@ func ContainerIDForPID(cache *ttlcache.Cache[string, string], pid int) (string, 
 	}
 
 	// Combine the pid with the process start time as a cache key to avoid "fork-bomb"
-	// attack which reuse a PID for a different container within the cache TTL.
+	// attack which reuses a PID for a different container within the cache TTL.
 	cacheKey := strconv.Itoa(pid) + "_" + stat
 
 	// Check the cache first
@@ -104,9 +106,19 @@ func getProcessStartTime(pid int) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("reading proc start time for %d pid: %w", pid, err)
 	}
-	fields := strings.Fields(string(stat))
-	if len(fields) < 22 {
+
+	// The comm field (field 2) is in parentheses and can contain spaces,
+	// so split after the last ")" to get reliable field indices.
+	raw := string(stat)
+	i := strings.LastIndexByte(raw, ')')
+	if i < 0 || i+2 >= len(raw) {
 		return "", fmt.Errorf("invalid proc stat format for pid: %d", pid)
 	}
-	return fields[21], nil
+	// After ")" the fields are: state(3) ppid(4) ... starttime(22),
+	// which is index 19 in the zero-based slice after ")".
+	fields := strings.Fields(raw[i+2:])
+	if len(fields) < 20 {
+		return "", fmt.Errorf("invalid proc stat format for pid: %d", pid)
+	}
+	return fields[19], nil
 }

--- a/internal/pkg/util/containers_test.go
+++ b/internal/pkg/util/containers_test.go
@@ -115,6 +115,8 @@ func TestGetProcessStartTimeTicks(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
 			mockFileReader := func(pid int) ([]byte, error) {
 				if tt.mockErr != nil {
 					return nil, tt.mockErr

--- a/internal/pkg/util/containers_test.go
+++ b/internal/pkg/util/containers_test.go
@@ -17,6 +17,8 @@ limitations under the License.
 package util
 
 import (
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -61,4 +63,95 @@ func TestExtractContainerID(t *testing.T) {
 			require.Equal(t, tt.want, got)
 		})
 	}
+}
+
+func TestGetProcessStartTimeTicks(t *testing.T) {
+	t.Parallel()
+
+	filler := "S 1 1234 1234 0 -1 4194560 1234 0 0 0 10 20 30 40 20 0 1 0"
+
+	tests := []struct {
+		name        string
+		pid         int
+		mockContent string
+		mockErr     error
+		want        string
+		wantErr     bool
+	}{
+		{
+			name:        "Standard valid output",
+			pid:         1234,
+			mockContent: fmt.Sprintf("1234 (bash) %s 88888 1234", filler),
+			want:        "88888",
+			wantErr:     false,
+		},
+		{
+			name:        "Edge-case: comm field with spaces",
+			pid:         1234,
+			mockContent: fmt.Sprintf("1234 (my cool daemon) %s 99999 1234", filler),
+			want:        "99999",
+			wantErr:     false,
+		},
+		{
+			name:        "Edge-case: nested and trailing parentheses",
+			pid:         1234,
+			mockContent: fmt.Sprintf("1234 (my (cool) daemon()) %s 11111 1234", filler),
+			want:        "11111",
+			wantErr:     false,
+		},
+		{
+			name:    "Error path: missing /proc/<pid>/stat file",
+			pid:     9999,
+			mockErr: os.ErrNotExist,
+			wantErr: true,
+		},
+		{
+			name:        "Error path: truncated stat output",
+			pid:         1234,
+			mockContent: "1234 (bash S 1 1234",
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockFileReader := func(pid int) ([]byte, error) {
+				if tt.mockErr != nil {
+					return nil, tt.mockErr
+				}
+				return []byte(tt.mockContent), nil
+			}
+
+			got, err := getProcessStartTimeTicks(tt.pid, mockFileReader)
+
+			if tt.wantErr {
+				require.Error(t, err, "expected an error but got none")
+			} else {
+				require.NoError(t, err, "expected no error but got one")
+				require.Equal(t, tt.want, got, "start time ticks did not match")
+			}
+		})
+	}
+}
+
+func TestGetProcessStartTimeTicks_CacheMissOnRecycledPID(t *testing.T) {
+	pid := 1234
+	filler := "S 1 1234 1234 0 -1 4194560 1234 0 0 0 10 20 30 40 20 0 1 0"
+
+	// Execution 1: Mocking the original process
+	mockReader1 := func(pid int) ([]byte, error) {
+		return []byte(fmt.Sprintf("%d (bash) %s 100 1234", pid, filler)), nil
+	}
+	time1, err := getProcessStartTimeTicks(pid, mockReader1)
+	require.NoError(t, err)
+
+	// Execution 2: Mocking a new process that reused the same PID
+	mockReader2 := func(pid int) ([]byte, error) {
+		return []byte(fmt.Sprintf("%d (python3) %s 5000 1234", pid, filler)), nil
+	}
+	time2, err := getProcessStartTimeTicks(pid, mockReader2)
+	require.NoError(t, err)
+
+	// Verify the start times are distinct to prevent cache collisions
+	require.NotEqual(t, time1, time2, "expected different start times for a recycled PID to prevent cache poisoning")
 }

--- a/internal/pkg/util/containers_test.go
+++ b/internal/pkg/util/containers_test.go
@@ -119,6 +119,7 @@ func TestGetProcessStartTimeTicks(t *testing.T) {
 				if tt.mockErr != nil {
 					return nil, tt.mockErr
 				}
+
 				return []byte(tt.mockContent), nil
 			}
 
@@ -135,19 +136,21 @@ func TestGetProcessStartTimeTicks(t *testing.T) {
 }
 
 func TestGetProcessStartTimeTicks_CacheMissOnRecycledPID(t *testing.T) {
+	t.Parallel()
+
 	pid := 1234
 	filler := "S 1 1234 1234 0 -1 4194560 1234 0 0 0 10 20 30 40 20 0 1 0"
 
 	// Execution 1: Mocking the original process
 	mockReader1 := func(pid int) ([]byte, error) {
-		return []byte(fmt.Sprintf("%d (bash) %s 100 1234", pid, filler)), nil
+		return fmt.Appendf(nil, "%d (bash) %s 100 1234", pid, filler), nil
 	}
 	time1, err := getProcessStartTimeTicks(pid, mockReader1)
 	require.NoError(t, err)
 
 	// Execution 2: Mocking a new process that reused the same PID
 	mockReader2 := func(pid int) ([]byte, error) {
-		return []byte(fmt.Sprintf("%d (python3) %s 5000 1234", pid, filler)), nil
+		return fmt.Appendf(nil, "%d (python3) %s 5000 1234", pid, filler), nil
 	}
 	time2, err := getProcessStartTimeTicks(pid, mockReader2)
 	require.NoError(t, err)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

This is a mitigation to avoid a fork-bomb attack when a PID is reused
within the TTL of the cached container ID to introduce malicious content
within the profile recording.


#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Mitigate PID reuse attack in container ID caching by combining PID with process start time as the cache key
```