### PR TITLE
fix: support RHEL OS images without release

### DIFF
--- a/deploy/base/profiles/selinuxd-image-mapping.json
+++ b/deploy/base/profiles/selinuxd-image-mapping.json
@@ -1,14 +1,14 @@
 [
     {
-        "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*|(.*)(Red Hat Enterprise Linux release)\\s+8\\.[0-9]+",
+        "regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*|(.*)(Red Hat Enterprise Linux)(\\s+release)?\\s+8\\.[0-9]+",
         "imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
     },
     {
-        "regex": "(.*)(CoreOS).*10\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux CoreOS)\\s+10\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux release)\\s+10\\.[0-9]+",
+        "regex": "(.*)(CoreOS).*10\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux CoreOS)\\s+10\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux)(\\s+release)?\\s+10\\.[0-9]+",
         "imageFromVar": "RELATED_IMAGE_SELINUXD_EL10"
     },
     {
-        "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux release)\\s+9\\.[0-9]+",
+        "regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux)(\\s+release)?\\s+9\\.[0-9]+",
         "imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
     },
     {

--- a/internal/pkg/util/kubernetes_test.go
+++ b/internal/pkg/util/kubernetes_test.go
@@ -182,17 +182,17 @@ func TestMatchSelinuxdImageVersion(t *testing.T) {
 
 	mappingJSON := `[
 		{
-			"regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*|(.*)(Red Hat Enterprise Linux release)\\s+8\\.[0-9]+",
+			"regex": "(.*)(CoreOS).*(41[0-2]\\.[0-9]+)\\..*|(.*)(Red Hat Enterprise Linux)(\\s+release)?\\s+8\\.[0-9]+",
 			"imageFromVar": "RELATED_IMAGE_SELINUXD_EL8"
 		},
 		{
 			"regex": "(.*)(CoreOS).*10\\.[0-9]+\\..*|(.*)(Red Hat Enterprise Linux CoreOS)\\s+10\\.[0-9]+\\..*` +
-		`|(.*)(Red Hat Enterprise Linux release)\\s+10\\.[0-9]+",
+		`|(.*)(Red Hat Enterprise Linux)(\\s+release)?\\s+10\\.[0-9]+",
 			"imageFromVar": "RELATED_IMAGE_SELINUXD_EL10"
 		},
 		{
 			"regex": "(.*)(CoreOS).*(41[3-9]\\.[0-9]+)\\..*|(.*)(CoreOS)\\s+9\\.[0-9]+\\..*` +
-		`|(.*)(Red Hat Enterprise Linux release)\\s+9\\.[0-9]+",
+		`|(.*)(Red Hat Enterprise Linux)(\\s+release)?\\s+9\\.[0-9]+",
 			"imageFromVar": "RELATED_IMAGE_SELINUXD_EL9"
 		}
 	]`
@@ -347,6 +347,28 @@ func TestMatchSelinuxdImageVersion(t *testing.T) {
 			},
 			want: "RELATED_IMAGE_SELINUXD_EL8",
 		},
+		{
+			name: "Direct RHEL 9.8 without release",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						OSImage: "Red Hat Enterprise Linux 9.8 (Plow)",
+					},
+				},
+			},
+			want: "RELATED_IMAGE_SELINUXD_EL9",
+		},
+		{
+			name: "Direct RHEL 8.6 without release",
+			node: &corev1.Node{
+				Status: corev1.NodeStatus{
+					NodeInfo: corev1.NodeSystemInfo{
+						OSImage: "Red Hat Enterprise Linux 8.6 (Ootpa)",
+					},
+				},
+			},
+			want: "RELATED_IMAGE_SELINUXD_EL8",
+		},
 	}
 
 	for _, tt := range tests {
@@ -386,7 +408,8 @@ func TestGetOperatorConfigMap(t *testing.T) {
 			args: args{
 				c: &MockClient{
 					MockGet: NewMockGetFn(kerrors.NewForbidden(
-						schema.GroupResource{}, "test", errors.New("test"))),
+						schema.GroupResource{}, "test", errors.New("test"),
+					)),
 				},
 			},
 			want:    nil,


### PR DESCRIPTION
#### What type of PR is this?
/kind bug

#### What this PR does / why we need it:
Updates the SELinuxd image mapping regex to recognize RHEL OS images that omit the `release` word, such as `Red Hat Enterprise Linux 9.8 (Plow)`.

The existing `Red Hat Enterprise Linux release <version>` and CoreOS formats remain supported.
<img width="2046" height="148" alt="image" src="https://github.com/user-attachments/assets/9f646651-d92e-4434-9648-1a00e15a9ca1" />

#### Which issue(s) this PR fixes:
None

#### Does this PR have test?
Yes. Added test cases for RHEL 8, 9, and 10 OS images without `release`.

#### Special notes for your reviewer:
None

#### Does this PR introduce a user-facing change?

```release-note
Support RHEL OS images that omit "release" when selecting the SELinuxd image.