### PR TITLE
fix: add default selinux options to v1 api so allowedSystemProfiles is applied

### DIFF
--- a/api/spod/v1/spod_types.go
+++ b/api/spod/v1/spod_types.go
@@ -198,6 +198,7 @@ type SPODSelinuxConfig struct {
 	TypeTag string `json:"typeTag,omitempty"`
 	// options defines options specific to the SELinux functionality.
 	// +optional
+	// +default={}
 	Options SelinuxOptions `json:"options,omitzero,omitempty"`
 }
 

--- a/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
@@ -1284,6 +1284,7 @@ spec:
                       controller will not be started. Defaults to true when SELinux is enabled.
                     type: boolean
                   options:
+                    default: {}
                     description: options defines options specific to the SELinux functionality.
                     properties:
                       allowedSystemProfiles:

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -2607,6 +2607,7 @@ spec:
                       controller will not be started. Defaults to true when SELinux is enabled.
                     type: boolean
                   options:
+                    default: {}
                     description: options defines options specific to the SELinux functionality.
                     properties:
                       allowedSystemProfiles:

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2607,6 +2607,7 @@ spec:
                       controller will not be started. Defaults to true when SELinux is enabled.
                     type: boolean
                   options:
+                    default: {}
                     description: options defines options specific to the SELinux functionality.
                     properties:
                       allowedSystemProfiles:

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3364,6 +3364,7 @@ spec:
                       controller will not be started. Defaults to true when SELinux is enabled.
                     type: boolean
                   options:
+                    default: {}
                     description: options defines options specific to the SELinux functionality.
                     properties:
                       allowedSystemProfiles:

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -2607,6 +2607,7 @@ spec:
                       controller will not be started. Defaults to true when SELinux is enabled.
                     type: boolean
                   options:
+                    default: {}
                     description: options defines options specific to the SELinux functionality.
                     properties:
                       allowedSystemProfiles:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2607,6 +2607,7 @@ spec:
                       controller will not be started. Defaults to true when SELinux is enabled.
                     type: boolean
                   options:
+                    default: {}
                     description: options defines options specific to the SELinux functionality.
                     properties:
                       allowedSystemProfiles:

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3364,6 +3364,7 @@ spec:
                       controller will not be started. Defaults to true when SELinux is enabled.
                     type: boolean
                   options:
+                    default: {}
                     description: options defines options specific to the SELinux functionality.
                     properties:
                       allowedSystemProfiles:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

#3243 was merged before the v1 API and it looks like it was missed in the v1 API.

Fix: add `+default={}` on `Options` so the API server creates the parent and applies the child default.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
Fixed `allowedSystemProfiles` default (`["container"]`) not being applied in v1 API.
```
