### PR TITLE
Add a new flag to enable insecure metrics access on daemon container

### DIFF
--- a/api/spod/v1/spod_types.go
+++ b/api/spod/v1/spod_types.go
@@ -118,6 +118,11 @@ type SPODSpec struct {
 	// +optional
 	// +default=false
 	EnableMemoryOptimization *bool `json:"enableMemoryOptimization,omitempty"`
+	// enableInsecureMetricsAccess enables unauthenticated access to the metrics
+	// endpoint. This will disable TLS and authentication for the metrics endpoint.
+	// +optional
+	// +default=false
+	EnableInsecureMetricsAccess *bool `json:"enableInsecureMetricsAccess,omitempty"`
 	// enableAppArmor tells the operator whether or not to enable AppArmor
 	// support for this SPOD instance.
 	// +optional

--- a/api/spod/v1/zz_generated.deepcopy.go
+++ b/api/spod/v1/zz_generated.deepcopy.go
@@ -199,6 +199,11 @@ func (in *SPODSpec) DeepCopyInto(out *SPODSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableInsecureMetricsAccess != nil {
+		in, out := &in.EnableInsecureMetricsAccess, &out.EnableInsecureMetricsAccess
+		*out = new(bool)
+		**out = **in
+	}
 	if in.EnableAppArmor != nil {
 		in, out := &in.EnableAppArmor, &out.EnableAppArmor
 		*out = new(bool)

--- a/api/spod/v1alpha1/conversion.go
+++ b/api/spod/v1alpha1/conversion.go
@@ -65,6 +65,7 @@ func (src *SecurityProfilesOperatorDaemon) ConvertTo(dstRaw conversion.Hub) erro
 	dst.Spec.Verbosity = src.Spec.Verbosity
 	dst.Spec.EnableProfiling = src.Spec.EnableProfiling
 	dst.Spec.EnableMemoryOptimization = src.Spec.EnableMemoryOptimization
+	dst.Spec.EnableInsecureMetricsAccess = src.Spec.EnableInsecureMetricsAccess
 	dst.Spec.EnableAppArmor = src.Spec.EnableAppArmor
 	dst.Spec.HostProcVolumePath = src.Spec.HostProcVolumePath
 	dst.Spec.ImagePullSecrets = src.Spec.ImagePullSecrets
@@ -136,6 +137,7 @@ func (dst *SecurityProfilesOperatorDaemon) ConvertFrom(srcRaw conversion.Hub) er
 	dst.Spec.Verbosity = src.Spec.Verbosity
 	dst.Spec.EnableProfiling = src.Spec.EnableProfiling
 	dst.Spec.EnableMemoryOptimization = src.Spec.EnableMemoryOptimization
+	dst.Spec.EnableInsecureMetricsAccess = src.Spec.EnableInsecureMetricsAccess
 	dst.Spec.EnableAppArmor = src.Spec.EnableAppArmor
 	dst.Spec.HostProcVolumePath = src.Spec.HostProcVolumePath
 	dst.Spec.ImagePullSecrets = src.Spec.ImagePullSecrets

--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -109,6 +109,11 @@ type SPODSpec struct {
 	// +optional
 	// +default=false
 	EnableMemoryOptimization *bool `json:"enableMemoryOptimization,omitempty"`
+	// enableInsecureMetricsAccess enables unauthenticated access to the metrics
+	// endpoint. This will disable TLS and authentication for the metrics endpoint.
+	// +optional
+	// +default=false
+	EnableInsecureMetricsAccess *bool `json:"enableInsecureMetricsAccess,omitempty"`
 	// enableAppArmor tells the operator whether or not to enable AppArmor
 	// support for this SPOD instance.
 	// +optional

--- a/api/spod/v1alpha1/zz_generated.deepcopy.go
+++ b/api/spod/v1alpha1/zz_generated.deepcopy.go
@@ -199,6 +199,11 @@ func (in *SPODSpec) DeepCopyInto(out *SPODSpec) {
 		*out = new(bool)
 		**out = **in
 	}
+	if in.EnableInsecureMetricsAccess != nil {
+		in, out := &in.EnableInsecureMetricsAccess, &out.EnableInsecureMetricsAccess
+		*out = new(bool)
+		**out = **in
+	}
 	if in.EnableAppArmor != nil {
 		in, out := &in.EnableAppArmor, &out.EnableAppArmor
 		*out = new(bool)

--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -227,7 +227,7 @@ func main() {
 				},
 				&cli.BoolFlag{
 					Name:    insecureMetricsAccessFlag,
-					Usage:   "Allow unauthenticated access to metrics endpoint (default: false)",
+					Usage:   "Allow unauthenticated access to metrics endpoint",
 					Value:   false,
 					EnvVars: []string{config.EnableInsecureMetricsAccessEnvKey},
 				},
@@ -722,7 +722,7 @@ func runDaemon(ctx *cli.Context, info *version.Info) error {
 	}
 
 	if ctx.Bool(insecureMetricsAccessFlag) {
-		setupLog.Info("WARNING: insecure metrics access enabled, TLS and authentication are disabled")
+		setupLog.Info("Insecure metrics access enabled, TLS and authentication are disabled")
 
 		ctrlOpts.Metrics.SecureServing = false
 		ctrlOpts.Metrics.CertDir = ""

--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -102,6 +102,7 @@ const (
 	rawSelinuxFlag               string = "with-raw-selinux"
 	webhookFlag                  string = "webhook"
 	memOptimFlag                 string = "with-mem-optim"
+	insecureMetricsAccessFlag    string = "with-insecure-metrics-access"
 	defaultWebhookPort           int    = 9443
 	auditLogIntervalSecondsParam string = "audit-log-interval-seconds"
 	auditLogPathParam            string = "audit-log-path"
@@ -223,6 +224,12 @@ func main() {
 					Name:  memOptimFlag,
 					Usage: "Enable memory optimization by watching only labeled pods",
 					Value: false,
+				},
+				&cli.BoolFlag{
+					Name:    insecureMetricsAccessFlag,
+					Usage:   "Allow unauthenticated access to metrics endpoint (default: false)",
+					Value:   false,
+					EnvVars: []string{config.EnableInsecureMetricsAccessEnvKey},
 				},
 			},
 		},
@@ -712,6 +719,14 @@ func runDaemon(ctx *cli.Context, info *version.Info) error {
 			},
 			TLSOpts: []func(*tls.Config){disableHTTP2},
 		},
+	}
+
+	if ctx.Bool(insecureMetricsAccessFlag) {
+		setupLog.Info("WARNING: insecure metrics access enabled, TLS and authentication are disabled")
+		ctrlOpts.Metrics.SecureServing = false
+		ctrlOpts.Metrics.CertDir = ""
+		ctrlOpts.Metrics.FilterProvider = nil
+		ctrlOpts.Metrics.TLSOpts = nil
 	}
 
 	setControllerOptionsForNamespaces(&ctrlOpts)

--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -723,6 +723,7 @@ func runDaemon(ctx *cli.Context, info *version.Info) error {
 
 	if ctx.Bool(insecureMetricsAccessFlag) {
 		setupLog.Info("WARNING: insecure metrics access enabled, TLS and authentication are disabled")
+
 		ctrlOpts.Metrics.SecureServing = false
 		ctrlOpts.Metrics.CertDir = ""
 		ctrlOpts.Metrics.FilterProvider = nil

--- a/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
@@ -1613,6 +1613,12 @@ spec:
                   enableAppArmor tells the operator whether or not to enable AppArmor
                   support for this SPOD instance.
                 type: boolean
+              enableInsecureMetricsAccess:
+                default: false
+                description: |-
+                  enableInsecureMetricsAccess enables unauthenticated access to the metrics
+                  endpoint. This will disable TLS and authentication for the metrics endpoint.
+                type: boolean
               enableMemoryOptimization:
                 default: false
                 description: |-

--- a/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
@@ -112,6 +112,12 @@ spec:
                   enableAppArmor tells the operator whether or not to enable AppArmor
                   support for this SPOD instance.
                 type: boolean
+              enableInsecureMetricsAccess:
+                default: false
+                description: |-
+                  enableInsecureMetricsAccess enables unauthenticated access to the metrics
+                  endpoint. This will disable TLS and authentication for the metrics endpoint.
+                type: boolean
               enableMemoryOptimization:
                 default: false
                 description: |-

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -1497,6 +1497,12 @@ spec:
                   enableAppArmor tells the operator whether or not to enable AppArmor
                   support for this SPOD instance.
                 type: boolean
+              enableInsecureMetricsAccess:
+                default: false
+                description: |-
+                  enableInsecureMetricsAccess enables unauthenticated access to the metrics
+                  endpoint. This will disable TLS and authentication for the metrics endpoint.
+                type: boolean
               enableMemoryOptimization:
                 default: false
                 description: |-

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -2998,6 +2998,12 @@ spec:
                   enableAppArmor tells the operator whether or not to enable AppArmor
                   support for this SPOD instance.
                 type: boolean
+              enableInsecureMetricsAccess:
+                default: false
+                description: |-
+                  enableInsecureMetricsAccess enables unauthenticated access to the metrics
+                  endpoint. This will disable TLS and authentication for the metrics endpoint.
+                type: boolean
               enableMemoryOptimization:
                 default: false
                 description: |-

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1497,6 +1497,12 @@ spec:
                   enableAppArmor tells the operator whether or not to enable AppArmor
                   support for this SPOD instance.
                 type: boolean
+              enableInsecureMetricsAccess:
+                default: false
+                description: |-
+                  enableInsecureMetricsAccess enables unauthenticated access to the metrics
+                  endpoint. This will disable TLS and authentication for the metrics endpoint.
+                type: boolean
               enableMemoryOptimization:
                 default: false
                 description: |-

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2998,6 +2998,12 @@ spec:
                   enableAppArmor tells the operator whether or not to enable AppArmor
                   support for this SPOD instance.
                 type: boolean
+              enableInsecureMetricsAccess:
+                default: false
+                description: |-
+                  enableInsecureMetricsAccess enables unauthenticated access to the metrics
+                  endpoint. This will disable TLS and authentication for the metrics endpoint.
+                type: boolean
               enableMemoryOptimization:
                 default: false
                 description: |-

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -2254,6 +2254,12 @@ spec:
                   enableAppArmor tells the operator whether or not to enable AppArmor
                   support for this SPOD instance.
                 type: boolean
+              enableInsecureMetricsAccess:
+                default: false
+                description: |-
+                  enableInsecureMetricsAccess enables unauthenticated access to the metrics
+                  endpoint. This will disable TLS and authentication for the metrics endpoint.
+                type: boolean
               enableMemoryOptimization:
                 default: false
                 description: |-

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3760,6 +3760,12 @@ spec:
                   enableAppArmor tells the operator whether or not to enable AppArmor
                   support for this SPOD instance.
                 type: boolean
+              enableInsecureMetricsAccess:
+                default: false
+                description: |-
+                  enableInsecureMetricsAccess enables unauthenticated access to the metrics
+                  endpoint. This will disable TLS and authentication for the metrics endpoint.
+                type: boolean
               enableMemoryOptimization:
                 default: false
                 description: |-

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -1497,6 +1497,12 @@ spec:
                   enableAppArmor tells the operator whether or not to enable AppArmor
                   support for this SPOD instance.
                 type: boolean
+              enableInsecureMetricsAccess:
+                default: false
+                description: |-
+                  enableInsecureMetricsAccess enables unauthenticated access to the metrics
+                  endpoint. This will disable TLS and authentication for the metrics endpoint.
+                type: boolean
               enableMemoryOptimization:
                 default: false
                 description: |-

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -3003,6 +3003,12 @@ spec:
                   enableAppArmor tells the operator whether or not to enable AppArmor
                   support for this SPOD instance.
                 type: boolean
+              enableInsecureMetricsAccess:
+                default: false
+                description: |-
+                  enableInsecureMetricsAccess enables unauthenticated access to the metrics
+                  endpoint. This will disable TLS and authentication for the metrics endpoint.
+                type: boolean
               enableMemoryOptimization:
                 default: false
                 description: |-

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1497,6 +1497,12 @@ spec:
                   enableAppArmor tells the operator whether or not to enable AppArmor
                   support for this SPOD instance.
                 type: boolean
+              enableInsecureMetricsAccess:
+                default: false
+                description: |-
+                  enableInsecureMetricsAccess enables unauthenticated access to the metrics
+                  endpoint. This will disable TLS and authentication for the metrics endpoint.
+                type: boolean
               enableMemoryOptimization:
                 default: false
                 description: |-

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2998,6 +2998,12 @@ spec:
                   enableAppArmor tells the operator whether or not to enable AppArmor
                   support for this SPOD instance.
                 type: boolean
+              enableInsecureMetricsAccess:
+                default: false
+                description: |-
+                  enableInsecureMetricsAccess enables unauthenticated access to the metrics
+                  endpoint. This will disable TLS and authentication for the metrics endpoint.
+                type: boolean
               enableMemoryOptimization:
                 default: false
                 description: |-

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -2254,6 +2254,12 @@ spec:
                   enableAppArmor tells the operator whether or not to enable AppArmor
                   support for this SPOD instance.
                 type: boolean
+              enableInsecureMetricsAccess:
+                default: false
+                description: |-
+                  enableInsecureMetricsAccess enables unauthenticated access to the metrics
+                  endpoint. This will disable TLS and authentication for the metrics endpoint.
+                type: boolean
               enableMemoryOptimization:
                 default: false
                 description: |-

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3755,6 +3755,12 @@ spec:
                   enableAppArmor tells the operator whether or not to enable AppArmor
                   support for this SPOD instance.
                 type: boolean
+              enableInsecureMetricsAccess:
+                default: false
+                description: |-
+                  enableInsecureMetricsAccess enables unauthenticated access to the metrics
+                  endpoint. This will disable TLS and authentication for the metrics endpoint.
+                type: boolean
               enableMemoryOptimization:
                 default: false
                 description: |-

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -94,6 +94,10 @@ const (
 	// EnableRecordingEnvKey is the environment variable key to enabling profile recording.
 	EnableRecordingEnvKey = "ENABLE_RECORDING"
 
+	// EnableInsecureMetricsAccessEnvKey is the environment variable key for allowing unauthenticated
+	// access to metrics endpoint.
+	EnableInsecureMetricsAccessEnvKey = "ENABLE_INSECURE_METRICS_ACCESS"
+
 	// VerboseLevel is the increased verbosity log level.
 	VerboseLevel = 1
 

--- a/internal/pkg/manager/spod/bindata/servicemonitor.go
+++ b/internal/pkg/manager/spod/bindata/servicemonitor.go
@@ -29,7 +29,7 @@ import (
 
 // ServiceMonitor returns the default ServiceMonitor for automatic metrics
 // retrieval via the prometheus operator.
-func ServiceMonitor(caInjectType CAInjectType) *v1.ServiceMonitor {
+func ServiceMonitor(caInjectType CAInjectType, enableInsecureMetricsAccess bool) *v1.ServiceMonitor {
 	return &v1.ServiceMonitor{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "security-profiles-operator-monitor",
@@ -37,8 +37,8 @@ func ServiceMonitor(caInjectType CAInjectType) *v1.ServiceMonitor {
 		},
 		Spec: v1.ServiceMonitorSpec{
 			Endpoints: []v1.Endpoint{
-				endpointFor("/metrics", caInjectType),
-				endpointFor("/metrics-spod", caInjectType),
+				endpointFor("/metrics", caInjectType, enableInsecureMetricsAccess),
+				endpointFor("/metrics-spod", caInjectType, enableInsecureMetricsAccess),
 			},
 			Selector: metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -54,15 +54,25 @@ func ServiceMonitor(caInjectType CAInjectType) *v1.ServiceMonitor {
 }
 
 // endpointFor provides a standard endpoint for the given URL path.
-func endpointFor(path string, caInjectType CAInjectType) v1.Endpoint {
+func endpointFor(path string, caInjectType CAInjectType, enableInsecureMetricsAccess bool) v1.Endpoint {
 	serverName := fmt.Sprintf("metrics.%s.svc", config.GetOperatorNamespace())
 	scheme := v1.Scheme("https")
+	port := "https"
+
+	if enableInsecureMetricsAccess {
+		scheme = v1.Scheme("http")
+		port = "http"
+	}
 
 	ep := v1.Endpoint{
 		Path:     path,
 		Interval: "10s",
-		Port:     "https",
+		Port:     port,
 		Scheme:   &scheme,
+	}
+
+	if enableInsecureMetricsAccess {
+		return ep
 	}
 
 	ep.Authorization = &v1.SafeAuthorization{

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -84,11 +84,12 @@ var DefaultSPOD = &spodapi.SecurityProfilesOperatorDaemon{
 		Labels: map[string]string{"app": config.OperatorName},
 	},
 	Spec: spodapi.SPODSpec{
-		Verbosity:                0,
-		EnableProfiling:          new(bool),
-		EnableMemoryOptimization: new(bool),
-		EnableAppArmor:           new(bool),
-		HostProcVolumePath:       DefaultHostProcPath,
+		Verbosity:                   0,
+		EnableProfiling:             new(bool),
+		EnableMemoryOptimization:    new(bool),
+		EnableInsecureMetricsAccess: new(bool),
+		EnableAppArmor:              new(bool),
+		HostProcVolumePath:          DefaultHostProcPath,
 		Selinux: spodapi.SPODSelinuxConfig{
 			Options: spodapi.SelinuxOptions{
 				AllowedSystemProfiles: []string{

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -753,6 +753,13 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 			"--with-mem-optim=true")
 	}
 
+	// Enable insecure metrics access if requested
+	if isInsecureMetricsEnabled(cfg) {
+		templateSpec.Containers[bindata.ContainerIDDaemon].Args = append(
+			templateSpec.Containers[bindata.ContainerIDDaemon].Args,
+			"--with-insecure-metrics=true")
+	}
+
 	for i := range templateSpec.InitContainers {
 		// Set image pull policy
 		templateSpec.InitContainers[i].ImagePullPolicy = pullPolicy
@@ -908,6 +915,15 @@ func isJsonEnricherEnabled(cfg *spodapi.SecurityProfilesOperatorDaemon) bool {
 	}
 
 	return ptr.Deref(cfg.Spec.Enricher.EnableJsonEnricher, false) || enableJsonEnricherEnv
+}
+
+func isInsecureMetricsEnabled(cfg *spodapi.SecurityProfilesOperatorDaemon) bool {
+	enableInsecureMetricsEnv, err := strconv.ParseBool(os.Getenv(config.EnableInsecureMetricsAccessEnvKey))
+	if err != nil {
+		enableInsecureMetricsEnv = false
+	}
+
+	return ptr.Deref(cfg.Spec.EnableInsecureMetricsAccess, false) || enableInsecureMetricsEnv
 }
 
 func addArgsConfig(args []string, argonfig string) []string {

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -753,11 +753,10 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 			"--with-mem-optim=true")
 	}
 
-	// Enable insecure metrics access if requested
 	if isInsecureMetricsEnabled(cfg) {
 		templateSpec.Containers[bindata.ContainerIDDaemon].Args = append(
 			templateSpec.Containers[bindata.ContainerIDDaemon].Args,
-			"--with-insecure-metrics=true")
+			"--with-insecure-metrics-access=true")
 	}
 
 	for i := range templateSpec.InitContainers {

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -187,7 +187,8 @@ func (r *ReconcileSPOd) Reconcile(ctx context.Context, req reconcile.Request) (r
 	configuredSPOd := r.getConfiguredSPOd(ctx, spod, image, pullPolicy, caInjectType)
 	webhook := r.getConfiguredWebook(spod, image, pullPolicy, caInjectType)
 	metricsService := bindata.GetMetricsService(r.namespace, caInjectType)
-	serviceMonitor := bindata.ServiceMonitor(caInjectType)
+	serviceMonitor := bindata.ServiceMonitor(caInjectType,
+		ptr.Deref(spod.Spec.EnableInsecureMetricsAccess, false))
 
 	var certManagerResources *bindata.CertManagerResources
 	if caInjectType == bindata.CAInjectTypeCertManager {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

- If this is your first time, please read our contributor guidelines: https://git.k8s.io/community/contributors/guide#your-first-contribution and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
- Please label this pull request according to what type of issue you are addressing, especially if this is a release targeted pull request. For reference on required PR/issue labels, read here:
https://git.k8s.io/community/contributors/devel/sig-release/release.md#issuepr-kind-label
- If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
- If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

#### What type of PR is this?

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind deprecation
/kind failing-test
/kind flake
/kind regression
-->

/kind feature

#### What this PR does / why we need it:

Adds a new flag `--with-insecure-metrics-access` on daemon command and a new configuration flag
in spod `enableInsecureMetricsAccess` to enable insecure metrics access. This flag will disable
TLS and authentication on metrics endpoint.

#### Which issue(s) this PR fixes:

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

None
-->

#### Does this PR have test?

<!--
If tests aren't applicable just write N/A.
-->

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->

```release-note
Add a new flag --with-insecure-metrics-access on daemon command a new configuration flag to
spod which disables TLS and authentication.
```
