### PR TITLE
Make sure that the profiles are really bound when another profile exists in security context

### DIFF
--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -419,6 +419,7 @@ func (p *podBinder) addAppArmorContext(
 
 	if c.SecurityContext.AppArmorProfile == nil {
 		c.SecurityContext.AppArmorProfile = &aa
+
 		return true
 	}
 
@@ -427,6 +428,7 @@ func (p *podBinder) addAppArmorContext(
 	// profile is enforced through a binding.
 	if !ptr.Equal(c.SecurityContext.AppArmorProfile, &aa) {
 		c.SecurityContext.AppArmorProfile = &aa
+
 		return true
 	}
 

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -30,6 +30,7 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -346,7 +347,6 @@ func (p *podBinder) addSecurityContext(
 func (p *podBinder) addSeccompContext(
 	c *corev1.Container, seccompProfile *seccompprofileapi.SeccompProfile,
 ) bool {
-	podChanged := false
 	profileRef := seccompProfile.Status.LocalhostProfile
 	sp := corev1.SeccompProfile{
 		Type:             corev1.SeccompProfileTypeLocalhost,
@@ -357,20 +357,25 @@ func (p *podBinder) addSeccompContext(
 		c.SecurityContext = &corev1.SecurityContext{}
 	}
 
-	if c.SecurityContext.SeccompProfile != nil {
-		p.log.Info("cannot override existing seccomp profile for pod or container")
-	} else {
+	if c.SecurityContext.SeccompProfile == nil {
 		c.SecurityContext.SeccompProfile = &sp
-		podChanged = true
+		return true
 	}
 
-	return podChanged
+	// Make srue that the bound profile is realy in the pod security context if already a profile
+	// exists, otherwise it can be easily overwritten with something less permissive like
+	// "type": "Unconfined", even though a specific profile is enforced through a binding.
+	if !ptr.Equal(c.SecurityContext.SeccompProfile, &sp) {
+		c.SecurityContext.SeccompProfile = &sp
+		return true
+	}
+
+	return false
 }
 
 func (p *podBinder) addSelinuxContext(
 	c *corev1.Container, selinuxProfile *selinuxprofileapi.SelinuxProfile,
 ) bool {
-	podChanged := false
 	usage := selinuxProfile.Status.Usage
 	sl := corev1.SELinuxOptions{
 		Type: usage,
@@ -380,20 +385,25 @@ func (p *podBinder) addSelinuxContext(
 		c.SecurityContext = &corev1.SecurityContext{}
 	}
 
-	if c.SecurityContext.SELinuxOptions != nil {
-		p.log.Info("cannot override existing selinux profile for pod or container")
-	} else {
+	if c.SecurityContext.SeccompProfile == nil {
 		c.SecurityContext.SELinuxOptions = &sl
-		podChanged = true
+		return true
 	}
 
-	return podChanged
+	// Make srue that the bound profile is realy in the pod security context if the profile exists,
+	// otherwise it can be easily overwritten with something less permissive, even though a specific
+	// profile is enforced through a binding.
+	if !ptr.Equal(c.SecurityContext.SELinuxOptions, &sl) {
+		c.SecurityContext.SELinuxOptions = &sl
+		return true
+	}
+
+	return false
 }
 
 func (p *podBinder) addAppArmorContext(
 	c *corev1.Container, appArmorProfile *apparmorprofileapi.AppArmorProfile,
 ) bool {
-	podChanged := false
 	profileName := appArmorProfile.GetProfileName()
 	aa := corev1.AppArmorProfile{
 		Type:             corev1.AppArmorProfileTypeLocalhost,
@@ -404,14 +414,20 @@ func (p *podBinder) addAppArmorContext(
 		c.SecurityContext = &corev1.SecurityContext{}
 	}
 
-	if c.SecurityContext.AppArmorProfile != nil {
-		p.log.Info("cannot override existing apparmor profile for pod or container")
-	} else {
+	if c.SecurityContext.AppArmorProfile == nil {
 		c.SecurityContext.AppArmorProfile = &aa
-		podChanged = true
+		return true
 	}
 
-	return podChanged
+	// Make srue that the bound profile is realy in the pod security context, otherwise
+	// it can be easily overwritten with something less permissive, even though a specific
+	// profile is enforced through a binding.
+	if !ptr.Equal(c.SecurityContext.AppArmorProfile, &aa) {
+		c.SecurityContext.AppArmorProfile = &aa
+		return true
+	}
+
+	return false
 }
 
 func (p *podBinder) addPodSecurityContext(

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -363,7 +363,7 @@ func (p *podBinder) addSeccompContext(
 		return true
 	}
 
-	// Make srue that the bound profile is really in the pod security context if already a profile
+	// Make sure that the bound profile is really in the pod security context if already a profile
 	// exists, otherwise it can be easily overwritten with something less permissive like
 	// "type": "Unconfined", even though a specific profile is enforced through a binding.
 	if !ptr.Equal(c.SecurityContext.SeccompProfile, &sp) {
@@ -387,13 +387,13 @@ func (p *podBinder) addSelinuxContext(
 		c.SecurityContext = &corev1.SecurityContext{}
 	}
 
-	if c.SecurityContext.SeccompProfile == nil {
+	if c.SecurityContext.SELinuxOptions == nil {
 		c.SecurityContext.SELinuxOptions = &sl
 
 		return true
 	}
 
-	// Make srue that the bound profile is really in the pod security context if the profile exists,
+	// Make sure that the bound profile is really in the pod security context if the profile exists,
 	// otherwise it can be easily overwritten with something less permissive, even though a specific
 	// profile is enforced through a binding.
 	if !ptr.Equal(c.SecurityContext.SELinuxOptions, &sl) {
@@ -424,7 +424,7 @@ func (p *podBinder) addAppArmorContext(
 		return true
 	}
 
-	// Make srue that the bound profile is really in the pod security context, otherwise
+	// Make sure that the bound profile is really in the pod security context, otherwise
 	// it can be easily overwritten with something less permissive, even though a specific
 	// profile is enforced through a binding.
 	if !ptr.Equal(c.SecurityContext.AppArmorProfile, &aa) {

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -398,6 +398,7 @@ func (p *podBinder) addSelinuxContext(
 	// profile is enforced through a binding.
 	if !ptr.Equal(c.SecurityContext.SELinuxOptions, &sl) {
 		c.SecurityContext.SELinuxOptions = &sl
+
 		return true
 	}
 

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -359,14 +359,16 @@ func (p *podBinder) addSeccompContext(
 
 	if c.SecurityContext.SeccompProfile == nil {
 		c.SecurityContext.SeccompProfile = &sp
+
 		return true
 	}
 
-	// Make srue that the bound profile is realy in the pod security context if already a profile
+	// Make srue that the bound profile is really in the pod security context if already a profile
 	// exists, otherwise it can be easily overwritten with something less permissive like
 	// "type": "Unconfined", even though a specific profile is enforced through a binding.
 	if !ptr.Equal(c.SecurityContext.SeccompProfile, &sp) {
 		c.SecurityContext.SeccompProfile = &sp
+
 		return true
 	}
 
@@ -387,10 +389,11 @@ func (p *podBinder) addSelinuxContext(
 
 	if c.SecurityContext.SeccompProfile == nil {
 		c.SecurityContext.SELinuxOptions = &sl
+
 		return true
 	}
 
-	// Make srue that the bound profile is realy in the pod security context if the profile exists,
+	// Make srue that the bound profile is really in the pod security context if the profile exists,
 	// otherwise it can be easily overwritten with something less permissive, even though a specific
 	// profile is enforced through a binding.
 	if !ptr.Equal(c.SecurityContext.SELinuxOptions, &sl) {
@@ -419,7 +422,7 @@ func (p *podBinder) addAppArmorContext(
 		return true
 	}
 
-	// Make srue that the bound profile is realy in the pod security context, otherwise
+	// Make srue that the bound profile is really in the pod security context, otherwise
 	// it can be easily overwritten with something less permissive, even though a specific
 	// profile is enforced through a binding.
 	if !ptr.Equal(c.SecurityContext.AppArmorProfile, &aa) {

--- a/internal/pkg/webhooks/binding/binding_test.go
+++ b/internal/pkg/webhooks/binding/binding_test.go
@@ -134,6 +134,7 @@ func TestHandle(t *testing.T) {
 				require.Len(t, resp.Patches, 1)
 			},
 		},
+		//nolint:dupl // test duplicates are fine
 		{ // success pod changed with * image
 			prepare: func(mock *bindingfakes.FakeImpl) {
 				mock.ListProfileBindingsReturns(&profilebindingapi.ProfileBindingList{
@@ -438,6 +439,7 @@ func TestHandle(t *testing.T) {
 				require.Len(t, resp.Patches, 2)
 			},
 		},
+		//nolint:dupl // test duplicates are fine
 		{ // apparmor success pod changed with * image
 			prepare: func(mock *bindingfakes.FakeImpl) {
 				mock.ListProfileBindingsReturns(&profilebindingapi.ProfileBindingList{

--- a/internal/pkg/webhooks/binding/binding_test.go
+++ b/internal/pkg/webhooks/binding/binding_test.go
@@ -204,12 +204,11 @@ func TestHandle(t *testing.T) {
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							podWithSecurityContext := testPod.DeepCopy()
-							podWithSecurityContext.Spec.Containers[0].SecurityContext =
-								&corev1.SecurityContext{
-									SeccompProfile: &corev1.SeccompProfile{
-										Type: corev1.SeccompProfileTypeUnconfined,
-									},
-								}
+							podWithSecurityContext.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeUnconfined,
+								},
+							}
 							b, err := json.Marshal(podWithSecurityContext)
 							require.NoError(t, err)
 
@@ -292,12 +291,11 @@ func TestHandle(t *testing.T) {
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							podWithSecurityContext := testPod.DeepCopy()
-							podWithSecurityContext.Spec.Containers[0].SecurityContext =
-								&corev1.SecurityContext{
-									SELinuxOptions: &corev1.SELinuxOptions{
-										Type: "unconfined",
-									},
-								}
+							podWithSecurityContext.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+								SELinuxOptions: &corev1.SELinuxOptions{
+									Type: "unconfined",
+								},
+							}
 							b, err := json.Marshal(podWithSecurityContext)
 							require.NoError(t, err)
 
@@ -423,12 +421,11 @@ func TestHandle(t *testing.T) {
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							podWithSecurityContext := testPod.DeepCopy()
-							podWithSecurityContext.Spec.Containers[0].SecurityContext =
-								&corev1.SecurityContext{
-									AppArmorProfile: &corev1.AppArmorProfile{
-										Type: corev1.AppArmorProfileTypeUnconfined,
-									},
-								}
+							podWithSecurityContext.Spec.Containers[0].SecurityContext = &corev1.SecurityContext{
+								AppArmorProfile: &corev1.AppArmorProfile{
+									Type: corev1.AppArmorProfileTypeUnconfined,
+								},
+							}
 							b, err := json.Marshal(podWithSecurityContext)
 							require.NoError(t, err)
 

--- a/internal/pkg/webhooks/binding/binding_test.go
+++ b/internal/pkg/webhooks/binding/binding_test.go
@@ -308,7 +308,7 @@ func TestHandle(t *testing.T) {
 			},
 			assert: func(resp admission.Response) {
 				require.True(t, resp.Allowed)
-				require.Len(t, resp.Patches, 1)
+				require.Len(t, resp.Patches, 2)
 			},
 		},
 		{ // selinux success pod changed with * image

--- a/internal/pkg/webhooks/binding/binding_test.go
+++ b/internal/pkg/webhooks/binding/binding_test.go
@@ -174,6 +174,53 @@ func TestHandle(t *testing.T) {
 				require.Len(t, resp.Patches, 1)
 			},
 		},
+		{ // success seccomp pod security context overwrite with * image
+			prepare: func(mock *bindingfakes.FakeImpl) {
+				mock.ListProfileBindingsReturns(&profilebindingapi.ProfileBindingList{
+					Items: []profilebindingapi.ProfileBinding{
+						{
+							Spec: profilebindingapi.ProfileBindingSpec{
+								ProfileRef: profilebindingapi.ProfileRef{
+									Kind: profilebindingapi.ProfileBindingKindSeccompProfile,
+								},
+								Image: profilebindingapi.SelectAllContainersImage,
+							},
+						},
+					},
+				}, nil)
+				mock.DecodePodReturns(testPod.DeepCopy(), nil)
+				mock.GetSeccompProfileReturns(&seccompprofileapi.SeccompProfile{
+					Status: seccompprofileapi.SeccompProfileStatus{
+						StatusBase: profilebaseapi.StatusBase{
+							Status: secprofnodestatusapi.ProfileStateInstalled,
+						},
+						LocalhostProfile: "seccomp-test-profile",
+					},
+				}, nil)
+			},
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{
+						Raw: func() []byte {
+							podWithSecurityContext := testPod.DeepCopy()
+							podWithSecurityContext.Spec.SecurityContext = &corev1.PodSecurityContext{
+								SeccompProfile: &corev1.SeccompProfile{
+									Type: corev1.SeccompProfileTypeUnconfined,
+								},
+							}
+							b, err := json.Marshal(podWithSecurityContext)
+							require.NoError(t, err)
+
+							return b
+						}(),
+					},
+				},
+			},
+			assert: func(resp admission.Response) {
+				require.True(t, resp.Allowed)
+				require.Len(t, resp.Patches, 2) // add localProfile, replace type with Localhost
+			},
+		},
 		{ // selinux success pod changed
 			prepare: func(mock *bindingfakes.FakeImpl) {
 				mock.ListProfileBindingsReturns(&profilebindingapi.ProfileBindingList{
@@ -202,6 +249,53 @@ func TestHandle(t *testing.T) {
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPod.DeepCopy())
+							require.NoError(t, err)
+
+							return b
+						}(),
+					},
+				},
+			},
+			assert: func(resp admission.Response) {
+				require.True(t, resp.Allowed)
+				require.Len(t, resp.Patches, 1)
+			},
+		},
+		{ // success selinux pod security context overwrite with * image
+			prepare: func(mock *bindingfakes.FakeImpl) {
+				mock.ListProfileBindingsReturns(&profilebindingapi.ProfileBindingList{
+					Items: []profilebindingapi.ProfileBinding{
+						{
+							Spec: profilebindingapi.ProfileBindingSpec{
+								ProfileRef: profilebindingapi.ProfileRef{
+									Kind: profilebindingapi.ProfileBindingKindSelinuxProfile,
+								},
+								Image: profilebindingapi.SelectAllContainersImage,
+							},
+						},
+					},
+				}, nil)
+				mock.DecodePodReturns(testPod.DeepCopy(), nil)
+				mock.GetSelinuxProfileReturns(&selinuxprofileapi.SelinuxProfile{
+					Status: selinuxprofileapi.SelinuxProfileStatus{
+						StatusBase: profilebaseapi.StatusBase{
+							Status: "Installed",
+						},
+						Usage: "test-usage",
+					},
+				}, nil)
+			},
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{
+						Raw: func() []byte {
+							podWithSecurityContext := testPod.DeepCopy()
+							podWithSecurityContext.Spec.SecurityContext = &corev1.PodSecurityContext{
+								SELinuxOptions: &corev1.SELinuxOptions{
+									Type: "unconfined",
+								},
+							}
+							b, err := json.Marshal(podWithSecurityContext)
 							require.NoError(t, err)
 
 							return b
@@ -293,6 +387,55 @@ func TestHandle(t *testing.T) {
 			assert: func(resp admission.Response) {
 				require.True(t, resp.Allowed)
 				require.Len(t, resp.Patches, 1)
+			},
+		},
+		{ // success apparmor security context overwritten with * image
+			prepare: func(mock *bindingfakes.FakeImpl) {
+				mock.ListProfileBindingsReturns(&profilebindingapi.ProfileBindingList{
+					Items: []profilebindingapi.ProfileBinding{
+						{
+							Spec: profilebindingapi.ProfileBindingSpec{
+								ProfileRef: profilebindingapi.ProfileRef{
+									Kind: profilebindingapi.ProfileBindingKindAppArmorProfile,
+								},
+								Image: profilebindingapi.SelectAllContainersImage,
+							},
+						},
+					},
+				}, nil)
+				mock.DecodePodReturns(testPod.DeepCopy(), nil)
+				mock.GetAppArmorProfileReturns(&apparmorprofileapi.AppArmorProfile{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-apparmor-profile",
+					},
+					Status: apparmorprofileapi.AppArmorProfileStatus{
+						StatusBase: profilebaseapi.StatusBase{
+							Status: secprofnodestatusapi.ProfileStateInstalled,
+						},
+					},
+				}, nil)
+			},
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{
+						Raw: func() []byte {
+							podWithSecurityContext := testPod.DeepCopy()
+							podWithSecurityContext.Spec.SecurityContext = &corev1.PodSecurityContext{
+								AppArmorProfile: &corev1.AppArmorProfile{
+									Type: corev1.AppArmorProfileTypeUnconfined,
+								},
+							}
+							b, err := json.Marshal(podWithSecurityContext)
+							require.NoError(t, err)
+
+							return b
+						}(),
+					},
+				},
+			},
+			assert: func(resp admission.Response) {
+				require.True(t, resp.Allowed)
+				require.Len(t, resp.Patches, 2)
 			},
 		},
 		{ // apparmor success pod changed with * image

--- a/internal/pkg/webhooks/binding/binding_test.go
+++ b/internal/pkg/webhooks/binding/binding_test.go
@@ -204,11 +204,12 @@ func TestHandle(t *testing.T) {
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							podWithSecurityContext := testPod.DeepCopy()
-							podWithSecurityContext.Spec.SecurityContext = &corev1.PodSecurityContext{
-								SeccompProfile: &corev1.SeccompProfile{
-									Type: corev1.SeccompProfileTypeUnconfined,
-								},
-							}
+							podWithSecurityContext.Spec.Containers[0].SecurityContext =
+								&corev1.SecurityContext{
+									SeccompProfile: &corev1.SeccompProfile{
+										Type: corev1.SeccompProfileTypeUnconfined,
+									},
+								}
 							b, err := json.Marshal(podWithSecurityContext)
 							require.NoError(t, err)
 
@@ -291,11 +292,12 @@ func TestHandle(t *testing.T) {
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							podWithSecurityContext := testPod.DeepCopy()
-							podWithSecurityContext.Spec.SecurityContext = &corev1.PodSecurityContext{
-								SELinuxOptions: &corev1.SELinuxOptions{
-									Type: "unconfined",
-								},
-							}
+							podWithSecurityContext.Spec.Containers[0].SecurityContext =
+								&corev1.SecurityContext{
+									SELinuxOptions: &corev1.SELinuxOptions{
+										Type: "unconfined",
+									},
+								}
 							b, err := json.Marshal(podWithSecurityContext)
 							require.NoError(t, err)
 
@@ -421,11 +423,12 @@ func TestHandle(t *testing.T) {
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							podWithSecurityContext := testPod.DeepCopy()
-							podWithSecurityContext.Spec.SecurityContext = &corev1.PodSecurityContext{
-								AppArmorProfile: &corev1.AppArmorProfile{
-									Type: corev1.AppArmorProfileTypeUnconfined,
-								},
-							}
+							podWithSecurityContext.Spec.Containers[0].SecurityContext =
+								&corev1.SecurityContext{
+									AppArmorProfile: &corev1.AppArmorProfile{
+										Type: corev1.AppArmorProfileTypeUnconfined,
+									},
+								}
 							b, err := json.Marshal(podWithSecurityContext)
 							require.NoError(t, err)
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

Make sure that the bound profile is really in the security context and
not skip if some other profile is set already.

This can lead to a security issue when the set profile is less
permissive the than the profile being enforced. For example, an attacker
can set "type": "Unconfined" in the security context and skip the
profile being bound by the security profile operator.

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

Yes

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
NONE
```
