### PR TITLE
fix: make selinuxd policy compatible with refpolicy

### DIFF
--- a/deploy/base/profiles/selinuxd.cil
+++ b/deploy/base/profiles/selinuxd.cil
@@ -15,7 +15,6 @@
     (allow process file_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
     (allow process file_context_t ( sock_file ( append getattr open read write )))
     (allow process security_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-    (typeattributeset can_load_policy process)
     (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rename rmdir search setattr write )))
     (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
     (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
@@ -37,7 +36,17 @@
     (allow process sysfs_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
     (allow process sysfs_t ( sock_file ( append getattr open read write )))
 
-    (optional rhel_only
+    ; Best effort to allow loading policies
+    (optional load_policy_rule_support
+        ; Targets distros that allow direct rules but might lack the 'can_load_policy' typeattribute (fails safely if blocked by a neverallow)
+        (allow process security_t ( security ( load_policy )))
+    )
+    (optional can_load_policy_attr_support
+        ; Targets distros where 'can_load_policy' typeattribute exists
+        (typeattributeset can_load_policy process)
+    )
+
+    (optional login_config_support
         (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
         (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))

--- a/deploy/base/profiles/selinuxd.cil
+++ b/deploy/base/profiles/selinuxd.cil
@@ -20,10 +20,6 @@
     (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
     (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
     (allow process selinux_config_t ( sock_file ( append getattr open read write )))
-    (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
-    (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
-    (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-    (allow process selinux_login_config_t ( sock_file ( append getattr open read write )))
     (allow process semanage_read_lock_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
     (allow process semanage_read_lock_t ( fifo_file ( getattr read write append ioctl lock open )))
     (allow process semanage_read_lock_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
@@ -40,4 +36,11 @@
     (allow process sysfs_t ( fifo_file ( getattr read write append ioctl lock open )))
     (allow process sysfs_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
     (allow process sysfs_t ( sock_file ( append getattr open read write )))
+
+    (optional rhel_only
+        (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
+        (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
+        (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
+        (allow process selinux_login_config_t ( sock_file ( append getattr open read write )))
+    )
 )

--- a/deploy/base/profiles/selinuxd.cil
+++ b/deploy/base/profiles/selinuxd.cil
@@ -38,11 +38,11 @@
 
     ; Best effort to allow loading policies
     (optional load_policy_rule_support
-        ; Targets distros that allow direct rules but might lack the 'can_load_policy' typeattribute (fails safely if blocked by a neverallow)
+        ; Direct allow rule for distros without 'can_load_policy' (e.g. minimal SELinux setups)
         (allow process security_t ( security ( load_policy )))
     )
     (optional can_load_policy_attr_support
-        ; Targets distros where 'can_load_policy' typeattribute exists
+        ; Join the can_load_policy attribute, which also satisfies refpolicy's neverallow
         (typeattributeset can_load_policy process)
     )
 

--- a/deploy/base/profiles/selinuxd.cil
+++ b/deploy/base/profiles/selinuxd.cil
@@ -15,7 +15,7 @@
     (allow process file_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
     (allow process file_context_t ( sock_file ( append getattr open read write )))
     (allow process security_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-    (allow process security_t ( security ( load_policy )))
+    (typeattributeset can_load_policy process)
     (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rename rmdir search setattr write )))
     (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
     (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -1011,15 +1011,11 @@ data:
         (allow process file_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process file_context_t ( sock_file ( append getattr open read write )))
         (allow process security_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (allow process security_t ( security ( load_policy )))
+        (typeattributeset can_load_policy process)
         (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rename rmdir search setattr write )))
         (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process selinux_config_t ( sock_file ( append getattr open read write )))
-        (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
-        (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
-        (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (allow process selinux_login_config_t ( sock_file ( append getattr open read write )))
         (allow process semanage_read_lock_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
         (allow process semanage_read_lock_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process semanage_read_lock_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
@@ -1036,6 +1032,13 @@ data:
         (allow process sysfs_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process sysfs_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process sysfs_t ( sock_file ( append getattr open read write )))
+
+        (optional rhel_only
+            (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
+            (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
+            (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
+            (allow process selinux_login_config_t ( sock_file ( append getattr open read write )))
+        )
     )
   selinuxrecording.cil: |
     (block selinuxrecording

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -1034,11 +1034,11 @@ data:
 
         ; Best effort to allow loading policies
         (optional load_policy_rule_support
-            ; Targets distros that allow direct rules but might lack the 'can_load_policy' typeattribute (fails safely if blocked by a neverallow)
+            ; Direct allow rule for distros without 'can_load_policy' (e.g. minimal SELinux setups)
             (allow process security_t ( security ( load_policy )))
         )
         (optional can_load_policy_attr_support
-            ; Targets distros where 'can_load_policy' typeattribute exists
+            ; Join the can_load_policy attribute, which also satisfies refpolicy's neverallow
             (typeattributeset can_load_policy process)
         )
 

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -1011,7 +1011,6 @@ data:
         (allow process file_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process file_context_t ( sock_file ( append getattr open read write )))
         (allow process security_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (typeattributeset can_load_policy process)
         (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rename rmdir search setattr write )))
         (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
@@ -1033,7 +1032,17 @@ data:
         (allow process sysfs_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process sysfs_t ( sock_file ( append getattr open read write )))
 
-        (optional rhel_only
+        ; Best effort to allow loading policies
+        (optional load_policy_rule_support
+            ; Targets distros that allow direct rules but might lack the 'can_load_policy' typeattribute (fails safely if blocked by a neverallow)
+            (allow process security_t ( security ( load_policy )))
+        )
+        (optional can_load_policy_attr_support
+            ; Targets distros where 'can_load_policy' typeattribute exists
+            (typeattributeset can_load_policy process)
+        )
+
+        (optional login_config_support
             (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
             (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
             (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -6451,15 +6451,11 @@ data:
         (allow process file_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process file_context_t ( sock_file ( append getattr open read write )))
         (allow process security_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (allow process security_t ( security ( load_policy )))
+        (typeattributeset can_load_policy process)
         (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rename rmdir search setattr write )))
         (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process selinux_config_t ( sock_file ( append getattr open read write )))
-        (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
-        (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
-        (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (allow process selinux_login_config_t ( sock_file ( append getattr open read write )))
         (allow process semanage_read_lock_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
         (allow process semanage_read_lock_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process semanage_read_lock_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
@@ -6476,6 +6472,13 @@ data:
         (allow process sysfs_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process sysfs_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process sysfs_t ( sock_file ( append getattr open read write )))
+
+        (optional rhel_only
+            (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
+            (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
+            (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
+            (allow process selinux_login_config_t ( sock_file ( append getattr open read write )))
+        )
     )
   selinuxrecording.cil: |
     (block selinuxrecording

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -6474,11 +6474,11 @@ data:
 
         ; Best effort to allow loading policies
         (optional load_policy_rule_support
-            ; Targets distros that allow direct rules but might lack the 'can_load_policy' typeattribute (fails safely if blocked by a neverallow)
+            ; Direct allow rule for distros without 'can_load_policy' (e.g. minimal SELinux setups)
             (allow process security_t ( security ( load_policy )))
         )
         (optional can_load_policy_attr_support
-            ; Targets distros where 'can_load_policy' typeattribute exists
+            ; Join the can_load_policy attribute, which also satisfies refpolicy's neverallow
             (typeattributeset can_load_policy process)
         )
 

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -6451,7 +6451,6 @@ data:
         (allow process file_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process file_context_t ( sock_file ( append getattr open read write )))
         (allow process security_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (typeattributeset can_load_policy process)
         (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rename rmdir search setattr write )))
         (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
@@ -6473,7 +6472,17 @@ data:
         (allow process sysfs_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process sysfs_t ( sock_file ( append getattr open read write )))
 
-        (optional rhel_only
+        ; Best effort to allow loading policies
+        (optional load_policy_rule_support
+            ; Targets distros that allow direct rules but might lack the 'can_load_policy' typeattribute (fails safely if blocked by a neverallow)
+            (allow process security_t ( security ( load_policy )))
+        )
+        (optional can_load_policy_attr_support
+            ; Targets distros where 'can_load_policy' typeattribute exists
+            (typeattributeset can_load_policy process)
+        )
+
+        (optional login_config_support
             (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
             (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
             (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -6438,7 +6438,6 @@ data:
         (allow process file_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process file_context_t ( sock_file ( append getattr open read write )))
         (allow process security_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (typeattributeset can_load_policy process)
         (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rename rmdir search setattr write )))
         (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
@@ -6460,7 +6459,17 @@ data:
         (allow process sysfs_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process sysfs_t ( sock_file ( append getattr open read write )))
 
-        (optional rhel_only
+        ; Best effort to allow loading policies
+        (optional load_policy_rule_support
+            ; Targets distros that allow direct rules but might lack the 'can_load_policy' typeattribute (fails safely if blocked by a neverallow)
+            (allow process security_t ( security ( load_policy )))
+        )
+        (optional can_load_policy_attr_support
+            ; Targets distros where 'can_load_policy' typeattribute exists
+            (typeattributeset can_load_policy process)
+        )
+
+        (optional login_config_support
             (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
             (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
             (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -6438,15 +6438,11 @@ data:
         (allow process file_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process file_context_t ( sock_file ( append getattr open read write )))
         (allow process security_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (allow process security_t ( security ( load_policy )))
+        (typeattributeset can_load_policy process)
         (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rename rmdir search setattr write )))
         (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process selinux_config_t ( sock_file ( append getattr open read write )))
-        (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
-        (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
-        (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (allow process selinux_login_config_t ( sock_file ( append getattr open read write )))
         (allow process semanage_read_lock_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
         (allow process semanage_read_lock_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process semanage_read_lock_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
@@ -6463,6 +6459,13 @@ data:
         (allow process sysfs_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process sysfs_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process sysfs_t ( sock_file ( append getattr open read write )))
+
+        (optional rhel_only
+            (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
+            (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
+            (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
+            (allow process selinux_login_config_t ( sock_file ( append getattr open read write )))
+        )
     )
   selinuxrecording.cil: |
     (block selinuxrecording

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -6461,11 +6461,11 @@ data:
 
         ; Best effort to allow loading policies
         (optional load_policy_rule_support
-            ; Targets distros that allow direct rules but might lack the 'can_load_policy' typeattribute (fails safely if blocked by a neverallow)
+            ; Direct allow rule for distros without 'can_load_policy' (e.g. minimal SELinux setups)
             (allow process security_t ( security ( load_policy )))
         )
         (optional can_load_policy_attr_support
-            ; Targets distros where 'can_load_policy' typeattribute exists
+            ; Join the can_load_policy attribute, which also satisfies refpolicy's neverallow
             (typeattributeset can_load_policy process)
         )
 

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -6469,7 +6469,6 @@ data:
         (allow process file_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process file_context_t ( sock_file ( append getattr open read write )))
         (allow process security_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (typeattributeset can_load_policy process)
         (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rename rmdir search setattr write )))
         (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
@@ -6491,7 +6490,17 @@ data:
         (allow process sysfs_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process sysfs_t ( sock_file ( append getattr open read write )))
 
-        (optional rhel_only
+        ; Best effort to allow loading policies
+        (optional load_policy_rule_support
+            ; Targets distros that allow direct rules but might lack the 'can_load_policy' typeattribute (fails safely if blocked by a neverallow)
+            (allow process security_t ( security ( load_policy )))
+        )
+        (optional can_load_policy_attr_support
+            ; Targets distros where 'can_load_policy' typeattribute exists
+            (typeattributeset can_load_policy process)
+        )
+
+        (optional login_config_support
             (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
             (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
             (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -6469,15 +6469,11 @@ data:
         (allow process file_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process file_context_t ( sock_file ( append getattr open read write )))
         (allow process security_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (allow process security_t ( security ( load_policy )))
+        (typeattributeset can_load_policy process)
         (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rename rmdir search setattr write )))
         (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process selinux_config_t ( sock_file ( append getattr open read write )))
-        (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
-        (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
-        (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (allow process selinux_login_config_t ( sock_file ( append getattr open read write )))
         (allow process semanage_read_lock_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
         (allow process semanage_read_lock_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process semanage_read_lock_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
@@ -6494,6 +6490,13 @@ data:
         (allow process sysfs_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process sysfs_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process sysfs_t ( sock_file ( append getattr open read write )))
+
+        (optional rhel_only
+            (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
+            (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
+            (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
+            (allow process selinux_login_config_t ( sock_file ( append getattr open read write )))
+        )
     )
   selinuxrecording.cil: |
     (block selinuxrecording

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -6492,11 +6492,11 @@ data:
 
         ; Best effort to allow loading policies
         (optional load_policy_rule_support
-            ; Targets distros that allow direct rules but might lack the 'can_load_policy' typeattribute (fails safely if blocked by a neverallow)
+            ; Direct allow rule for distros without 'can_load_policy' (e.g. minimal SELinux setups)
             (allow process security_t ( security ( load_policy )))
         )
         (optional can_load_policy_attr_support
-            ; Targets distros where 'can_load_policy' typeattribute exists
+            ; Join the can_load_policy attribute, which also satisfies refpolicy's neverallow
             (typeattributeset can_load_policy process)
         )
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -6451,15 +6451,11 @@ data:
         (allow process file_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process file_context_t ( sock_file ( append getattr open read write )))
         (allow process security_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (allow process security_t ( security ( load_policy )))
+        (typeattributeset can_load_policy process)
         (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rename rmdir search setattr write )))
         (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process selinux_config_t ( sock_file ( append getattr open read write )))
-        (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
-        (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
-        (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (allow process selinux_login_config_t ( sock_file ( append getattr open read write )))
         (allow process semanage_read_lock_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
         (allow process semanage_read_lock_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process semanage_read_lock_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
@@ -6476,6 +6472,13 @@ data:
         (allow process sysfs_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process sysfs_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process sysfs_t ( sock_file ( append getattr open read write )))
+
+        (optional rhel_only
+            (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
+            (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
+            (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
+            (allow process selinux_login_config_t ( sock_file ( append getattr open read write )))
+        )
     )
   selinuxrecording.cil: |
     (block selinuxrecording

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -6474,11 +6474,11 @@ data:
 
         ; Best effort to allow loading policies
         (optional load_policy_rule_support
-            ; Targets distros that allow direct rules but might lack the 'can_load_policy' typeattribute (fails safely if blocked by a neverallow)
+            ; Direct allow rule for distros without 'can_load_policy' (e.g. minimal SELinux setups)
             (allow process security_t ( security ( load_policy )))
         )
         (optional can_load_policy_attr_support
-            ; Targets distros where 'can_load_policy' typeattribute exists
+            ; Join the can_load_policy attribute, which also satisfies refpolicy's neverallow
             (typeattributeset can_load_policy process)
         )
 

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -6451,7 +6451,6 @@ data:
         (allow process file_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process file_context_t ( sock_file ( append getattr open read write )))
         (allow process security_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (typeattributeset can_load_policy process)
         (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rename rmdir search setattr write )))
         (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
@@ -6473,7 +6472,17 @@ data:
         (allow process sysfs_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process sysfs_t ( sock_file ( append getattr open read write )))
 
-        (optional rhel_only
+        ; Best effort to allow loading policies
+        (optional load_policy_rule_support
+            ; Targets distros that allow direct rules but might lack the 'can_load_policy' typeattribute (fails safely if blocked by a neverallow)
+            (allow process security_t ( security ( load_policy )))
+        )
+        (optional can_load_policy_attr_support
+            ; Targets distros where 'can_load_policy' typeattribute exists
+            (typeattributeset can_load_policy process)
+        )
+
+        (optional login_config_support
             (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
             (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
             (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -6422,7 +6422,6 @@ data:
         (allow process file_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process file_context_t ( sock_file ( append getattr open read write )))
         (allow process security_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (typeattributeset can_load_policy process)
         (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rename rmdir search setattr write )))
         (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
@@ -6444,7 +6443,17 @@ data:
         (allow process sysfs_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process sysfs_t ( sock_file ( append getattr open read write )))
 
-        (optional rhel_only
+        ; Best effort to allow loading policies
+        (optional load_policy_rule_support
+            ; Targets distros that allow direct rules but might lack the 'can_load_policy' typeattribute (fails safely if blocked by a neverallow)
+            (allow process security_t ( security ( load_policy )))
+        )
+        (optional can_load_policy_attr_support
+            ; Targets distros where 'can_load_policy' typeattribute exists
+            (typeattributeset can_load_policy process)
+        )
+
+        (optional login_config_support
             (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
             (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
             (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -6422,15 +6422,11 @@ data:
         (allow process file_context_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process file_context_t ( sock_file ( append getattr open read write )))
         (allow process security_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (allow process security_t ( security ( load_policy )))
+        (typeattributeset can_load_policy process)
         (allow process selinux_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rename rmdir search setattr write )))
         (allow process selinux_config_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process selinux_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process selinux_config_t ( sock_file ( append getattr open read write )))
-        (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
-        (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
-        (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
-        (allow process selinux_login_config_t ( sock_file ( append getattr open read write )))
         (allow process semanage_read_lock_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
         (allow process semanage_read_lock_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process semanage_read_lock_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
@@ -6447,6 +6443,13 @@ data:
         (allow process sysfs_t ( fifo_file ( getattr read write append ioctl lock open )))
         (allow process sysfs_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
         (allow process sysfs_t ( sock_file ( append getattr open read write )))
+
+        (optional rhel_only
+            (allow process selinux_login_config_t ( dir ( add_name create getattr ioctl lock open read remove_name rmdir search setattr write )))
+            (allow process selinux_login_config_t ( fifo_file ( getattr read write append ioctl lock open )))
+            (allow process selinux_login_config_t ( file ( append create getattr ioctl lock map open read rename setattr unlink write )))
+            (allow process selinux_login_config_t ( sock_file ( append getattr open read write )))
+        )
     )
   selinuxrecording.cil: |
     (block selinuxrecording

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -6445,11 +6445,11 @@ data:
 
         ; Best effort to allow loading policies
         (optional load_policy_rule_support
-            ; Targets distros that allow direct rules but might lack the 'can_load_policy' typeattribute (fails safely if blocked by a neverallow)
+            ; Direct allow rule for distros without 'can_load_policy' (e.g. minimal SELinux setups)
             (allow process security_t ( security ( load_policy )))
         )
         (optional can_load_policy_attr_support
-            ; Targets distros where 'can_load_policy' typeattribute exists
+            ; Join the can_load_policy attribute, which also satisfies refpolicy's neverallow
             (typeattributeset can_load_policy process)
         )
 


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The `selinuxd.cil` policy shipped by SPO is incompatible with [refpolicy](https://github.com/SELinuxProject/refpolicy)-based distributions (such as Flatcar Linux):

1. **`selinux_login_config_t` is not defined**: refpolicy does not define the `selinux_login_config_t` type.

2. **`load_policy` neverallow violation**: refpolicy enforces [`neverallow ~{ selinux_unconfined_type can_load_policy } security_t:security load_policy`](https://github.com/SELinuxProject/refpolicy/blob/30d3cf5abd1872d3da5dd44de37de4251674f736/policy/modules/kernel/selinux.te#L71). The current policy grants `load_policy` directly via an `allow` rule, violating this rule.

This PR fixes both issues:
- Wraps the `selinux_login_config_t` rules in an `(optional rhel_only ...)` block so they are silently skipped on systems where that type is not defined.
- Replaces the direct `allow ... load_policy` with `(typeattributeset can_load_policy process)`

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

The `can_load_policy` attribute exist in both  [refpolicy](https://github.com/SELinuxProject/refpolicy) and [fedora-selinux/selinux-policy](https://github.com/fedora-selinux/selinux-policy).

#### Does this PR introduce a user-facing change?

```release-note
Fixed selinuxd CIL policy compatibility with refpolicy-based distributions (e.g. Flatcar Linux)
```