### PR TITLE
feat: add SELinux options in helm chart

### DIFF
--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -20,7 +20,7 @@ spec:
   selinux:
     enable: {{ or .Values.enableSelinux .Values.selinux.enable }}
     enableRawSelinuxProfiles: {{ .Values.selinux.enableRawSelinuxProfiles }}
-    typeTag: {{ .Values.selinux.typeTag }}
+    typeTag: {{ .Values.selinux.typeTag | quote }}
     {{- with .Values.selinux.options }}
     options:
       {{- toYaml . | nindent 6 }}

--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -18,7 +18,13 @@ spec:
   daemonResourceRequirements:
     {{- toYaml .Values.daemon.resources | nindent 4 }}
   selinux:
-    enable: {{ .Values.enableSelinux }}
+    enable: {{ or .Values.enableSelinux .Values.selinux.enable }}
+    enableRawSelinuxProfiles: {{ .Values.selinux.enableRawSelinuxProfiles }}
+    typeTag: {{ .Values.selinux.typeTag }}
+    {{- with .Values.selinux.options }}
+    options:
+      {{- toYaml . | nindent 6 }}
+    {{- end }}
   enricher:
     enableLogEnricher: {{ .Values.enableLogEnricher }}
     enableJsonEnricher: {{ .Values.enableJsonEnricher }}

--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -18,7 +18,7 @@ spec:
   daemonResourceRequirements:
     {{- toYaml .Values.daemon.resources | nindent 4 }}
   selinux:
-    enable: {{ or .Values.enableSelinux .Values.selinux.enable }}
+    enable: {{ hasKey .Values.selinux "enable" | ternary .Values.selinux.enable .Values.enableSelinux }}
     enableRawSelinuxProfiles: {{ .Values.selinux.enableRawSelinuxProfiles }}
     typeTag: {{ .Values.selinux.typeTag | quote }}
     {{- with .Values.selinux.options }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -27,7 +27,7 @@ selinuxdImage:
 # Deprecated, use selinux.enable instead
 enableSelinux: false
 selinux:
-  enable: false
+  # enable: false # Overrides deprecated enableSelinux flag
   enableRawSelinuxProfiles: true
   typeTag: spc_t
   options: {}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -24,7 +24,13 @@ selinuxdImage:
     repository: security-profiles-operator/selinuxd-fedora
     tag: latest
 
+# Deprecated, use selinux.enable instead
 enableSelinux: false
+selinux:
+  enable: false
+  enableRawSelinuxProfiles: true
+  typeTag: spc_t
+  options: {}
 enableLogEnricher: false
 enableJsonEnricher: false
 enableAppArmor: false

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -31,6 +31,14 @@ selinux:
   enableRawSelinuxProfiles: true
   typeTag: spc_t
   options: {}
+    # allowedSystemProfiles:
+    #   - container
+    # deniedTypes: []
+    # deniedClasses: []
+    # deniedPermissions: []
+    # allowedTypes: []
+    # allowedClasses: []
+    # allowedPermissions: []
 enableLogEnricher: false
 enableJsonEnricher: false
 enableAppArmor: false


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind deprecation

#### What this PR does / why we need it:

The Helm chart currently only exposes the SELinux `enable` flag (`enableSelinux`), while the `SecurityProfilesOperatorDaemon` CRD supports a much richer `selinux` block: `enableRawSelinuxProfiles`, `typeTag`, and others `options`. Users installing via Helm had no way to set these without manually patching the `spod` CR after install.

This PR adds a `selinux` value to the chart that mirrors the CRD structure:

```yaml
selinux:
  enable: false
  enableRawSelinuxProfiles: true
  typeTag: spc_t
  options: {}
```

#### Which issue(s) this PR fixes:

N/A

#### Special notes for your reviewer:

**Deprecation of `enableSelinux`:** I thought it was best to deprecate the top-level `enableSelinux` value in favor of `selinux.enable`. With the rest of the SELinux configuration now living under `selinux` key, keeping the enable flag as a separate top-level value would split one logical configuration block across two places. `enableSelinux` still works, so existing values files should be backwards compatible.

#### Does this PR introduce a user-facing change?

```release-note
Exposed the full SELinux configuration of the SPOD in Helm chart values. The top-level `enableSelinux` value is deprecated in favor of `selinux.enable`.
```
