### PR TITLE
Verify the base profile OIDC on immutable image digest and add options to spod config to setup allowed identity and Oidc Issuer regexp(s)

### DIFF
--- a/api/spod/v1/spod_types.go
+++ b/api/spod/v1/spod_types.go
@@ -267,7 +267,7 @@ type SPODSecurityConfig struct {
 	// +default=".*"
 	AllowedIdentityRegexp string `json:"allowedIdentityRegexp,omitempty"`
 
-	// allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+	// allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
 	// image used to distribute the base profile in the cluster.
 	// +optional
 	// +default=".*"

--- a/api/spod/v1/spod_types.go
+++ b/api/spod/v1/spod_types.go
@@ -260,6 +260,18 @@ type SPODSecurityConfig struct {
 	// +optional
 	// +default=false
 	DisableOCIArtifactSignatureVerification *bool `json:"disableOciArtifactSignatureVerification,omitempty"`
+
+	// allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
+	// image used to distribute the base profile in the cluster.
+	// +optional
+	// +default=".*"
+	AllowedIdentityRegexp string `json:"allowedIdentityRegexp,omitempty"`
+
+	// allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+	// image used to distribute the base profile in the cluster.
+	// +optional
+	// +default=".*"
+	AllowedOidcIssuerRegexp string `json:"allowedOidcIssuerRegexp,omitempty"`
 }
 
 // SPODState defines the state that the spod is in.

--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -252,7 +252,7 @@ metadata:
     capabilities: Basic Install
     categories: Security
     containerImage: registry.k8s.io/security-profiles-operator/security-profiles-operator:v0.10.1
-    createdAt: "2026-06-15T14:03:46Z"
+    createdAt: "2026-06-15T14:55:30Z"
     olm.skipRange: '>=0.4.1 <0.10.2-dev'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/os.linux: supported

--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -252,7 +252,7 @@ metadata:
     capabilities: Basic Install
     categories: Security
     containerImage: registry.k8s.io/security-profiles-operator/security-profiles-operator:v0.10.1
-    createdAt: "2026-06-11T07:44:22Z"
+    createdAt: "2026-06-15T14:03:46Z"
     olm.skipRange: '>=0.4.1 <0.10.2-dev'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/os.linux: supported

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_securityprofilesoperatordaemons.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_securityprofilesoperatordaemons.yaml
@@ -1242,7 +1242,7 @@ spec:
                   allowedOidcIssuerRegexp:
                     default: .*
                     description: |-
-                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
                     type: string
                   allowedSeccompActions:

--- a/bundle/manifests/security-profiles-operator.x-k8s.io_securityprofilesoperatordaemons.yaml
+++ b/bundle/manifests/security-profiles-operator.x-k8s.io_securityprofilesoperatordaemons.yaml
@@ -1233,6 +1233,18 @@ spec:
               security:
                 description: security contains security policy configuration.
                 properties:
+                  allowedIdentityRegexp:
+                    default: .*
+                    description: |-
+                      allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
+                      image used to distribute the base profile in the cluster.
+                    type: string
+                  allowedOidcIssuerRegexp:
+                    default: .*
+                    description: |-
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      image used to distribute the base profile in the cluster.
+                    type: string
                   allowedSeccompActions:
                     description: allowedSeccompActions if specified, a list of allowed
                       seccomp actions.
@@ -2763,6 +2775,7 @@ spec:
                       controller will not be started. Defaults to true when SELinux is enabled.
                     type: boolean
                   options:
+                    default: {}
                     description: options defines options specific to the SELinux functionality.
                     properties:
                       allowedSystemProfiles:

--- a/cmd/spoc/main.go
+++ b/cmd/spoc/main.go
@@ -244,7 +244,7 @@ func main() {
 					Usage:   "disable signature verification",
 				},
 				&cli.StringFlag{
-					Name:    puller.FlagAllowedIdentitiesRegexp,
+					Name:    puller.FlagAllowedIdentityRegexp,
 					Aliases: []string{"i"},
 					EnvVars: []string{"ALLOWED_IDENTITIES_REGEXP"},
 					Usage:   "regexp for allowed identities in signature verification",

--- a/cmd/spoc/main.go
+++ b/cmd/spoc/main.go
@@ -243,6 +243,18 @@ func main() {
 					EnvVars: []string{"DISABLE_SIGNATURE_VERIFICATION"},
 					Usage:   "disable signature verification",
 				},
+				&cli.StringFlag{
+					Name:    puller.FlagAllowedIdentitiesRegexp,
+					Aliases: []string{"i"},
+					EnvVars: []string{"ALLOWED_IDENTITIES_REGEXP"},
+					Usage:   "regexp for allowed identities in signature verification",
+				},
+				&cli.StringFlag{
+					Name:    puller.FlagAllowedOidcIssuerRegexp,
+					Aliases: []string{"o"},
+					EnvVars: []string{"ALLOWED_OIDC_ISSUER_REGEXP"},
+					Usage:   "regexp for allowed Oidc issuer in signature verification",
+				},
 			},
 		},
 	)

--- a/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
@@ -1219,6 +1219,18 @@ spec:
               security:
                 description: security contains security policy configuration.
                 properties:
+                  allowedIdentityRegexp:
+                    default: .*
+                    description: |-
+                      allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
+                      image used to distribute the base profile in the cluster.
+                    type: string
+                  allowedOidcIssuerRegexp:
+                    default: .*
+                    description: |-
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      image used to distribute the base profile in the cluster.
+                    type: string
                   allowedSeccompActions:
                     description: allowedSeccompActions if specified, a list of allowed
                       seccomp actions.

--- a/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
@@ -1228,7 +1228,7 @@ spec:
                   allowedOidcIssuerRegexp:
                     default: .*
                     description: |-
-                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
                     type: string
                   allowedSeccompActions:

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -2613,7 +2613,7 @@ spec:
                   allowedOidcIssuerRegexp:
                     default: .*
                     description: |-
-                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
                     type: string
                   allowedSeccompActions:

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -2604,6 +2604,18 @@ spec:
               security:
                 description: security contains security policy configuration.
                 properties:
+                  allowedIdentityRegexp:
+                    default: .*
+                    description: |-
+                      allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
+                      image used to distribute the base profile in the cluster.
+                    type: string
+                  allowedOidcIssuerRegexp:
+                    default: .*
+                    description: |-
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      image used to distribute the base profile in the cluster.
+                    type: string
                   allowedSeccompActions:
                     description: allowedSeccompActions if specified, a list of allowed
                       seccomp actions.

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2613,7 +2613,7 @@ spec:
                   allowedOidcIssuerRegexp:
                     default: .*
                     description: |-
-                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
                     type: string
                   allowedSeccompActions:

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2604,6 +2604,18 @@ spec:
               security:
                 description: security contains security policy configuration.
                 properties:
+                  allowedIdentityRegexp:
+                    default: .*
+                    description: |-
+                      allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
+                      image used to distribute the base profile in the cluster.
+                    type: string
+                  allowedOidcIssuerRegexp:
+                    default: .*
+                    description: |-
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      image used to distribute the base profile in the cluster.
+                    type: string
                   allowedSeccompActions:
                     description: allowedSeccompActions if specified, a list of allowed
                       seccomp actions.

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3370,7 +3370,7 @@ spec:
                   allowedOidcIssuerRegexp:
                     default: .*
                     description: |-
-                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
                     type: string
                   allowedSeccompActions:

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3361,6 +3361,18 @@ spec:
               security:
                 description: security contains security policy configuration.
                 properties:
+                  allowedIdentityRegexp:
+                    default: .*
+                    description: |-
+                      allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
+                      image used to distribute the base profile in the cluster.
+                    type: string
+                  allowedOidcIssuerRegexp:
+                    default: .*
+                    description: |-
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      image used to distribute the base profile in the cluster.
+                    type: string
                   allowedSeccompActions:
                     description: allowedSeccompActions if specified, a list of allowed
                       seccomp actions.

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -2613,7 +2613,7 @@ spec:
                   allowedOidcIssuerRegexp:
                     default: .*
                     description: |-
-                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
                     type: string
                   allowedSeccompActions:

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -2604,6 +2604,18 @@ spec:
               security:
                 description: security contains security policy configuration.
                 properties:
+                  allowedIdentityRegexp:
+                    default: .*
+                    description: |-
+                      allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
+                      image used to distribute the base profile in the cluster.
+                    type: string
+                  allowedOidcIssuerRegexp:
+                    default: .*
+                    description: |-
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      image used to distribute the base profile in the cluster.
+                    type: string
                   allowedSeccompActions:
                     description: allowedSeccompActions if specified, a list of allowed
                       seccomp actions.

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2613,7 +2613,7 @@ spec:
                   allowedOidcIssuerRegexp:
                     default: .*
                     description: |-
-                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
                     type: string
                   allowedSeccompActions:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2604,6 +2604,18 @@ spec:
               security:
                 description: security contains security policy configuration.
                 properties:
+                  allowedIdentityRegexp:
+                    default: .*
+                    description: |-
+                      allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
+                      image used to distribute the base profile in the cluster.
+                    type: string
+                  allowedOidcIssuerRegexp:
+                    default: .*
+                    description: |-
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      image used to distribute the base profile in the cluster.
+                    type: string
                   allowedSeccompActions:
                     description: allowedSeccompActions if specified, a list of allowed
                       seccomp actions.

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3370,7 +3370,7 @@ spec:
                   allowedOidcIssuerRegexp:
                     default: .*
                     description: |-
-                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
                     type: string
                   allowedSeccompActions:

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3361,6 +3361,18 @@ spec:
               security:
                 description: security contains security policy configuration.
                 properties:
+                  allowedIdentityRegexp:
+                    default: .*
+                    description: |-
+                      allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
+                      image used to distribute the base profile in the cluster.
+                    type: string
+                  allowedOidcIssuerRegexp:
+                    default: .*
+                    description: |-
+                      allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OIDC
+                      image used to distribute the base profile in the cluster.
+                    type: string
                   allowedSeccompActions:
                     description: allowedSeccompActions if specified, a list of allowed
                       seccomp actions.

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/maxbrunsfeld/counterfeiter/v6 v6.12.2
 	github.com/mogensen/kubernetes-split-yaml v0.4.0
 	github.com/nxadm/tail v1.4.11
+	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
 	github.com/opencontainers/runc v1.4.2
 	github.com/opencontainers/runtime-spec v1.3.0
@@ -228,7 +229,6 @@ require (
 	github.com/olekukonko/tablewriter v1.1.4 // indirect
 	github.com/open-policy-agent/opa v1.14.0 // indirect
 	github.com/opencontainers/cgroups v0.0.6 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/pborman/uuid v1.2.1 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.4 // indirect
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect

--- a/internal/pkg/artifact/artifact.go
+++ b/internal/pkg/artifact/artifact.go
@@ -83,6 +83,18 @@ type Artifact struct {
 	logger logr.Logger
 }
 
+// PullSignatureOptions options for verifying the OCI image signature during pulling.
+type PullSignatureOptions struct {
+	// DisableSignatureVerification disables signature verification during pulling.
+	DisableSignatureVerification bool
+
+	// AllowedIdentityRegexp regexp for allowed identities for signature verification.
+	AllowedIdentityRegexp string
+
+	// AllowedOidcIssuerRegexp regexp for allowed Oidc issuer for signature verification.
+	AllowedOidcIssuerRegexp string
+}
+
 // New returns a new Artifact instance.
 func New(logger logr.Logger) *Artifact {
 	return &Artifact{
@@ -266,7 +278,7 @@ func (a *Artifact) Pull(
 	c context.Context,
 	from, username, password string,
 	platform *v1.Platform,
-	disableSignatureVerification bool,
+	signOpts *PullSignatureOptions,
 ) (*PullResult, error) {
 	ctx, cancel := context.WithTimeout(c, defaultTimeout)
 	defer cancel()
@@ -282,15 +294,13 @@ func (a *Artifact) Pull(
 		return nil, fmt.Errorf("resolving digest for image %q: %w", from, err)
 	}
 
-	if !disableSignatureVerification {
+	if signOpts != nil && !signOpts.DisableSignatureVerification {
 		a.logger.Info("Verifying signature")
-
-		const all = ".*"
 
 		v := verify.VerifyCommand{
 			CertVerifyOptions: options.CertVerifyOptions{
-				CertIdentityRegexp:   all,
-				CertOidcIssuerRegexp: all,
+				CertIdentityRegexp:   signOpts.AllowedIdentityRegexp,
+				CertOidcIssuerRegexp: signOpts.AllowedOidcIssuerRegexp,
 			},
 		}
 		if err := a.VerifyCmd(ctx, v, from); err != nil {

--- a/internal/pkg/artifact/artifact.go
+++ b/internal/pkg/artifact/artifact.go
@@ -271,11 +271,12 @@ func (a *Artifact) Pull(
 	ctx, cancel := context.WithTimeout(c, defaultTimeout)
 	defer cancel()
 
+	a.logger.Info("Resolving digest of image: " + from)
+
 	// Retrieve the immutable image digest before doing any verification to
 	// prevent a TOCTOU attack on the mutable tag of the base image, which
 	// it might lead to a malicious based profile being injected between
-	// verification and copying the content
-	a.logger.Info("Resolving digest of image: " + from)
+	// verification and copying the content.
 	from, repo, sha, err := a.imageWithDigest(ctx, from, username, password)
 	if err != nil {
 		return nil, fmt.Errorf("resolving digest for image %q: %w", from, err)

--- a/internal/pkg/artifact/artifact.go
+++ b/internal/pkg/artifact/artifact.go
@@ -276,7 +276,7 @@ func (a *Artifact) Pull(
 	// it might lead to a malicious based profile being injected between
 	// verification and copying the content
 	a.logger.Info("Resolving digest of image: " + from)
-	from, repo, digest, err := a.imageWithDigest(ctx, from, username, password)
+	from, repo, sha, err := a.imageWithDigest(ctx, from, username, password)
 	if err != nil {
 		return nil, fmt.Errorf("resolving digest for image %q: %w", from, err)
 	}
@@ -321,12 +321,11 @@ func (a *Artifact) Pull(
 		}
 	}()
 
-	sha := digest.String()
-	a.logger.Info("Use image digest: %s", sha)
 	a.logger.Info("Copying profile from repository")
+	a.logger.Info("Source image", "image", from)
 
 	if _, err := a.Copy(
-		ctx, repo, sha, store, sha, oras.DefaultCopyOptions,
+		ctx, repo, sha.String(), store, sha.String(), oras.DefaultCopyOptions,
 	); err != nil {
 		return nil, fmt.Errorf("copy from repository: %w", err)
 	}
@@ -382,7 +381,8 @@ func (a *Artifact) Pull(
 // It retrieves the digest from the remote repository. Returns the updated image with
 // digest and the repository and the digest as separate return arguments.
 func (a *Artifact) imageWithDigest(ctx context.Context, image, username, password string) (
-	string, *remote.Repository, digest.Digest, error) {
+	string, *remote.Repository, digest.Digest, error,
+) {
 	ref, err := a.ParseReference(image)
 	if err != nil {
 		return "", nil, "", fmt.Errorf("parsing ref for image %q: %w", image, err)
@@ -391,7 +391,7 @@ func (a *Artifact) imageWithDigest(ctx context.Context, image, username, passwor
 	repo, err := a.NewRepository(ref.Name())
 	if err != nil {
 		return "", nil, "", fmt.Errorf("creating repository for %q: %w",
-			ref.Context().Name(), err)
+			ref.Name(), err)
 	}
 
 	if username != "" && password != "" {

--- a/internal/pkg/artifact/artifact.go
+++ b/internal/pkg/artifact/artifact.go
@@ -41,6 +41,8 @@ import (
 	selinuxprofileapi "sigs.k8s.io/security-profiles-operator/api/selinuxprofile/v1"
 )
 
+const allowAllRegexp = ".*"
+
 // PullResult is the type returned by Pull.
 type PullResult struct {
 	typ PullResultType
@@ -287,7 +289,7 @@ func (a *Artifact) Pull(
 
 	// Retrieve the immutable image digest before doing any verification to
 	// prevent a TOCTOU attack on the mutable tag of the base image, which
-	// it might lead to a malicious based profile being injected between
+	// which might lead to a malicious base profile being injected between
 	// verification and copying the content.
 	originalImage := from
 	from, repo, sha, err := a.imageWithDigest(ctx, originalImage, username, password)
@@ -295,7 +297,14 @@ func (a *Artifact) Pull(
 		return nil, fmt.Errorf("resolving digest for image %q: %w", originalImage, err)
 	}
 
-	if signOpts != nil && !signOpts.DisableSignatureVerification {
+	if signOpts == nil {
+		signOpts = &PullSignatureOptions{
+			AllowedIdentityRegexp:   allowAllRegexp,
+			AllowedOidcIssuerRegexp: allowAllRegexp,
+		}
+	}
+
+	if !signOpts.DisableSignatureVerification {
 		a.logger.Info("Verifying signature")
 
 		v := verify.VerifyCommand{

--- a/internal/pkg/artifact/artifact.go
+++ b/internal/pkg/artifact/artifact.go
@@ -26,11 +26,13 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
+	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/generate"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/verify"
 	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/retry"
 
@@ -269,6 +271,16 @@ func (a *Artifact) Pull(
 	ctx, cancel := context.WithTimeout(c, defaultTimeout)
 	defer cancel()
 
+	// Retrieve the immutable image digest before doing any verification to
+	// prevent a TOCTOU attack on the mutable tag of the base image, which
+	// it might lead to a malicious based profile being injected between
+	// verification and copying the content
+	a.logger.Info("Resolving digest of image: " + from)
+	from, repo, digest, err := a.imageWithDigest(ctx, from, username, password)
+	if err != nil {
+		return nil, fmt.Errorf("resolving digest for image %q: %w", from, err)
+	}
+
 	if !disableSignatureVerification {
 		a.logger.Info("Verifying signature")
 
@@ -309,41 +321,12 @@ func (a *Artifact) Pull(
 		}
 	}()
 
-	a.logger.Info("Verifying reference: " + from)
-
-	parsedRef, err := a.ParseReference(from)
-	if err != nil {
-		return nil, fmt.Errorf("parse reference: %w", err)
-	}
-
-	ref := parsedRef.Context().Name()
-	a.logger.Info("Creating repository for " + ref)
-
-	repo, err := a.NewRepository(ref)
-	if err != nil {
-		return nil, fmt.Errorf("create repository: %w", err)
-	}
-
-	if username != "" && password != "" {
-		a.logger.Info("Using username and password")
-
-		repo.Client = &auth.Client{
-			Client: retry.DefaultClient,
-			Cache:  auth.DefaultCache,
-			Credential: auth.StaticCredential(
-				repo.Reference.Registry,
-				auth.Credential{Username: username, Password: password},
-			),
-		}
-	}
-
-	tag := parsedRef.Identifier()
-	a.logger.Info("Using tag: " + tag)
-
+	sha := digest.String()
+	a.logger.Info("Use image digest: %s", sha)
 	a.logger.Info("Copying profile from repository")
 
 	if _, err := a.Copy(
-		ctx, repo, tag, store, tag, oras.DefaultCopyOptions,
+		ctx, repo, sha, store, sha, oras.DefaultCopyOptions,
 	); err != nil {
 		return nil, fmt.Errorf("copy from repository: %w", err)
 	}
@@ -393,6 +376,45 @@ func (a *Artifact) Pull(
 	default:
 		return nil, fmt.Errorf("cannot process %T to PullResult", obj)
 	}
+}
+
+// imageWithDigest transforms the given image into an image with digest instead of a tag.
+// It retrieves the digest from the remote repository. Returns the updated image with
+// digest and the repository and the digest as separate return arguments.
+func (a *Artifact) imageWithDigest(ctx context.Context, image, username, password string) (
+	string, *remote.Repository, digest.Digest, error) {
+	ref, err := a.ParseReference(image)
+	if err != nil {
+		return "", nil, "", fmt.Errorf("parsing ref for image %q: %w", image, err)
+	}
+
+	repo, err := a.NewRepository(ref.Name())
+	if err != nil {
+		return "", nil, "", fmt.Errorf("creating repository for %q: %w",
+			ref.Context().Name(), err)
+	}
+
+	if username != "" && password != "" {
+		a.logger.Info("Using username and password")
+
+		repo.Client = &auth.Client{
+			Client: retry.DefaultClient,
+			Cache:  auth.DefaultCache,
+			Credential: auth.StaticCredential(
+				repo.Reference.Registry,
+				auth.Credential{Username: username, Password: password},
+			),
+		}
+	}
+
+	desc, err := a.ResolveRepository(ctx, repo, ref.Identifier())
+	if err != nil {
+		return "", nil, "",
+			fmt.Errorf("resolving image identifier %q: %w", ref.Identifier(), err)
+	}
+
+	return fmt.Sprintf("%s@%s", ref.Name(),
+		desc.Digest.String()), repo, desc.Digest, nil
 }
 
 // profileName returns the name for the profile based on the platform.

--- a/internal/pkg/artifact/artifact.go
+++ b/internal/pkg/artifact/artifact.go
@@ -285,13 +285,14 @@ func (a *Artifact) Pull(
 	ctx, cancel := context.WithTimeout(c, defaultTimeout)
 	defer cancel()
 
-	a.logger.Info("Resolving digest of image: " + from)
+	originalImage := from
+
+	a.logger.Info("Resolving digest of image: " + originalImage)
 
 	// Retrieve the immutable image digest before doing any verification to
 	// prevent a TOCTOU attack on the mutable tag of the base image, which
-	// which might lead to a malicious base profile being injected between
+	// might lead to a malicious base profile being injected between
 	// verification and copying the content.
-	originalImage := from
 	from, repo, sha, err := a.imageWithDigest(ctx, originalImage, username, password)
 	if err != nil {
 		return nil, fmt.Errorf("resolving digest for image %q: %w", originalImage, err)

--- a/internal/pkg/artifact/artifact.go
+++ b/internal/pkg/artifact/artifact.go
@@ -289,9 +289,10 @@ func (a *Artifact) Pull(
 	// prevent a TOCTOU attack on the mutable tag of the base image, which
 	// it might lead to a malicious based profile being injected between
 	// verification and copying the content.
-	from, repo, sha, err := a.imageWithDigest(ctx, from, username, password)
+	originalImage := from
+	from, repo, sha, err := a.imageWithDigest(ctx, originalImage, username, password)
 	if err != nil {
-		return nil, fmt.Errorf("resolving digest for image %q: %w", from, err)
+		return nil, fmt.Errorf("resolving digest for image %q: %w", originalImage, err)
 	}
 
 	if signOpts != nil && !signOpts.DisableSignatureVerification {
@@ -399,7 +400,7 @@ func (a *Artifact) imageWithDigest(ctx context.Context, image, username, passwor
 		return "", nil, "", fmt.Errorf("parsing ref for image %q: %w", image, err)
 	}
 
-	repo, err := a.NewRepository(ref.Name())
+	repo, err := a.NewRepository(ref.Context().Name())
 	if err != nil {
 		return "", nil, "", fmt.Errorf("creating repository for %q: %w",
 			ref.Name(), err)
@@ -424,7 +425,7 @@ func (a *Artifact) imageWithDigest(ctx context.Context, image, username, passwor
 			fmt.Errorf("resolving image identifier %q: %w", ref.Identifier(), err)
 	}
 
-	return fmt.Sprintf("%s@%s", ref.Name(),
+	return fmt.Sprintf("%s@%s", ref.Context().Name(),
 		desc.Digest.String()), repo, desc.Digest, nil
 }
 

--- a/internal/pkg/artifact/artifact_test.go
+++ b/internal/pkg/artifact/artifact_test.go
@@ -235,6 +235,7 @@ func TestPull(t *testing.T) {
 			name: "success with failed cleanup",
 			prepare: func(mock *artifactfakes.FakeImpl) {
 				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
 				mock.ParseReferenceReturns(testRef, nil)
 				mock.ReadFileReturns([]byte{}, nil)
 				mock.ReadProfileReturns(&seccompprofileapi.SeccompProfile{}, nil)
@@ -253,6 +254,7 @@ func TestPull(t *testing.T) {
 			name: "success seccomp",
 			prepare: func(mock *artifactfakes.FakeImpl) {
 				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
 				mock.ParseReferenceReturns(testRef, nil)
 				mock.ReadFileReturns([]byte{}, nil)
 				mock.ReadProfileReturns(&seccompprofileapi.SeccompProfile{}, nil)
@@ -269,6 +271,7 @@ func TestPull(t *testing.T) {
 			name: "success selinux",
 			prepare: func(mock *artifactfakes.FakeImpl) {
 				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
 				mock.ParseReferenceReturns(testRef, nil)
 				mock.ReadFileReturns([]byte{}, nil)
 				mock.ReadProfileReturns(&selinuxprofileapi.SelinuxProfile{}, nil)
@@ -285,6 +288,7 @@ func TestPull(t *testing.T) {
 			name: "success apparmor",
 			prepare: func(mock *artifactfakes.FakeImpl) {
 				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
 				mock.ParseReferenceReturns(testRef, nil)
 				mock.ReadFileReturns([]byte{}, nil)
 				mock.ReadProfileReturns(&apparmorprofileapi.AppArmorProfile{}, nil)
@@ -301,6 +305,7 @@ func TestPull(t *testing.T) {
 			name: "failure on all YAML decodes",
 			prepare: func(mock *artifactfakes.FakeImpl) {
 				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
 				mock.ParseReferenceReturns(testRef, nil)
 				mock.ReadFileReturns([]byte{}, nil)
 				mock.ReadProfileReturns(nil, errTest)
@@ -315,6 +320,7 @@ func TestPull(t *testing.T) {
 			name: "failure on ReadFile",
 			prepare: func(mock *artifactfakes.FakeImpl) {
 				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
 				mock.ParseReferenceReturns(testRef, nil)
 				mock.ReadFileReturns(nil, errTest)
 			},
@@ -327,6 +333,7 @@ func TestPull(t *testing.T) {
 			name: "failure on Copy",
 			prepare: func(mock *artifactfakes.FakeImpl) {
 				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
 				mock.ParseReferenceReturns(testRef, nil)
 				mock.CopyReturns(defaultDescriptor(), errTest)
 			},
@@ -357,8 +364,23 @@ func TestPull(t *testing.T) {
 			},
 		},
 		{
+			name: "failure on ResolveRepository",
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ParseReferenceReturns(testRef, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, errTest)
+			},
+			assert: func(res *PullResult, err error) {
+				require.ErrorIs(t, err, errTest)
+				require.Nil(t, res)
+			},
+		},
+		{
 			name: "failure on FileNew",
 			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+				mock.ParseReferenceReturns(testRef, nil)
 				mock.FileNewReturns(nil, errTest)
 			},
 			assert: func(res *PullResult, err error) {
@@ -369,6 +391,9 @@ func TestPull(t *testing.T) {
 		{
 			name: "failure on MkdirTemp",
 			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+				mock.ParseReferenceReturns(testRef, nil)
 				mock.MkdirTempReturns("", errTest)
 			},
 			assert: func(res *PullResult, err error) {
@@ -379,6 +404,9 @@ func TestPull(t *testing.T) {
 		{
 			name: "failure on VerifyCmd",
 			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+				mock.ParseReferenceReturns(testRef, nil)
 				mock.VerifyCmdReturns(errTest)
 			},
 			assert: func(res *PullResult, err error) {

--- a/internal/pkg/artifact/artifact_test.go
+++ b/internal/pkg/artifact/artifact_test.go
@@ -427,7 +427,7 @@ func TestPull(t *testing.T) {
 			sut := New(logr.Discard())
 			sut.impl = mock
 
-			res, err := sut.Pull(t.Context(), "", "foo", "bar", nil, false)
+			res, err := sut.Pull(t.Context(), "", "foo", "bar", nil, &PullSignatureOptions{})
 			assert(res, err)
 		})
 	}

--- a/internal/pkg/artifact/artifactfakes/fake_impl.go
+++ b/internal/pkg/artifact/artifactfakes/fake_impl.go
@@ -196,6 +196,21 @@ type FakeImpl struct {
 	removeAllReturnsOnCall map[int]struct {
 		result1 error
 	}
+	ResolveRepositoryStub        func(context.Context, *remote.Repository, string) (v1.Descriptor, error)
+	resolveRepositoryMutex       sync.RWMutex
+	resolveRepositoryArgsForCall []struct {
+		arg1 context.Context
+		arg2 *remote.Repository
+		arg3 string
+	}
+	resolveRepositoryReturns struct {
+		result1 v1.Descriptor
+		result2 error
+	}
+	resolveRepositoryReturnsOnCall map[int]struct {
+		result1 v1.Descriptor
+		result2 error
+	}
 	SignCmdStub        func(*options.RootOptions, options.KeyOpts, options.SignOptions, []string) error
 	signCmdMutex       sync.RWMutex
 	signCmdArgsForCall []struct {
@@ -1034,6 +1049,72 @@ func (fake *FakeImpl) RemoveAllReturnsOnCall(i int, result1 error) {
 	fake.removeAllReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
+}
+
+func (fake *FakeImpl) ResolveRepository(arg1 context.Context, arg2 *remote.Repository, arg3 string) (v1.Descriptor, error) {
+	fake.resolveRepositoryMutex.Lock()
+	ret, specificReturn := fake.resolveRepositoryReturnsOnCall[len(fake.resolveRepositoryArgsForCall)]
+	fake.resolveRepositoryArgsForCall = append(fake.resolveRepositoryArgsForCall, struct {
+		arg1 context.Context
+		arg2 *remote.Repository
+		arg3 string
+	}{arg1, arg2, arg3})
+	stub := fake.ResolveRepositoryStub
+	fakeReturns := fake.resolveRepositoryReturns
+	fake.recordInvocation("ResolveRepository", []interface{}{arg1, arg2, arg3})
+	fake.resolveRepositoryMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) ResolveRepositoryCallCount() int {
+	fake.resolveRepositoryMutex.RLock()
+	defer fake.resolveRepositoryMutex.RUnlock()
+	return len(fake.resolveRepositoryArgsForCall)
+}
+
+func (fake *FakeImpl) ResolveRepositoryCalls(stub func(context.Context, *remote.Repository, string) (v1.Descriptor, error)) {
+	fake.resolveRepositoryMutex.Lock()
+	defer fake.resolveRepositoryMutex.Unlock()
+	fake.ResolveRepositoryStub = stub
+}
+
+func (fake *FakeImpl) ResolveRepositoryArgsForCall(i int) (context.Context, *remote.Repository, string) {
+	fake.resolveRepositoryMutex.RLock()
+	defer fake.resolveRepositoryMutex.RUnlock()
+	argsForCall := fake.resolveRepositoryArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeImpl) ResolveRepositoryReturns(result1 v1.Descriptor, result2 error) {
+	fake.resolveRepositoryMutex.Lock()
+	defer fake.resolveRepositoryMutex.Unlock()
+	fake.ResolveRepositoryStub = nil
+	fake.resolveRepositoryReturns = struct {
+		result1 v1.Descriptor
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) ResolveRepositoryReturnsOnCall(i int, result1 v1.Descriptor, result2 error) {
+	fake.resolveRepositoryMutex.Lock()
+	defer fake.resolveRepositoryMutex.Unlock()
+	fake.ResolveRepositoryStub = nil
+	if fake.resolveRepositoryReturnsOnCall == nil {
+		fake.resolveRepositoryReturnsOnCall = make(map[int]struct {
+			result1 v1.Descriptor
+			result2 error
+		})
+	}
+	fake.resolveRepositoryReturnsOnCall[i] = struct {
+		result1 v1.Descriptor
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeImpl) SignCmd(arg1 *options.RootOptions, arg2 options.KeyOpts, arg3 options.SignOptions, arg4 []string) error {

--- a/internal/pkg/artifact/impl.go
+++ b/internal/pkg/artifact/impl.go
@@ -56,6 +56,7 @@ type impl interface {
 	ClientSecret(options.OIDCOptions) (string, error)
 	SignCmd(*options.RootOptions, options.KeyOpts, options.SignOptions, []string) error
 	VerifyCmd(context.Context, verify.VerifyCommand, string) error
+	ResolveRepository(context.Context, *remote.Repository, string) (ocispec.Descriptor, error)
 }
 
 func (*defaultImpl) ParseReference(s string, opts ...ggcrname.Option) (ggcrname.Reference, error) {
@@ -140,4 +141,10 @@ func (*defaultImpl) VerifyCmd(
 	ctx context.Context, cmd verify.VerifyCommand, image string,
 ) error {
 	return cmd.Exec(ctx, []string{image})
+}
+
+//nolint:gocritic // intentional for the mock
+func (*defaultImpl) ResolveRepository(ctx context.Context,
+	repo *remote.Repository, reference string) (ocispec.Descriptor, error) {
+	return repo.Resolve(ctx, reference)
 }

--- a/internal/pkg/artifact/impl.go
+++ b/internal/pkg/artifact/impl.go
@@ -143,8 +143,8 @@ func (*defaultImpl) VerifyCmd(
 	return cmd.Exec(ctx, []string{image})
 }
 
-//nolint:gocritic // intentional for the mock
 func (*defaultImpl) ResolveRepository(ctx context.Context,
-	repo *remote.Repository, reference string) (ocispec.Descriptor, error) {
+	repo *remote.Repository, reference string,
+) (ocispec.Descriptor, error) {
 	return repo.Resolve(ctx, reference)
 }

--- a/internal/pkg/cli/puller/consts.go
+++ b/internal/pkg/cli/puller/consts.go
@@ -35,4 +35,12 @@ const (
 	// FlagDisableSignatureVerification is the flag for disabling the signature
 	// verification on pull.
 	FlagDisableSignatureVerification string = "disable-signature-verification"
+
+	// FlagAllowedIdentitiesRegexp is the flag for defining the allowed identity
+	// regexp when verifying the image signature.
+	FlagAllowedIdentitiesRegexp string = "allowed-identities-regexp"
+
+	// FlagAllowedOidcIssuerRegexp is the flag for defining the allowed Oidc issuers
+	// regexp when verifying the image signature.
+	FlagAllowedOidcIssuerRegexp string = "allowed-oidc-issuer-regexp"
 )

--- a/internal/pkg/cli/puller/consts.go
+++ b/internal/pkg/cli/puller/consts.go
@@ -36,9 +36,9 @@ const (
 	// verification on pull.
 	FlagDisableSignatureVerification string = "disable-signature-verification"
 
-	// FlagAllowedIdentitiesRegexp is the flag for defining the allowed identity
+	// FlagAllowedIdentityRegexp is the flag for defining the allowed identity
 	// regexp when verifying the image signature.
-	FlagAllowedIdentitiesRegexp string = "allowed-identity-regexp"
+	FlagAllowedIdentityRegexp string = "allowed-identity-regexp"
 
 	// FlagAllowedOidcIssuerRegexp is the flag for defining the allowed Oidc issuers
 	// regexp when verifying the image signature.

--- a/internal/pkg/cli/puller/consts.go
+++ b/internal/pkg/cli/puller/consts.go
@@ -38,7 +38,7 @@ const (
 
 	// FlagAllowedIdentitiesRegexp is the flag for defining the allowed identity
 	// regexp when verifying the image signature.
-	FlagAllowedIdentitiesRegexp string = "allowed-identities-regexp"
+	FlagAllowedIdentitiesRegexp string = "allowed-identity-regexp"
 
 	// FlagAllowedOidcIssuerRegexp is the flag for defining the allowed Oidc issuers
 	// regexp when verifying the image signature.

--- a/internal/pkg/cli/puller/impl.go
+++ b/internal/pkg/cli/puller/impl.go
@@ -32,15 +32,15 @@ type defaultImpl struct{}
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate -header ../../../../hack/boilerplate/boilerplate.generatego.txt
 //counterfeiter:generate . impl
 type impl interface {
-	Pull(string, string, string, *v1.Platform, bool) (*artifact.PullResult, error)
+	Pull(string, string, string, *v1.Platform, *artifact.PullSignatureOptions) (*artifact.PullResult, error)
 	WriteFile(string, []byte, os.FileMode) error
 }
 
 func (*defaultImpl) Pull(
-	from, username, password string, platform *v1.Platform, disableSignatureVerification bool,
+	from, username, password string, platform *v1.Platform, signOpts *artifact.PullSignatureOptions,
 ) (*artifact.PullResult, error) {
 	return artifact.New(logr.New(&cli.LogSink{})).Pull(
-		context.Background(), from, username, password, platform, disableSignatureVerification,
+		context.Background(), from, username, password, platform, signOpts,
 	)
 }
 

--- a/internal/pkg/cli/puller/options.go
+++ b/internal/pkg/cli/puller/options.go
@@ -75,8 +75,8 @@ func FromContext(ctx *ucli.Context) (*Options, error) {
 		options.disableSignatureVerification = ctx.Bool(FlagDisableSignatureVerification)
 	}
 
-	if ctx.IsSet(FlagAllowedIdentitiesRegexp) {
-		options.allowedIdentityRegexp = ctx.String(FlagAllowedIdentitiesRegexp)
+	if ctx.IsSet(FlagAllowedIdentityRegexp) {
+		options.allowedIdentityRegexp = ctx.String(FlagAllowedIdentityRegexp)
 	}
 
 	if ctx.IsSet(FlagAllowedOidcIssuerRegexp) {

--- a/internal/pkg/cli/puller/options.go
+++ b/internal/pkg/cli/puller/options.go
@@ -35,12 +35,16 @@ type Options struct {
 	password                     string
 	platform                     *v1.Platform
 	disableSignatureVerification bool
+	allowedIdentityRegexp        string
+	allowedOidcIssuerRegexp      string
 }
 
 // Default returns a default options instance.
 func Default() *Options {
 	return &Options{
-		outputFile: DefaultOutputFile,
+		outputFile:              DefaultOutputFile,
+		allowedIdentityRegexp:   ".*",
+		allowedOidcIssuerRegexp: ".*",
 	}
 }
 
@@ -69,6 +73,14 @@ func FromContext(ctx *ucli.Context) (*Options, error) {
 
 	if ctx.IsSet(FlagDisableSignatureVerification) {
 		options.disableSignatureVerification = ctx.Bool(FlagDisableSignatureVerification)
+	}
+
+	if ctx.IsSet(FlagAllowedIdentitiesRegexp) {
+		options.allowedIdentityRegexp = ctx.String(FlagAllowedIdentitiesRegexp)
+	}
+
+	if ctx.IsSet(FlagAllowedOidcIssuerRegexp) {
+		options.allowedOidcIssuerRegexp = ctx.String(FlagAllowedOidcIssuerRegexp)
 	}
 
 	options.password = os.Getenv(cli.EnvKeyPassword)

--- a/internal/pkg/cli/puller/options_test.go
+++ b/internal/pkg/cli/puller/options_test.go
@@ -67,8 +67,8 @@ func TestFromContext(t *testing.T) {
 			},
 			assert: func(opts *Options, err error) {
 				require.NoError(t, err)
-				require.Equal(t, opts.allowedIdentityRegexp, "testIdentity*")
-				require.Equal(t, opts.allowedOidcIssuerRegexp, "testOidc*")
+				require.Equal(t, "testIdentity*", opts.allowedIdentityRegexp)
+				require.Equal(t, "testOidc*", opts.allowedOidcIssuerRegexp)
 			},
 		},
 		{

--- a/internal/pkg/cli/puller/options_test.go
+++ b/internal/pkg/cli/puller/options_test.go
@@ -59,9 +59,9 @@ func TestFromContext(t *testing.T) {
 		{
 			name: "success with verify allowed identity and allowed oidc issuer regexp(s)",
 			prepare: func(set *flag.FlagSet) {
-				set.String(FlagAllowedIdentitiesRegexp, "testIdentity*", "")
+				set.String(FlagAllowedIdentityRegexp, "testIdentity*", "")
 				set.String(FlagAllowedOidcIssuerRegexp, "testOidc*", "")
-				require.NoError(t, set.Set(FlagAllowedIdentitiesRegexp, "testIdentity*"))
+				require.NoError(t, set.Set(FlagAllowedIdentityRegexp, "testIdentity*"))
 				require.NoError(t, set.Set(FlagAllowedOidcIssuerRegexp, "testOidc*"))
 				require.NoError(t, set.Parse([]string{"echo"}))
 			},

--- a/internal/pkg/cli/puller/options_test.go
+++ b/internal/pkg/cli/puller/options_test.go
@@ -57,6 +57,21 @@ func TestFromContext(t *testing.T) {
 			},
 		},
 		{
+			name: "success with verify allowed identity and allowed oidc issuer regexp(s)",
+			prepare: func(set *flag.FlagSet) {
+				set.String(FlagAllowedIdentitiesRegexp, "testIdentity*", "")
+				set.String(FlagAllowedOidcIssuerRegexp, "testOidc*", "")
+				require.NoError(t, set.Set(FlagAllowedIdentitiesRegexp, "testIdentity*"))
+				require.NoError(t, set.Set(FlagAllowedOidcIssuerRegexp, "testOidc*"))
+				require.NoError(t, set.Parse([]string{"echo"}))
+			},
+			assert: func(opts *Options, err error) {
+				require.NoError(t, err)
+				require.Equal(t, opts.allowedIdentityRegexp, "testIdentity*")
+				require.Equal(t, opts.allowedOidcIssuerRegexp, "testOidc*")
+			},
+		},
+		{
 			name: "failure no image provided",
 			prepare: func(set *flag.FlagSet) {
 				set.String(FlagOutputFile, "", "")

--- a/internal/pkg/cli/puller/puller.go
+++ b/internal/pkg/cli/puller/puller.go
@@ -47,7 +47,11 @@ func (p *Puller) Run() error {
 		p.options.username,
 		p.options.password,
 		p.options.platform,
-		p.options.disableSignatureVerification,
+		&artifact.PullSignatureOptions{
+			DisableSignatureVerification: p.options.disableSignatureVerification,
+			AllowedIdentityRegexp:        p.options.allowedIdentityRegexp,
+			AllowedOidcIssuerRegexp:      p.options.allowedOidcIssuerRegexp,
+		},
 	)
 	if err != nil {
 		return fmt.Errorf("pull profile: %w", err)

--- a/internal/pkg/cli/puller/pullerfakes/fake_impl.go
+++ b/internal/pkg/cli/puller/pullerfakes/fake_impl.go
@@ -26,14 +26,14 @@ import (
 )
 
 type FakeImpl struct {
-	PullStub        func(string, string, string, *v1.Platform, bool) (*artifact.PullResult, error)
+	PullStub        func(string, string, string, *v1.Platform, *artifact.PullSignatureOptions) (*artifact.PullResult, error)
 	pullMutex       sync.RWMutex
 	pullArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
 		arg4 *v1.Platform
-		arg5 bool
+		arg5 *artifact.PullSignatureOptions
 	}
 	pullReturns struct {
 		result1 *artifact.PullResult
@@ -60,7 +60,7 @@ type FakeImpl struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeImpl) Pull(arg1 string, arg2 string, arg3 string, arg4 *v1.Platform, arg5 bool) (*artifact.PullResult, error) {
+func (fake *FakeImpl) Pull(arg1 string, arg2 string, arg3 string, arg4 *v1.Platform, arg5 *artifact.PullSignatureOptions) (*artifact.PullResult, error) {
 	fake.pullMutex.Lock()
 	ret, specificReturn := fake.pullReturnsOnCall[len(fake.pullArgsForCall)]
 	fake.pullArgsForCall = append(fake.pullArgsForCall, struct {
@@ -68,7 +68,7 @@ func (fake *FakeImpl) Pull(arg1 string, arg2 string, arg3 string, arg4 *v1.Platf
 		arg2 string
 		arg3 string
 		arg4 *v1.Platform
-		arg5 bool
+		arg5 *artifact.PullSignatureOptions
 	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.PullStub
 	fakeReturns := fake.pullReturns
@@ -89,13 +89,13 @@ func (fake *FakeImpl) PullCallCount() int {
 	return len(fake.pullArgsForCall)
 }
 
-func (fake *FakeImpl) PullCalls(stub func(string, string, string, *v1.Platform, bool) (*artifact.PullResult, error)) {
+func (fake *FakeImpl) PullCalls(stub func(string, string, string, *v1.Platform, *artifact.PullSignatureOptions) (*artifact.PullResult, error)) {
 	fake.pullMutex.Lock()
 	defer fake.pullMutex.Unlock()
 	fake.PullStub = stub
 }
 
-func (fake *FakeImpl) PullArgsForCall(i int) (string, string, string, *v1.Platform, bool) {
+func (fake *FakeImpl) PullArgsForCall(i int) (string, string, string, *v1.Platform, *artifact.PullSignatureOptions) {
 	fake.pullMutex.RLock()
 	defer fake.pullMutex.RUnlock()
 	argsForCall := fake.pullArgsForCall[i]

--- a/internal/pkg/daemon/seccompprofile/impl.go
+++ b/internal/pkg/daemon/seccompprofile/impl.go
@@ -37,7 +37,7 @@ type defaultImpl struct{}
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate -header ../../../../hack/boilerplate/boilerplate.generatego.txt
 //counterfeiter:generate . impl
 type impl interface {
-	Pull(context.Context, logr.Logger, string, string, string, *v1.Platform, bool) (*artifact.PullResult, error)
+	Pull(context.Context, logr.Logger, string, string, string, *v1.Platform, *artifact.PullSignatureOptions) (*artifact.PullResult, error)
 	PullResultType(*artifact.PullResult) artifact.PullResultType
 	PullResultSeccompProfile(*artifact.PullResult) *seccompprofileapi.SeccompProfile
 	ClientGetProfile(
@@ -53,9 +53,9 @@ func (*defaultImpl) Pull(
 	l logr.Logger,
 	from, username, password string,
 	platform *v1.Platform,
-	disableSignatureVerification bool,
+	signOpts *artifact.PullSignatureOptions,
 ) (*artifact.PullResult, error) {
-	return artifact.New(l).Pull(ctx, from, username, password, platform, disableSignatureVerification)
+	return artifact.New(l).Pull(ctx, from, username, password, platform, signOpts)
 }
 
 func (*defaultImpl) PullResultType(res *artifact.PullResult) artifact.PullResultType {

--- a/internal/pkg/daemon/seccompprofile/impl.go
+++ b/internal/pkg/daemon/seccompprofile/impl.go
@@ -37,7 +37,8 @@ type defaultImpl struct{}
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate -header ../../../../hack/boilerplate/boilerplate.generatego.txt
 //counterfeiter:generate . impl
 type impl interface {
-	Pull(context.Context, logr.Logger, string, string, string, *v1.Platform, *artifact.PullSignatureOptions) (*artifact.PullResult, error)
+	Pull(context.Context, logr.Logger, string, string, string, *v1.Platform,
+		*artifact.PullSignatureOptions) (*artifact.PullResult, error)
 	PullResultType(*artifact.PullResult) artifact.PullResultType
 	PullResultSeccompProfile(*artifact.PullResult) *seccompprofileapi.SeccompProfile
 	ClientGetProfile(

--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -86,6 +86,8 @@ const (
 
 	defaultCacheTimeout time.Duration = 24 * time.Hour
 	maxCacheItems       uint64        = 1000
+
+	allowedAllRegexp string = ".*"
 )
 
 // NewController returns a new empty controller instance.
@@ -388,6 +390,14 @@ func (r *Reconciler) resolveSyscallsForProfile(
 			spod, err := r.GetSPOD(ctx, r.client)
 			if err != nil {
 				return nil, fmt.Errorf("retrieving the SPOD configuration: %w", err)
+			}
+
+			if spod.Spec.Security.AllowedIdentityRegexp == "" {
+				spod.Spec.Security.AllowedIdentityRegexp = allowedAllRegexp
+			}
+
+			if spod.Spec.Security.AllowedOidcIssuerRegexp == "" {
+				spod.Spec.Security.AllowedOidcIssuerRegexp = allowedAllRegexp
 			}
 
 			signOpts := &artifact.PullSignatureOptions{

--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -390,16 +390,22 @@ func (r *Reconciler) resolveSyscallsForProfile(
 				return nil, fmt.Errorf("retrieving the SPOD configuration: %w", err)
 			}
 
-			disableVerification := ptr.Deref(spod.Spec.Security.DisableOCIArtifactSignatureVerification, false)
+			signOpts := &artifact.PullSignatureOptions{
+				DisableSignatureVerification: ptr.Deref(spod.Spec.Security.DisableOCIArtifactSignatureVerification, false),
+				AllowedIdentityRegexp:        spod.Spec.Security.AllowedIdentityRegexp,
+				AllowedOidcIssuerRegexp:      spod.Spec.Security.AllowedOidcIssuerRegexp,
+			}
 			l.Info(
 				"Pulling base profile: "+from,
-				"disableOCIArtifactSignatureVerification", disableVerification,
+				"disableOCIArtifactSignatureVerification", signOpts.DisableSignatureVerification,
+				"allowedIdentityRegexp", signOpts.AllowedIdentityRegexp,
+				"allowedOidcIssuerRegexp", signOpts.AllowedOidcIssuerRegexp,
 			)
 
 			res, err := r.Pull(ctx, l, from, "", "", &v1.Platform{
 				Architecture: runtime.GOARCH,
 				OS:           runtime.GOOS,
-			}, disableVerification)
+			}, signOpts)
 			if err != nil {
 				l.Error(err, "cannot pull base profile "+baseProfileName)
 				r.IncSeccompProfileError(r.metrics, reasonCannotPullProfile)

--- a/internal/pkg/daemon/seccompprofile/seccompprofilefakes/fake_impl.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofilefakes/fake_impl.go
@@ -69,7 +69,7 @@ type FakeImpl struct {
 		arg1 *metrics.Metrics
 		arg2 string
 	}
-	PullStub        func(context.Context, logr.Logger, string, string, string, *v1b.Platform, bool) (*artifact.PullResult, error)
+	PullStub        func(context.Context, logr.Logger, string, string, string, *v1b.Platform, *artifact.PullSignatureOptions) (*artifact.PullResult, error)
 	pullMutex       sync.RWMutex
 	pullArgsForCall []struct {
 		arg1 context.Context
@@ -78,7 +78,7 @@ type FakeImpl struct {
 		arg4 string
 		arg5 string
 		arg6 *v1b.Platform
-		arg7 bool
+		arg7 *artifact.PullSignatureOptions
 	}
 	pullReturns struct {
 		result1 *artifact.PullResult
@@ -288,7 +288,7 @@ func (fake *FakeImpl) IncSeccompProfileErrorArgsForCall(i int) (*metrics.Metrics
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeImpl) Pull(arg1 context.Context, arg2 logr.Logger, arg3 string, arg4 string, arg5 string, arg6 *v1b.Platform, arg7 bool) (*artifact.PullResult, error) {
+func (fake *FakeImpl) Pull(arg1 context.Context, arg2 logr.Logger, arg3 string, arg4 string, arg5 string, arg6 *v1b.Platform, arg7 *artifact.PullSignatureOptions) (*artifact.PullResult, error) {
 	fake.pullMutex.Lock()
 	ret, specificReturn := fake.pullReturnsOnCall[len(fake.pullArgsForCall)]
 	fake.pullArgsForCall = append(fake.pullArgsForCall, struct {
@@ -298,7 +298,7 @@ func (fake *FakeImpl) Pull(arg1 context.Context, arg2 logr.Logger, arg3 string, 
 		arg4 string
 		arg5 string
 		arg6 *v1b.Platform
-		arg7 bool
+		arg7 *artifact.PullSignatureOptions
 	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
 	stub := fake.PullStub
 	fakeReturns := fake.pullReturns
@@ -319,13 +319,13 @@ func (fake *FakeImpl) PullCallCount() int {
 	return len(fake.pullArgsForCall)
 }
 
-func (fake *FakeImpl) PullCalls(stub func(context.Context, logr.Logger, string, string, string, *v1b.Platform, bool) (*artifact.PullResult, error)) {
+func (fake *FakeImpl) PullCalls(stub func(context.Context, logr.Logger, string, string, string, *v1b.Platform, *artifact.PullSignatureOptions) (*artifact.PullResult, error)) {
 	fake.pullMutex.Lock()
 	defer fake.pullMutex.Unlock()
 	fake.PullStub = stub
 }
 
-func (fake *FakeImpl) PullArgsForCall(i int) (context.Context, logr.Logger, string, string, string, *v1b.Platform, bool) {
+func (fake *FakeImpl) PullArgsForCall(i int) (context.Context, logr.Logger, string, string, string, *v1b.Platform, *artifact.PullSignatureOptions) {
 	fake.pullMutex.RLock()
 	defer fake.pullMutex.RUnlock()
 	argsForCall := fake.pullArgsForCall[i]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

Make sure that the signature verification of the base profile OIDC image is done on the immutable
image digest to avoid a TOCTOU attack on the immutable tag between verification and copy.

Adds two new options in the spod configuration to configure the allowed identities and allowed
Oidc issuer regexp(s) instead of allowing any signed image without an option to restrict it.

Refactor the puller interface to pass these options as single option struct, and extended the 
puller CLI command to allow them to be configured as CLI arguments.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add two new flags in spod configuration to `AllowedIdentityRegexp` and `AllowedOidcIssuerRegexp` to
restrict which identities and Oidc issuers are allowed during the image verification.
```
