### PR TITLE
fix: skip binding mutation on pod UPDATE

### DIFF
--- a/deploy/overlays/webhook/webhook_config.yaml
+++ b/deploy/overlays/webhook/webhook_config.yaml
@@ -12,7 +12,7 @@ webhooks:
     timeoutSeconds: 5
     sideEffects: None
     rules:
-      - operations: ["CREATE", "UPDATE", "DELETE"]
+      - operations: ["CREATE", "DELETE"]
         apiGroups: ["*"]
         apiVersions: ["v1"]
         resources: ["pods"]

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -6799,7 +6799,6 @@ webhooks:
     - v1
     operations:
     - CREATE
-    - UPDATE
     - DELETE
     resources:
     - pods

--- a/internal/pkg/manager/spod/bindata/webhook.go
+++ b/internal/pkg/manager/spod/bindata/webhook.go
@@ -44,7 +44,19 @@ var (
 	caBundle                      = []byte("Cg==")
 	sideEffects                   = admissionregv1.SideEffectClassNone
 	admissionReviewVersions       = []string{"v1beta1"}
-	rules                         = []admissionregv1.RuleWithOperations{
+	bindingRules                  = []admissionregv1.RuleWithOperations{
+		{
+			Operations: []admissionregv1.OperationType{
+				"CREATE", "DELETE",
+			},
+			Rule: admissionregv1.Rule{
+				APIGroups:   []string{""},
+				APIVersions: []string{"v1"},
+				Resources:   []string{"pods"},
+			},
+		},
+	}
+	recordingRules = []admissionregv1.RuleWithOperations{
 		{
 			Operations: []admissionregv1.OperationType{
 				"CREATE", "UPDATE", "DELETE",
@@ -482,7 +494,7 @@ func getWebhookConfig(execMetadataWebhookEnabled bool) *admissionregv1.MutatingW
 			Name:           binding.name,
 			FailurePolicy:  &failurePolicyFail,
 			SideEffects:    &sideEffects,
-			Rules:          rules,
+			Rules:          bindingRules,
 			ObjectSelector: &objectSelector,
 			NamespaceSelector: &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -505,7 +517,7 @@ func getWebhookConfig(execMetadataWebhookEnabled bool) *admissionregv1.MutatingW
 			Name:           recording.name,
 			FailurePolicy:  &failurePolicyFail,
 			SideEffects:    &sideEffects,
-			Rules:          rules,
+			Rules:          recordingRules,
 			ObjectSelector: &objectSelector,
 			NamespaceSelector: &metav1.LabelSelector{
 				MatchExpressions: []metav1.LabelSelectorRequirement{

--- a/internal/pkg/manager/spod/bindata/webhook_test.go
+++ b/internal/pkg/manager/spod/bindata/webhook_test.go
@@ -225,6 +225,12 @@ func TestWebhook_getWebhookConfig(t *testing.T) {
 	webhookConfig := getWebhookConfig(false)
 	require.Len(t, webhookConfig.Webhooks, 2)
 
+	bindingOps := webhookConfig.Webhooks[binding.index].Rules[0].Operations
+	assert.ElementsMatch(t, []admissionregv1.OperationType{"CREATE", "DELETE"}, bindingOps)
+
+	recordingOps := webhookConfig.Webhooks[recording.index].Rules[0].Operations
+	assert.ElementsMatch(t, []admissionregv1.OperationType{"CREATE", "UPDATE", "DELETE"}, recordingOps)
+
 	webhookConfig = getWebhookConfig(true)
 	require.Len(t, webhookConfig.Webhooks, 4)
 }

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/google/go-cmp/cmp"
+	admissionv1 "k8s.io/api/admission/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -180,7 +181,13 @@ func (p *podBinder) updatePod(
 	pod := &corev1.Pod{}
 	podChanged := false
 
-	if req.Operation != "DELETE" {
+	// Pod security context fields are immutable after creation, so only
+	// mutate on CREATE. UPDATE would produce a patch the API server rejects.
+	if req.Operation != admissionv1.Create && req.Operation != admissionv1.Delete {
+		return pod, admission.Allowed("pod update, skipping mutation")
+	}
+
+	if req.Operation == admissionv1.Create {
 		pod, err = p.DecodePod(*req)
 		if err != nil {
 			p.log.Error(err, "failed to decode pod")
@@ -196,7 +203,7 @@ func (p *podBinder) updatePod(
 
 		profileName := profilebindings[i].Spec.ProfileRef.Name
 
-		if req.Operation == "DELETE" {
+		if req.Operation == admissionv1.Delete {
 			if err := p.removePodFromBinding(ctx, podID, &profilebindings[i]); err != nil {
 				return pod, admission.Errored(http.StatusInternalServerError, err)
 			}

--- a/internal/pkg/webhooks/binding/binding_test.go
+++ b/internal/pkg/webhooks/binding/binding_test.go
@@ -86,15 +86,51 @@ func TestHandle(t *testing.T) {
 				mock.ListProfileBindingsReturns(&profilebindingapi.ProfileBindingList{}, nil)
 				mock.DecodePodReturns(&corev1.Pod{}, nil)
 			},
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+				},
+			},
 			assert: func(resp admission.Response) {
 				require.True(t, resp.Allowed)
 				require.Equal(t, http.StatusOK, int(resp.Result.Code))
 				require.Equal(t, "pod unchanged", resp.Result.Message)
 			},
 		},
+		{ // success pod update skips mutation
+			prepare: func(mock *bindingfakes.FakeImpl) {
+				mock.ListProfileBindingsReturns(&profilebindingapi.ProfileBindingList{
+					Items: []profilebindingapi.ProfileBinding{
+						{
+							Spec: profilebindingapi.ProfileBindingSpec{
+								ProfileRef: profilebindingapi.ProfileRef{
+									Kind: profilebindingapi.ProfileBindingKindSeccompProfile,
+								},
+								Image: "foo",
+							},
+						},
+					},
+				}, nil)
+			},
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Update,
+				},
+			},
+			assert: func(resp admission.Response) {
+				require.True(t, resp.Allowed)
+				require.Empty(t, resp.Patches)
+				require.Equal(t, "pod update, skipping mutation", resp.Result.Message)
+			},
+		},
 		{ // error could not list profile bindings
 			prepare: func(mock *bindingfakes.FakeImpl) {
 				mock.ListProfileBindingsReturns(nil, errTest)
+			},
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+				},
 			},
 			assert: func(resp admission.Response) {
 				require.Equal(t, http.StatusInternalServerError, int(resp.Result.Code))
@@ -104,6 +140,11 @@ func TestHandle(t *testing.T) {
 			prepare: func(mock *bindingfakes.FakeImpl) {
 				mock.ListProfileBindingsReturns(&profilebindingapi.ProfileBindingList{}, nil)
 				mock.DecodePodReturns(nil, errTest)
+			},
+			request: admission.Request{
+				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
+				},
 			},
 			assert: func(resp admission.Response) {
 				require.Equal(t, http.StatusBadRequest, int(resp.Result.Code))
@@ -135,6 +176,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPod.DeepCopy())
@@ -178,6 +220,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPodWithLabels.DeepCopy())
@@ -221,6 +264,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPodWithLabels.DeepCopy())
@@ -263,6 +307,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPod.DeepCopy())
@@ -304,6 +349,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							podWithSecurityContext := testPod.DeepCopy()
@@ -350,6 +396,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPod.DeepCopy())
@@ -391,6 +438,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							podWithSecurityContext := testPod.DeepCopy()
@@ -437,6 +485,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPod.DeepCopy())
@@ -478,6 +527,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPod.DeepCopy())
@@ -521,6 +571,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							podWithSecurityContext := testPod.DeepCopy()
@@ -568,6 +619,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPod.DeepCopy())
@@ -601,6 +653,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPod.DeepCopy())
@@ -636,6 +689,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPod.DeepCopy())
@@ -674,6 +728,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPod.DeepCopy())
@@ -710,6 +765,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPod.DeepCopy())
@@ -742,6 +798,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPod.DeepCopy())
@@ -783,6 +840,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPod.DeepCopy())
@@ -824,6 +882,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPod.DeepCopy())
@@ -912,6 +971,7 @@ func TestHandle(t *testing.T) {
 			},
 			request: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
+					Operation: admissionv1.Create,
 					Object: runtime.RawExtension{
 						Raw: func() []byte {
 							b, err := json.Marshal(testPod.DeepCopy())


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The binding webhook registered for CREATE, UPDATE, and DELETE on pods but applied the same mutation logic to UPDATE as to CREATE. Since pod security context fields (seccompProfile, selinuxOptions, appArmorProfile) are immutable after creation, mutating on UPDATE always gets rejected by the API server. This makes pre-existing pods (created before the binding or namespace label existed) completely un-updatable.

Changes:
- Skip mutation for non-CREATE/non-DELETE operations in the binding handler
- Remove UPDATE from the binding webhook's registered operations and regenerated `deploy/webhook-operator.yaml`
- Use typed `admissionv1` constants instead of raw strings for operation checks
- Add unit test for UPDATE skip behavior (asserts response message), set `Operation` explicitly on all existing test cases, and add webhook config test asserting operations per webhook

The recording webhook keeps UPDATE since it has different semantics.

#### Which issue(s) this PR fixes:

Fixes #3296

#### Does this PR have test?

Yes. Added a test case verifying that UPDATE requests return `Allowed` with message `"pod update, skipping mutation"` and no patches. Updated all existing test cases to set `Operation` explicitly. Added assertions in `TestWebhook_getWebhookConfig` verifying that the binding webhook registers CREATE+DELETE and the recording webhook registers CREATE+UPDATE+DELETE.

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
Fixed binding webhook mutating pods on UPDATE, which the API server always rejects since security context fields are immutable after creation. Pre-existing pods matching a ProfileBinding are no longer blocked from updates.
```