### PR TITLE
fix(selinux): use client reader to get selinux image

### DIFF
--- a/internal/pkg/daemon/selinuxprofile/common_controller.go
+++ b/internal/pkg/daemon/selinuxprofile/common_controller.go
@@ -96,7 +96,10 @@ var errPolicyNotFound = errors.New("policy not found")
 type ReconcileSelinux struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver.
-	client            client.Client
+	client client.Client
+	// clientReader reads objects directly from api-server, this is useful when
+	// the cache is filtered or otherwise not expected to contain an object.
+	clientReader      client.Reader
 	scheme            *runtime.Scheme
 	record            record.EventRecorder
 	metrics           *metrics.Metrics
@@ -115,6 +118,7 @@ func (r *ReconcileSelinux) Setup(
 ) error {
 	r.log = logf.Log.WithName(r.controllerName)
 	r.client = mgr.GetClient()
+	r.clientReader = mgr.GetAPIReader()
 	r.scheme = mgr.GetScheme()
 	//nolint:staticcheck,nolintlint // TODO: migrate to GetEventRecorder
 	r.record = mgr.GetEventRecorderFor(r.controllerName)

--- a/internal/pkg/daemon/selinuxprofile/reload_job.go
+++ b/internal/pkg/daemon/selinuxprofile/reload_job.go
@@ -231,7 +231,10 @@ func (r *ReconcileSelinux) getSelinuxdImageFromPod(ctx context.Context, namespac
 	}
 
 	pod := &corev1.Pod{}
-	if err := r.client.Get(ctx, types.NamespacedName{Name: podName, Namespace: namespace}, pod); err != nil {
+	// The daemon manager can filter the pod cache to recording-enabled pods.
+	// Read the current SPOD pod directly so the reload path does not depend on
+	// recording labels being present on operator-managed pods.
+	if err := r.clientReader.Get(ctx, types.NamespacedName{Name: podName, Namespace: namespace}, pod); err != nil {
 		return "", fmt.Errorf("getting pod %s: %w", podName, err)
 	}
 

--- a/internal/pkg/daemon/selinuxprofile/reload_job_test.go
+++ b/internal/pkg/daemon/selinuxprofile/reload_job_test.go
@@ -69,13 +69,14 @@ func TestCreatePolicyReloadJob(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		nodeName       string
-		namespace      string
-		policyName     string
-		existingObjs   []runtime.Object
-		wantErr        bool
-		wantJobCreated bool
+		name            string
+		nodeName        string
+		namespace       string
+		policyName      string
+		existingObjs    []runtime.Object
+		podOnlyInReader bool
+		wantErr         bool
+		wantJobCreated  bool
 	}{
 		{
 			name:           "creates job successfully",
@@ -85,6 +86,16 @@ func TestCreatePolicyReloadJob(t *testing.T) {
 			existingObjs:   nil,
 			wantErr:        false,
 			wantJobCreated: true,
+		},
+		{
+			name:            "creates job when current pod is only in client reader",
+			nodeName:        testNodeName,
+			namespace:       testNamespace,
+			policyName:      "test-policy",
+			existingObjs:    nil,
+			podOnlyInReader: true,
+			wantErr:         false,
+			wantJobCreated:  true,
 		},
 		{
 			name:       "skips when job already running",
@@ -151,15 +162,28 @@ func TestCreatePolicyReloadJob(t *testing.T) {
 				setenvCleanup(t, "POD_NAME", "")
 			}
 
-			objs := append([]runtime.Object{testPod}, tt.existingObjs...)
+			objs := append([]runtime.Object{}, tt.existingObjs...)
+			if !tt.podOnlyInReader {
+				objs = append([]runtime.Object{testPod}, objs...)
+			}
+
+			readerObjs := []runtime.Object{testPod}
+			if tt.nodeName == "" {
+				readerObjs = nil
+			}
 
 			fakeClient := fake.NewClientBuilder().
 				WithScheme(schemeInstance).
 				WithRuntimeObjects(objs...).
 				Build()
+			fakeClientReader := fake.NewClientBuilder().
+				WithScheme(schemeInstance).
+				WithRuntimeObjects(readerObjs...).
+				Build()
 
 			r := &ReconcileSelinux{
-				client: fakeClient,
+				client:       fakeClient,
+				clientReader: fakeClientReader,
 			}
 
 			logger := logf.Log.WithName("test")


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Fixes SELinux policy reload job creation when the daemon manager's cached client does not contain the current SPOD pod.

The reloader obtains the `selinuxd` image from the current SPOD pod. When memory optimization is enabled (the default Helm configuration), the daemon cache stores only pods with the `enable-recording` label. Because the SPOD pod is not normally labeled for recording, it is absent from the cache and the reload job fails with `pod not found`.

Use the manager API reader for this lookup so it reads directly from the API server and does not depend on cache membership or recording labels.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Yes. Adds regression coverage for creating a reload job when the current pod is available through the API reader but absent from the cached client.

#### Special notes for your reviewer:

The direct API read is intentionally limited to retrieving the current SPOD pod for the reload path. Other controller reads continue to use the cached client.

#### Does this PR introduce a user-facing change?

```release-note
Fix SELinux policy reload job creation when SPOD pods are excluded from the daemon manager cache.
```