### PR TITLE
Skip binding when a referenced profile is not available

### DIFF
--- a/internal/pkg/util/retries.go
+++ b/internal/pkg/util/retries.go
@@ -47,12 +47,14 @@ func Retry(fn func() error, retryCondition func(error) bool) error {
 
 func RetryEx(backoff *wait.Backoff, fn func() error, retryCondition func(error) bool) error {
 	var lastRetryErr error
+
 	waitErr := wait.ExponentialBackoff(*backoff, func() (bool, error) {
 		err := fn()
 		if err == nil {
 			return true, nil
 		} else if retryCondition(err) {
 			lastRetryErr = err
+
 			return false, nil
 		}
 
@@ -62,6 +64,7 @@ func RetryEx(backoff *wait.Backoff, fn func() error, retryCondition func(error) 
 		if lastRetryErr != nil {
 			return fmt.Errorf("wait on retry: %w, last retry error: %w", waitErr, lastRetryErr)
 		}
+
 		return fmt.Errorf("wait on retry: %w", waitErr)
 	}
 

--- a/internal/pkg/util/retries.go
+++ b/internal/pkg/util/retries.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"errors"
 	"fmt"
 	"time"
 
@@ -62,7 +61,7 @@ func RetryEx(backoff *wait.Backoff, fn func() error, retryCondition func(error) 
 		return false, fmt.Errorf("retry function: %w", err)
 	})
 	if waitErr != nil {
-		if lastRetryErr != nil && errors.Is(waitErr, wait.ErrWaitTimeout) {
+		if lastRetryErr != nil && wait.Interrupted(waitErr) {
 			return fmt.Errorf("wait on retry: %w, last retry error: %w", waitErr, lastRetryErr)
 		}
 

--- a/internal/pkg/util/retries.go
+++ b/internal/pkg/util/retries.go
@@ -17,10 +17,11 @@ limitations under the License.
 package util
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -31,7 +32,7 @@ const (
 )
 
 func IsNotFoundOrConflict(err error) bool {
-	return errors.IsNotFound(err) || errors.IsConflict(err)
+	return kerrors.IsNotFound(err) || kerrors.IsConflict(err)
 }
 
 // Retry attempts to execute fn up to 5 times if its failure meets retryCondition.
@@ -61,7 +62,7 @@ func RetryEx(backoff *wait.Backoff, fn func() error, retryCondition func(error) 
 		return false, fmt.Errorf("retry function: %w", err)
 	})
 	if waitErr != nil {
-		if lastRetryErr != nil {
+		if lastRetryErr != nil && errors.Is(waitErr, wait.ErrWaitTimeout) {
 			return fmt.Errorf("wait on retry: %w, last retry error: %w", waitErr, lastRetryErr)
 		}
 

--- a/internal/pkg/util/retries.go
+++ b/internal/pkg/util/retries.go
@@ -46,17 +46,22 @@ func Retry(fn func() error, retryCondition func(error) bool) error {
 }
 
 func RetryEx(backoff *wait.Backoff, fn func() error, retryCondition func(error) bool) error {
+	var lastRetryErr error
 	waitErr := wait.ExponentialBackoff(*backoff, func() (bool, error) {
 		err := fn()
 		if err == nil {
 			return true, nil
 		} else if retryCondition(err) {
+			lastRetryErr = err
 			return false, nil
 		}
 
 		return false, fmt.Errorf("retry function: %w", err)
 	})
 	if waitErr != nil {
+		if lastRetryErr != nil {
+			return fmt.Errorf("wait on retry: %w, last retry error: %w", waitErr, lastRetryErr)
+		}
 		return fmt.Errorf("wait on retry: %w", waitErr)
 	}
 

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -202,6 +202,14 @@ func (p *podBinder) updatePod(
 		}
 
 		if err != nil {
+			if kerrors.IsNotFound(err) {
+				p.log.Info("skip binding due to unavailable profile", "profile-kind", profileKind, "profile", namespacedName)
+				// When a profile is not found for a pod, the binding should be just skipped. Otherwise all pod CRUD(s)
+				// operation in a namespace with binding enabled will be blocked with 500 error. This might also lead
+				// to a DoS when a ProfileBinding has a non-existing profileRef.
+				return pod, admission.Allowed(fmt.Sprintf("skip binding, not found: %v %#v", profileKind, namespacedName))
+			}
+
 			p.log.Error(err, fmt.Sprintf("failed to get %v %#v", profileKind, namespacedName))
 
 			return pod, admission.Errored(http.StatusInternalServerError, err)

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -202,7 +202,7 @@ func (p *podBinder) updatePod(
 		}
 
 		if err != nil {
-			// This relies on until.Retry to propagate the last retried error though the tree of wrapped errors when a
+			// This relies on util.Retry to propagate the last retried error though the tree of wrapped errors when a
 			// resource is not found. Without this, the last error when the retried reached the timeout would only be
 			// a wait.ErrWaitTimeout error which will never be matched by this if statement.
 			if kerrors.IsNotFound(err) {
@@ -210,7 +210,7 @@ func (p *podBinder) updatePod(
 				// When a profile is not found for a pod, the binding should be just skipped. Otherwise all pod CRUD(s)
 				// operation in a namespace with binding enabled will be blocked with 500 error. This might also lead
 				// to a DoS when a ProfileBinding has a non-existing profileRef.
-				return pod, admission.Allowed(fmt.Sprintf("skip binding, not found: %v %#v", profileKind, namespacedName))
+				continue
 			}
 
 			p.log.Error(err, fmt.Sprintf("failed to get %v %#v", profileKind, namespacedName))

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -202,6 +202,9 @@ func (p *podBinder) updatePod(
 		}
 
 		if err != nil {
+			// This relies on until.Retry to propagate the last retried error though the tree of wrapped errors when a
+			// resource is not found. Without this, the last error when the retried reached the timeout would only be
+			// a wait.ErrWaitTimeout error which will never be matched by this if statement.
 			if kerrors.IsNotFound(err) {
 				p.log.Info("skip binding due to unavailable profile", "profile-kind", profileKind, "profile", namespacedName)
 				// When a profile is not found for a pod, the binding should be just skipped. Otherwise all pod CRUD(s)

--- a/internal/pkg/webhooks/binding/binding_test.go
+++ b/internal/pkg/webhooks/binding/binding_test.go
@@ -792,7 +792,6 @@ func TestHandle(t *testing.T) {
 				require.Equal(t, http.StatusInternalServerError, int(resp.Result.Code))
 			},
 		},
-		//nolint:dupl // test duplicates are fine
 		{ // success when the profile referenced in the profile binding doesn't exist.
 			prepare: func(mock *bindingfakes.FakeImpl) {
 				mock.ListProfileBindingsReturns(&profilebindingapi.ProfileBindingList{
@@ -824,7 +823,7 @@ func TestHandle(t *testing.T) {
 			},
 			assert: func(resp admission.Response) {
 				require.True(t, resp.Allowed)
-				require.Len(t, resp.Patches, 0)
+				require.Empty(t, resp.Patches)
 			},
 		},
 	} {

--- a/internal/pkg/webhooks/binding/binding_test.go
+++ b/internal/pkg/webhooks/binding/binding_test.go
@@ -823,6 +823,7 @@ func TestHandle(t *testing.T) {
 			},
 			assert: func(resp admission.Response) {
 				require.True(t, resp.Allowed)
+				require.Contains(t, resp.Result.Message, "skip binding")
 				require.Empty(t, resp.Patches)
 			},
 		},

--- a/internal/pkg/webhooks/binding/binding_test.go
+++ b/internal/pkg/webhooks/binding/binding_test.go
@@ -27,8 +27,10 @@ import (
 	"github.com/stretchr/testify/require"
 	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	apparmorprofileapi "sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1"
@@ -788,6 +790,41 @@ func TestHandle(t *testing.T) {
 			},
 			assert: func(resp admission.Response) {
 				require.Equal(t, http.StatusInternalServerError, int(resp.Result.Code))
+			},
+		},
+		//nolint:dupl // test duplicates are fine
+		{ // success when the profile referenced in the profile binding doesn't exist.
+			prepare: func(mock *bindingfakes.FakeImpl) {
+				mock.ListProfileBindingsReturns(&profilebindingapi.ProfileBindingList{
+					Items: []profilebindingapi.ProfileBinding{
+						{
+							Spec: profilebindingapi.ProfileBindingSpec{
+								ProfileRef: profilebindingapi.ProfileRef{
+									Kind: profilebindingapi.ProfileBindingKindAppArmorProfile,
+								},
+								Image: "foo",
+							},
+						},
+					},
+				}, nil)
+				mock.DecodePodReturns(testPod.DeepCopy(), nil)
+				mock.GetAppArmorProfileReturns(nil, kerrors.NewNotFound(schema.GroupResource{}, "test-profile"))
+			},
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Object: runtime.RawExtension{
+						Raw: func() []byte {
+							b, err := json.Marshal(testPod.DeepCopy())
+							require.NoError(t, err)
+
+							return b
+						}(),
+					},
+				},
+			},
+			assert: func(resp admission.Response) {
+				require.True(t, resp.Allowed)
+				require.Len(t, resp.Patches, 0)
 			},
 		},
 	} {

--- a/internal/pkg/webhooks/binding/binding_test.go
+++ b/internal/pkg/webhooks/binding/binding_test.go
@@ -823,7 +823,6 @@ func TestHandle(t *testing.T) {
 			},
 			assert: func(resp admission.Response) {
 				require.True(t, resp.Allowed)
-				require.Contains(t, resp.Result.Message, "skip binding")
 				require.Empty(t, resp.Patches)
 			},
 		},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind bug

#### What this PR does / why we need it:


Skip binding when a referenced profile is not available.

The binding should be skipped when a profile is not found for a pod.
This is a measure to avoid that all Pod CRUD(s) operations in a
namespace with binding enabled will not be blocked with a 500 error.
This might also lead to a DoS when a ProfileBinding has a reference to a
non-existing profileRef.

Fix the retry logic to also propagate the last retried error in order
for the caller to understand the root cause of the retry timeout error.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

Yes
<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Skip binding a prod to a profile when a referenced security profile is not available. This is
a measure to prevent blocking all CRUD(s) operations in a namespace with binding enabled.
```
