### PR TITLE
Fix data races, OOM guards, and performance in BPF recorder and container ID cache

### DIFF
--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_apparmor.go
@@ -28,6 +28,8 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
+
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 )
 
 const (
@@ -44,8 +46,20 @@ const (
 	// to prevent memory exhaustion (OOM) attacks from malicious workloads.
 	maxTrackedPaths = 10000
 
-	// maxPathLength enforces a ceiling on the string size stored in the map.
-	maxPathLength = 4096
+	// maxTrackedMntns limits the number of distinct mount namespaces tracked
+	// to prevent unbounded map growth when many containers start concurrently.
+	maxTrackedMntns = 1000
+)
+
+var (
+	reDirectPathWithPid = regexp.MustCompile(`^/\d+/`)
+	reDirectPathWithTid = regexp.MustCompile(`^/@{pid}/task/\d+/`)
+	rePathWithPid       = regexp.MustCompile(`^/proc/\d+/`)
+	rePathWithTid       = regexp.MustCompile(`^/proc/@{pid}/task/\d+/`)
+	rePathWithCid       = regexp.MustCompile(`/var/lib/containers/storage/overlay/\w+/`)
+	reUUID              = regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
+	reHash              = regexp.MustCompile(`[0-9a-fA-F]{32,}`)
+	reDigitSequence     = regexp.MustCompile(`\d{6,}`)
 )
 
 var appArmorHooks = []string{
@@ -80,6 +94,9 @@ type AppArmorRecorder struct {
 
 	recordedFiles     map[mntnsID]map[string]*fileAccess
 	lockRecordedFiles sync.Mutex
+
+	maxPathsWarned map[mntnsID]bool
+	maxMntnsWarned bool
 }
 
 type fileAccess struct {
@@ -119,6 +136,7 @@ func newAppArmorRecorder(logger logr.Logger, programName string) *AppArmorRecord
 		lockRecordedCapabilities: sync.Mutex{},
 		recordedFiles:            map[mntnsID]map[string]*fileAccess{},
 		lockRecordedFiles:        sync.Mutex{},
+		maxPathsWarned:           map[mntnsID]bool{},
 	}
 }
 
@@ -157,6 +175,8 @@ func (b *AppArmorRecorder) StopRecording(r *BpfRecorder) error {
 	clear(b.recordedSocketsUse)
 	clear(b.recordedCapabilities)
 	clear(b.recordedFiles)
+	clear(b.maxPathsWarned)
+	b.maxMntnsWarned = false
 
 	return nil
 }
@@ -168,32 +188,37 @@ func (b *AppArmorRecorder) handleFileEvent(fileEvent *bpfEvent) {
 	fileName := fileDataToString(&fileEvent.Data)
 	fileName = ReplaceVarianceInFilePath(fileName)
 
-	b.logger.Info("File access", "filename",
-		fileName, "flags", fileEvent.Flags, "pid", fileEvent.Pid, "mntns", fileEvent.Mntns)
+	b.logger.V(config.VerboseLevel).Info("File access",
+		"filename", fileName, "flags", fileEvent.Flags, "pid", fileEvent.Pid, "mntns", fileEvent.Mntns)
 
 	if shouldExcludeFile(fileName) {
-		b.logger.Info("Exclude file", "filename", fileName)
+		b.logger.V(config.VerboseLevel).Info("Exclude file", "filename", fileName)
 
 		return
 	}
 
 	mid := mntnsID(fileEvent.Mntns)
 	if _, ok := b.recordedFiles[mid]; !ok {
+		if len(b.recordedFiles) >= maxTrackedMntns {
+			if !b.maxMntnsWarned {
+				b.logger.Info("Max tracked mount namespaces reached, new containers will not be recorded",
+					"limit", maxTrackedMntns)
+				b.maxMntnsWarned = true
+			}
+
+			return
+		}
+
 		b.recordedFiles[mid] = map[string]*fileAccess{}
 	}
 
 	// Enforce a limit on max tracked files to avoid OOM.
 	if len(b.recordedFiles[mid]) >= maxTrackedPaths {
-		b.logger.Info("Max tracked files reached. Profile will be truncated to avoid OOM",
-			"mntns", mid, "limit", maxTrackedPaths)
-
-		return
-	}
-
-	// Cap path length to prevent single-string memory bloat
-	if len(fileName) > maxPathLength {
-		b.logger.Info("Skipping file with excessively long path",
-			"length", len(fileName), "mntns", mid)
+		if !b.maxPathsWarned[mid] {
+			b.logger.Info("Max tracked files reached, profile will be truncated",
+				"mntns", mid, "limit", maxTrackedPaths)
+			b.maxPathsWarned[mid] = true
+		}
 
 		return
 	}
@@ -259,14 +284,14 @@ func (b *AppArmorRecorder) handleCapabilityEvent(capEvent *bpfEvent) {
 // The recorder triggers this after container initialization to make sure that
 // permissions needed for setup are not included in the final profile.
 func (b *AppArmorRecorder) clearMntns(event *bpfEvent) {
-	b.lockRecordedFiles.Lock()
-	defer b.lockRecordedFiles.Unlock()
+	b.lockRecordedSocketsUse.Lock()
+	defer b.lockRecordedSocketsUse.Unlock()
 
 	b.lockRecordedCapabilities.Lock()
 	defer b.lockRecordedCapabilities.Unlock()
 
-	b.lockRecordedSocketsUse.Lock()
-	defer b.lockRecordedSocketsUse.Unlock()
+	b.lockRecordedFiles.Lock()
+	defer b.lockRecordedFiles.Unlock()
 
 	mntns := mntnsID(event.Mntns)
 
@@ -274,17 +299,18 @@ func (b *AppArmorRecorder) clearMntns(event *bpfEvent) {
 	delete(b.recordedFiles, mntns)
 	delete(b.recordedCapabilities, mntns)
 	delete(b.recordedSocketsUse, mntns)
+	delete(b.maxPathsWarned, mntns)
 }
 
 func (b *AppArmorRecorder) GetKnownMntns() []mntnsID {
-	b.lockRecordedFiles.Lock()
-	defer b.lockRecordedFiles.Unlock()
+	b.lockRecordedSocketsUse.Lock()
+	defer b.lockRecordedSocketsUse.Unlock()
 
 	b.lockRecordedCapabilities.Lock()
 	defer b.lockRecordedCapabilities.Unlock()
 
-	b.lockRecordedSocketsUse.Lock()
-	defer b.lockRecordedSocketsUse.Unlock()
+	b.lockRecordedFiles.Lock()
+	defer b.lockRecordedFiles.Unlock()
 
 	known := make(map[mntnsID]bool, len(b.recordedFiles))
 	for mntns := range b.recordedFiles {
@@ -317,52 +343,29 @@ func (b *AppArmorRecorder) GetAppArmorProcessed(mntns uint32) BpfAppArmorProcess
 	mid := mntnsID(mntns)
 	processed.FileProcessed = b.processExecFsEvents(mid)
 
+	b.lockRecordedSocketsUse.Lock()
 	if sockets, ok := b.recordedSocketsUse[mid]; ok && sockets != nil {
-		processed.Socket = *b.recordedSocketsUse[mid]
+		processed.Socket = *sockets
 	}
 
-	processed.Capabilities = b.processCapabilities(mid)
-
-	// Clean up the recorded data after processing to avoid keeping global state.
 	delete(b.recordedSocketsUse, mid)
-	delete(b.recordedFiles, mid)
-	delete(b.recordedCapabilities, mid)
+	b.lockRecordedSocketsUse.Unlock()
+
+	processed.Capabilities = b.processCapabilities(mid)
 
 	return processed
 }
 
 func ReplaceVarianceInFilePath(filePath string) string {
-	// Replace PID value with a apparmor variable (direct procfs access without /proc prefix).
-	directPathWithPid := regexp.MustCompile(`^/\d+/`)
-	filePath = directPathWithPid.ReplaceAllString(filePath, "/@{pid}/")
+	filePath = reDirectPathWithPid.ReplaceAllString(filePath, "/@{pid}/")
+	filePath = reDirectPathWithTid.ReplaceAllString(filePath, "/@{pid}/task/@{tid}/")
+	filePath = rePathWithPid.ReplaceAllString(filePath, "/proc/@{pid}/")
+	filePath = rePathWithTid.ReplaceAllString(filePath, "/proc/@{pid}/task/@{tid}/")
+	filePath = rePathWithCid.ReplaceAllString(filePath, "/var/lib/containers/storage/overlay/*/")
+	filePath = reUUID.ReplaceAllString(filePath, "*")
+	filePath = reHash.ReplaceAllString(filePath, "*")
+	filePath = reDigitSequence.ReplaceAllString(filePath, "*")
 
-	// Replace TID value with a apparmor variable (direct procfs access without /proc prefix).
-	directPathWithTid := regexp.MustCompile(`^/@{pid}/task/\d+/`)
-	filePath = directPathWithTid.ReplaceAllString(filePath, "/@{pid}/task/@{tid}/")
-
-	// Replace PID value with a apparmor variable.
-	pathWithPid := regexp.MustCompile(`^/proc/\d+/`)
-	filePath = pathWithPid.ReplaceAllString(filePath, "/proc/@{pid}/")
-
-	// Replace TID value with a apparmor variable.
-	pathWithTid := regexp.MustCompile(`^/proc/@{pid}/task/\d+/`)
-	filePath = pathWithTid.ReplaceAllString(filePath, "/proc/@{pid}/task/@{tid}/")
-
-	// Replace container ID with any container ID
-	pathWithCid := regexp.MustCompile(`/var/lib/containers/storage/overlay/\w+/`)
-	filePath = pathWithCid.ReplaceAllString(filePath, "/var/lib/containers/storage/overlay/*/")
-
-	uuid := regexp.MustCompile(`[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}`)
-	filePath = uuid.ReplaceAllString(filePath, "*")
-
-	hash := regexp.MustCompile(`[0-9a-fA-F]{32,}`)
-	filePath = hash.ReplaceAllString(filePath, "*")
-
-	// Assume that long digit sequences are random, replace them with a placeholder
-	digitSequence := regexp.MustCompile(`\d{6,}`)
-	filePath = digitSequence.ReplaceAllString(filePath, "*")
-
-	// Replace the sys devices with a generic path
 	if strings.HasPrefix(filePath, "/sys/devices/") {
 		filePath = "/sys/devices/**"
 	}
@@ -435,6 +438,8 @@ func (b *AppArmorRecorder) processExecFsEvents(mid mntnsID) BpfAppArmorFileProce
 	slices.Sort(processedEvents.WriteOnlyPaths)
 	slices.Sort(processedEvents.ReadWritePaths)
 
+	delete(b.recordedFiles, mid)
+
 	return processedEvents
 }
 
@@ -496,16 +501,21 @@ func allowAnyFiles(filePaths []string) []string {
 }
 
 func (b *AppArmorRecorder) processCapabilities(mid mntnsID) []string {
-	if _, ok := b.recordedCapabilities[mid]; !ok {
+	b.lockRecordedCapabilities.Lock()
+	defer b.lockRecordedCapabilities.Unlock()
+
+	caps, ok := b.recordedCapabilities[mid]
+	if !ok {
 		return []string{}
 	}
 
-	ret := make([]string, 0, len(b.recordedCapabilities[mid]))
-	for _, capID := range b.recordedCapabilities[mid] {
+	ret := make([]string, 0, len(caps))
+	for _, capID := range caps {
 		ret = append(ret, capabilityToString(capID))
 	}
 
 	slices.Sort(ret)
+	delete(b.recordedCapabilities, mid)
 
 	return ret
 }

--- a/internal/pkg/util/containers.go
+++ b/internal/pkg/util/containers.go
@@ -18,10 +18,10 @@ package util
 
 import (
 	"bufio"
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -47,16 +47,29 @@ var (
 	errContainerIDSearchFailed = errors.New("failed looking for container ID")
 )
 
-// procStatReader closure function to read the /proc/<pid>stat which allows for
-// more testability.
-type procStatReader func(pid int) ([]byte, error)
+// procFileReader reads a /proc/<pid>/<file> for a given PID, allowing
+// dependency injection in tests.
+type procFileReader func(pid int) ([]byte, error)
 
 // ContainerIDForPID tries to find the 64 digit container ID for the provided
 // PID by using its cgroup. It supports caching via the cache argument.
 func ContainerIDForPID(cache *ttlcache.Cache[string, string], pid int) (string, error) {
-	startTime, err := getProcessStartTimeTicks(pid, func(pid int) ([]byte, error) {
+	readFile := func(pid int) ([]byte, error) {
 		return os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
-	})
+	}
+	readCgroup := func(pid int) ([]byte, error) {
+		return os.ReadFile(fmt.Sprintf("/proc/%d/cgroup", pid))
+	}
+
+	return containerIDForPID(cache, pid, readFile, readCgroup)
+}
+
+func containerIDForPID(
+	cache *ttlcache.Cache[string, string],
+	pid int,
+	statReader, cgroupReader procFileReader,
+) (string, error) {
+	startTime, err := getProcessStartTimeTicks(pid, statReader)
 	if err != nil {
 		return "", fmt.Errorf("reading proc start time: %w", err)
 	}
@@ -65,40 +78,29 @@ func ContainerIDForPID(cache *ttlcache.Cache[string, string], pid int) (string, 
 	// attack which reuses a PID for a different container within the cache TTL.
 	cacheKey := strconv.Itoa(pid) + "_" + startTime
 
-	// Check the cache first
 	item := cache.Get(cacheKey)
 	if item != nil {
 		return item.Value(), nil
 	}
 
-	cgroupPath := fmt.Sprintf("/proc/%d/cgroup", pid)
-
-	file, err := os.Open(filepath.Clean(cgroupPath))
+	cgroupData, err := cgroupReader(pid)
 	if err != nil {
 		return "", fmt.Errorf("%w: %w", ErrProcessNotFound, err)
 	}
 
-	defer func() {
-		cerr := file.Close()
-		if err == nil {
-			err = cerr
-		}
-	}()
-
-	scanner := bufio.NewScanner(file)
+	scanner := bufio.NewScanner(bytes.NewReader(cgroupData))
 	for scanner.Scan() {
 		text := scanner.Text()
 
 		if containerIDs := ContainerIDRegex.FindAllString(text, -1); 0 < len(containerIDs) {
 			// Using the last container ID in the cgroup path to support "docker in docker" use cases
 			containerID := containerIDs[len(containerIDs)-1]
-			// Update the cache
 			cache.Set(cacheKey, containerID, ttlcache.DefaultTTL)
 
 			return containerID, nil
 		}
 	}
-	// Check if not finding a container ID was caused by any scanning errors.
+
 	if err := scanner.Err(); err != nil {
 		return "", fmt.Errorf("%w: %w", errContainerIDSearchFailed, err)
 	}
@@ -107,8 +109,8 @@ func ContainerIDForPID(cache *ttlcache.Cache[string, string], pid int) (string, 
 }
 
 // getProcessStartTimeTicks return the start time for a process.
-func getProcessStartTimeTicks(pid int, procStatReader procStatReader) (string, error) {
-	stat, err := procStatReader(pid)
+func getProcessStartTimeTicks(pid int, reader procFileReader) (string, error) {
+	stat, err := reader(pid)
 	if err != nil {
 		return "", fmt.Errorf("reading proc start time for %d pid: %w", pid, err)
 	}

--- a/internal/pkg/util/containers_test.go
+++ b/internal/pkg/util/containers_test.go
@@ -21,6 +21,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/jellydator/ttlcache/v3"
 	"github.com/stretchr/testify/require"
 )
 
@@ -159,4 +160,69 @@ func TestGetProcessStartTimeTicks_CacheMissOnRecycledPID(t *testing.T) {
 
 	// Verify the start times are distinct to prevent cache collisions
 	require.NotEqual(t, time1, time2, "expected different start times for a recycled PID to prevent cache poisoning")
+}
+
+const (
+	testContainerID1 = "af208fd68bf39a07a439ed0c9b6609b9ae63ecd8a5f1a2af3e0db48b945b320a"
+	testContainerID2 = "b469ca5b54e01e7724b7a990f01d54f571dd7669b87851a87bd8b849c438c580"
+	testStatFiller   = "S 1 1234 1234 0 -1 4194560 1234 0 0 0 10 20 30 40 20 0 1 0"
+)
+
+func TestContainerIDForPID_CacheKeyWithStartTime(t *testing.T) {
+	t.Parallel()
+
+	cache := ttlcache.New[string, string]()
+
+	statReader := func(pid int) ([]byte, error) {
+		return fmt.Appendf(nil, "%d (bash) %s 100 1234", pid, testStatFiller), nil
+	}
+	cgroupReader := func(_ int) ([]byte, error) {
+		return fmt.Appendf(nil, "0::/kubepods/pod123/crio-%s\n", testContainerID1), nil
+	}
+
+	id1, err := containerIDForPID(cache, 1234, statReader, cgroupReader)
+	require.NoError(t, err)
+	require.Equal(t, testContainerID1, id1)
+
+	// Same PID but different start time (recycled PID) should produce a cache miss
+	// and return the new container's ID.
+	statReader2 := func(pid int) ([]byte, error) {
+		return fmt.Appendf(nil, "%d (python3) %s 200 1234", pid, testStatFiller), nil
+	}
+	cgroupReader2 := func(_ int) ([]byte, error) {
+		return fmt.Appendf(nil, "0::/kubepods/pod456/crio-%s\n", testContainerID2), nil
+	}
+
+	id2, err := containerIDForPID(cache, 1234, statReader2, cgroupReader2)
+	require.NoError(t, err)
+	require.Equal(t, testContainerID2, id2)
+	require.NotEqual(t, id1, id2)
+}
+
+func TestContainerIDForPID_CacheHit(t *testing.T) {
+	t.Parallel()
+
+	cache := ttlcache.New[string, string]()
+
+	cgroupCalls := 0
+	statReader := func(pid int) ([]byte, error) {
+		return fmt.Appendf(nil, "%d (bash) %s 100 1234", pid, testStatFiller), nil
+	}
+	cgroupReader := func(pid int) ([]byte, error) {
+		cgroupCalls++
+
+		return fmt.Appendf(nil, "0::/kubepods/pod123/crio-%s\n", testContainerID1), nil
+	}
+
+	id1, err := containerIDForPID(cache, 1234, statReader, cgroupReader)
+	require.NoError(t, err)
+	require.Equal(t, testContainerID1, id1)
+	require.Equal(t, 1, cgroupCalls)
+
+	// Second call with the same PID and start time should hit the cache
+	// and skip the cgroup read entirely.
+	id2, err := containerIDForPID(cache, 1234, statReader, cgroupReader)
+	require.NoError(t, err)
+	require.Equal(t, id1, id2)
+	require.Equal(t, 1, cgroupCalls)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Follow-up fixes from #3247 and #3246:
- Fix data race in `GetAppArmorProcessed`: socket and capability map access lacked locks while event handlers write concurrently. Fold cleanup deletes into the locked processing methods.
- Fix lock ordering inconsistency: align `clearMntns` and `GetKnownMntns` to acquire locks in the same order as `StopRecording` (Sockets, Capabilities, Files) to prevent potential deadlocks.
- Prevent log spam when `maxTrackedPaths` limit is hit: log only once per mount namespace instead of on every subsequent event.
- Cap tracked mount namespaces at 1000 to prevent unbounded map growth when many containers start concurrently.
- Move 8 `regexp.MustCompile` calls from `ReplaceVarianceInFilePath` (called per file event) to package-level vars.
- Change per-event "File access" and "Exclude file" logs from `Info` to `V(config.VerboseLevel)` to match other hot-path logging in the recorder.
- Remove dead `maxPathLength` check (redundant with BPF buffer `pathMax=4096`).
- Add integration tests for `ContainerIDForPID` cache behavior (PID reuse produces cache miss, same PID+starttime produces cache hit).
- Refactor `ContainerIDForPID` for testability by extracting internal function with injected readers.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Yes, added `TestContainerIDForPID_CacheKeyWithStartTime` and `TestContainerIDForPID_CacheHit`.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```