### PR TITLE
feat(recording): expose per-syscall coverage on merged seccomp profiles

### DIFF
--- a/installation-usage.md
+++ b/installation-usage.md
@@ -1900,6 +1900,43 @@ including the `mknod` syscall:
   - mknod
 ```
 
+**Syscall coverage annotation**
+
+When a `SeccompProfile` is produced by a merge (`mergeStrategy: Containers`), the resulting profile
+carries an informational annotation, `spo.x-k8s.io/syscall-coverage`, that records how the merged
+allowlist was assembled from the individual partial profiles. Its value is a small JSON document:
+
+```json
+{
+  "version": "v1",
+  "total": 3,
+  "syscalls": {
+    "mknod": 1,
+    "read": 3,
+    "write": 3
+  }
+}
+```
+
+The semantics are literal, per syscall: `total` is **M**, the number of partial profiles that were
+collected and included in the merge, and each entry under `syscalls` is **N**, the number of those
+partial profiles that contained that syscall. A syscall that appears more than once inside a single
+partial profile still counts once for that profile. In the example above, `read` and `write` were
+observed in all three recorded containers, while `mknod` was observed in only one.
+
+This is **observation coverage, not confidence or probability**, and it does not measure how many
+times a syscall was invoked. `total` counts the partial profiles that were actually collected, which
+is not necessarily the number of executions that occurred (for example, a recording can be lost if
+the operator restarts mid-recording). Recorded replicas usually run identical images and are
+therefore correlated rather than independent samples, so the counts should not be read as a
+statistical measure.
+
+The annotation is purely informational: it never changes the generated seccomp allowlist, and the
+enforced profile is exactly what the merge produces regardless of these counts. Treat it as a review
+aid only — **do not remove syscalls from a generated profile based solely on a low coverage count**,
+since a syscall observed in only one replica may still be required on a code path the other replicas
+did not exercise.
+
 ## Command Line Interface (CLI)
 
 The Security Profiles Operator CLI `spoc` aims to support use cases where

--- a/internal/pkg/manager/recordingmerger/coverage.go
+++ b/internal/pkg/manager/recordingmerger/coverage.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recordingmerger
+
+import (
+	"encoding/json"
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// syscallCoverageAnnotation is set on a merged SeccompProfile (mergeStrategy=
+// Containers) recording, per syscall, how many collected partials contained it.
+// Informational only; never affects the enforced profile.
+const syscallCoverageAnnotation = "spo.x-k8s.io/syscall-coverage"
+
+// syscallCoverageSchemaVersion is the annotation value's schema version.
+const syscallCoverageSchemaVersion = "v1"
+
+// syscallCoverage is the JSON document stored in syscallCoverageAnnotation:
+// Total merged partials, and per syscall how many of them contained it.
+type syscallCoverage struct {
+	Version  string         `json:"version"`
+	Total    int            `json:"total"`
+	Syscalls map[string]int `json:"syscalls"`
+}
+
+func seccompCoverageAnnotation(partials []mergeableProfile) (string, error) {
+	if len(partials) == 0 {
+		return "", nil
+	}
+
+	counts := make(map[string]int)
+
+	for _, partial := range partials {
+		seccompPartial, ok := partial.(*mergeableSeccompProfile)
+		if !ok {
+			// mergeTypedProfiles groups profiles by type before calling this
+			// function, so mixed profile types are not expected. Coverage is
+			// informational and must not prevent profile merging, so safely omit
+			// the annotation rather than returning an error.
+			return "", nil
+		}
+
+		seen := make(map[string]struct{})
+
+		for i := range seccompPartial.Spec.Syscalls {
+			for _, name := range seccompPartial.Spec.Syscalls[i].Names {
+				seen[name] = struct{}{}
+			}
+		}
+
+		for name := range seen {
+			counts[name]++
+		}
+	}
+
+	coverage := syscallCoverage{
+		Version:  syscallCoverageSchemaVersion,
+		Total:    len(partials),
+		Syscalls: counts,
+	}
+
+	data, err := json.Marshal(coverage)
+	if err != nil {
+		return "", fmt.Errorf("marshal syscall coverage: %w", err)
+	}
+
+	return string(data), nil
+}
+
+func setSyscallCoverageAnnotation(obj metav1.Object, value string) {
+	if value == "" {
+		return
+	}
+
+	annotations := obj.GetAnnotations()
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	annotations[syscallCoverageAnnotation] = value
+	obj.SetAnnotations(annotations)
+}

--- a/internal/pkg/manager/recordingmerger/coverage_test.go
+++ b/internal/pkg/manager/recordingmerger/coverage_test.go
@@ -1,0 +1,613 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package recordingmerger
+
+import (
+	"context"
+	"encoding/json"
+	"sort"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	apparmorprofileapi "sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1"
+	profilebase "sigs.k8s.io/security-profiles-operator/api/profilebase/v1"
+	profilerecordingapi "sigs.k8s.io/security-profiles-operator/api/profilerecording/v1"
+	seccompprofile "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1"
+	selinuxprofileapi "sigs.k8s.io/security-profiles-operator/api/selinuxprofile/v1"
+)
+
+// seccompPartial builds a mergeable seccomp partial profile from a set of rules,
+// where each rule is a (action, names) pair.
+func seccompPartial(name string, rules ...seccompprofile.Syscall) mergeableProfile {
+	return &mergeableSeccompProfile{
+		SeccompProfile: seccompprofile.SeccompProfile{
+			ObjectMeta: metav1.ObjectMeta{Name: name},
+			Spec: seccompprofile.SeccompProfileSpec{
+				DefaultAction: seccompprofile.ActErrno,
+				Syscalls:      rules,
+			},
+		},
+	}
+}
+
+func allow(names ...string) seccompprofile.Syscall {
+	return seccompprofile.Syscall{Action: seccompprofile.ActAllow, Names: names}
+}
+
+// parseCoverage unmarshals the annotation value into the coverage struct.
+func parseCoverage(t *testing.T, value string) syscallCoverage {
+	t.Helper()
+
+	var cov syscallCoverage
+	require.NoError(t, json.Unmarshal([]byte(value), &cov))
+
+	return cov
+}
+
+func TestSeccompCoverageAnnotation(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name         string
+		partials     []mergeableProfile
+		expectEmpty  bool
+		expectTotal  int
+		expectCounts map[string]int
+	}{
+		{
+			name: "heterogeneous",
+			partials: []mergeableProfile{
+				seccompPartial("a", allow("read", "write", "openat")),
+				seccompPartial("b", allow("read", "write", "socket")),
+				seccompPartial("c", allow("read", "write")),
+			},
+			expectTotal:  3,
+			expectCounts: map[string]int{"read": 3, "write": 3, "openat": 1, "socket": 1},
+		},
+		{
+			// All counts equal the total; no values are suppressed.
+			name: "homogeneous",
+			partials: []mergeableProfile{
+				seccompPartial("a", allow("read", "write")),
+				seccompPartial("b", allow("read", "write")),
+				seccompPartial("c", allow("read", "write")),
+			},
+			expectTotal:  3,
+			expectCounts: map[string]int{"read": 3, "write": 3},
+		},
+		{
+			// A single partial still produces coverage with total=1.
+			name: "single partial",
+			partials: []mergeableProfile{
+				seccompPartial("a", allow("read", "write")),
+			},
+			expectTotal:  1,
+			expectCounts: map[string]int{"read": 1, "write": 1},
+		},
+		{
+			// Duplicate names within one rule count once for that partial.
+			name: "duplicate names in one rule",
+			partials: []mergeableProfile{
+				seccompPartial("a", allow("read", "read", "write")),
+				seccompPartial("b", allow("read")),
+			},
+			expectTotal:  2,
+			expectCounts: map[string]int{"read": 2, "write": 1},
+		},
+		{
+			// The same syscall across multiple rules in one partial counts once.
+			name: "same syscall across multiple rules",
+			partials: []mergeableProfile{
+				seccompPartial("a", allow("read"), allow("read")),
+				seccompPartial("b", allow("write")),
+			},
+			expectTotal:  2,
+			expectCounts: map[string]int{"read": 1, "write": 1},
+		},
+		{
+			// Counting is by syscall name across rules, regardless of action.
+			name: "different actions",
+			partials: []mergeableProfile{
+				seccompPartial("a",
+					allow("read"),
+					seccompprofile.Syscall{Action: seccompprofile.ActLog, Names: []string{"write"}},
+				),
+				seccompPartial("b", allow("read")),
+			},
+			expectTotal:  2,
+			expectCounts: map[string]int{"read": 2, "write": 1},
+		},
+		{
+			// A partial with no syscall rules still contributes to the total.
+			name: "empty rules",
+			partials: []mergeableProfile{
+				seccompPartial("a", allow("read")),
+				seccompPartial("b"),
+			},
+			expectTotal:  2,
+			expectCounts: map[string]int{"read": 1},
+		},
+		{
+			name: "empty names list",
+			partials: []mergeableProfile{
+				seccompPartial("a", allow()),
+				seccompPartial("b", allow("read")),
+			},
+			expectTotal:  2,
+			expectCounts: map[string]int{"read": 1},
+		},
+		{
+			// No included partial profiles produce no annotation.
+			name:        "no partials",
+			partials:    []mergeableProfile{},
+			expectEmpty: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			value, err := seccompCoverageAnnotation(tc.partials)
+			require.NoError(t, err)
+
+			if tc.expectEmpty {
+				require.Empty(t, value)
+
+				return
+			}
+
+			require.NotEmpty(t, value)
+
+			cov := parseCoverage(t, value)
+			require.Equal(t, syscallCoverageSchemaVersion, cov.Version)
+			require.Equal(t, tc.expectTotal, cov.Total)
+			require.Equal(t, tc.expectCounts, cov.Syscalls)
+		})
+	}
+}
+
+// SELinux and AppArmor profiles are excluded.
+func TestSeccompCoverageAnnotation_NonSeccompExcluded(t *testing.T) {
+	t.Parallel()
+
+	selinuxPartials := []mergeableProfile{
+		&MergeableSelinuxProfile{
+			SelinuxProfile: selinuxprofileapi.SelinuxProfile{
+				ObjectMeta: metav1.ObjectMeta{Name: "sel"},
+			},
+		},
+	}
+	value, err := seccompCoverageAnnotation(selinuxPartials)
+	require.NoError(t, err)
+	require.Empty(t, value)
+
+	apparmorPartials := []mergeableProfile{
+		&mergeableAppArmorProfile{
+			AppArmorProfile: apparmorprofileapi.AppArmorProfile{
+				ObjectMeta: metav1.ObjectMeta{Name: "aa"},
+			},
+		},
+	}
+	value, err = seccompCoverageAnnotation(apparmorPartials)
+	require.NoError(t, err)
+	require.Empty(t, value)
+}
+
+func TestSeccompCoverageAnnotation_DeterministicAndOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	base := []mergeableProfile{
+		seccompPartial("a", allow("read", "write", "openat")),
+		seccompPartial("b", allow("read", "write", "socket")),
+		seccompPartial("c", allow("read", "write", "mmap")),
+	}
+
+	// Repeated calls on the same input are byte-identical.
+	first, err := seccompCoverageAnnotation(base)
+	require.NoError(t, err)
+
+	for range 20 {
+		again, aerr := seccompCoverageAnnotation(base)
+		require.NoError(t, aerr)
+		require.Equal(t, first, again)
+	}
+
+	// Shuffled input order yields an identical serialized value.
+	shuffles := [][]mergeableProfile{
+		{base[2], base[0], base[1]},
+		{base[1], base[2], base[0]},
+		{base[2], base[1], base[0]},
+	}
+	for _, shuffled := range shuffles {
+		value, verr := seccompCoverageAnnotation(shuffled)
+		require.NoError(t, verr)
+		require.Equal(t, first, value)
+	}
+}
+
+func TestSeccompCoverageAnnotation_DoesNotMutateSources(t *testing.T) {
+	t.Parallel()
+
+	original := seccompprofile.SeccompProfileSpec{
+		DefaultAction: seccompprofile.ActErrno,
+		Syscalls: []seccompprofile.Syscall{
+			{Action: seccompprofile.ActAllow, Names: []string{"read", "read", "write"}},
+			{Action: seccompprofile.ActLog, Names: []string{"read"}},
+		},
+	}
+
+	partial := &mergeableSeccompProfile{
+		SeccompProfile: seccompprofile.SeccompProfile{
+			ObjectMeta: metav1.ObjectMeta{Name: "a"},
+			Spec:       *original.DeepCopy(),
+		},
+	}
+
+	_, err := seccompCoverageAnnotation([]mergeableProfile{partial})
+	require.NoError(t, err)
+
+	// Spec (including exact rule and name ordering) is untouched.
+	require.Equal(t, original, partial.Spec)
+}
+
+// The merge path computes coverage from each group's own partials independently,
+// so two independent calls produce independent, non-interfering results.
+func TestSeccompCoverageAnnotation_NoCrossGroupLeak(t *testing.T) {
+	t.Parallel()
+
+	groupA := []mergeableProfile{
+		seccompPartial("a1", allow("read", "openat")),
+		seccompPartial("a2", allow("read")),
+	}
+	groupB := []mergeableProfile{
+		seccompPartial("b1", allow("write", "socket")),
+	}
+
+	valueA, err := seccompCoverageAnnotation(groupA)
+	require.NoError(t, err)
+	valueB, err := seccompCoverageAnnotation(groupB)
+	require.NoError(t, err)
+
+	covA := parseCoverage(t, valueA)
+	covB := parseCoverage(t, valueB)
+
+	require.Equal(t, 2, covA.Total)
+	require.Equal(t, map[string]int{"read": 2, "openat": 1}, covA.Syscalls)
+
+	require.Equal(t, 1, covB.Total)
+	require.Equal(t, map[string]int{"write": 1, "socket": 1}, covB.Syscalls)
+
+	// No group-A syscalls appear in group B and vice versa.
+	require.NotContains(t, covB.Syscalls, "read")
+	require.NotContains(t, covB.Syscalls, "openat")
+	require.NotContains(t, covA.Syscalls, "write")
+	require.NotContains(t, covA.Syscalls, "socket")
+}
+
+func TestSetSyscallCoverageAnnotation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil annotations map is initialized safely", func(t *testing.T) {
+		t.Parallel()
+
+		obj := &seccompprofile.SeccompProfile{}
+
+		require.NotPanics(t, func() {
+			setSyscallCoverageAnnotation(obj, `{"version":"v1","total":1,"syscalls":{"read":1}}`)
+		})
+		require.JSONEq(t,
+			`{"version":"v1","total":1,"syscalls":{"read":1}}`,
+			obj.GetAnnotations()[syscallCoverageAnnotation])
+	})
+
+	t.Run("preserves existing unrelated annotations", func(t *testing.T) {
+		t.Parallel()
+
+		obj := &seccompprofile.SeccompProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{"user.example.com/keep": "yes"},
+			},
+		}
+		setSyscallCoverageAnnotation(obj, "cov-value")
+
+		require.Equal(t, "yes", obj.GetAnnotations()["user.example.com/keep"])
+		require.Equal(t, "cov-value", obj.GetAnnotations()[syscallCoverageAnnotation])
+	})
+
+	t.Run("refreshes stale coverage value", func(t *testing.T) {
+		t.Parallel()
+
+		obj := &seccompprofile.SeccompProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{
+					syscallCoverageAnnotation: "stale",
+					"user.example.com/keep":   "yes",
+				},
+			},
+		}
+		setSyscallCoverageAnnotation(obj, "fresh")
+
+		require.Equal(t, "fresh", obj.GetAnnotations()[syscallCoverageAnnotation])
+		require.Equal(t, "yes", obj.GetAnnotations()["user.example.com/keep"])
+	})
+
+	t.Run("empty value is a no-op", func(t *testing.T) {
+		t.Parallel()
+
+		obj := &seccompprofile.SeccompProfile{}
+		setSyscallCoverageAnnotation(obj, "")
+		require.Nil(t, obj.GetAnnotations())
+	})
+}
+
+// This guards against the coverage work accidentally altering merged spec output.
+func TestMergeProfiles_SeccompUnionUnchanged(t *testing.T) {
+	t.Parallel()
+
+	partials := []client.Object{
+		&seccompprofile.SeccompProfile{
+			ObjectMeta: metav1.ObjectMeta{Name: "a"},
+			Spec: seccompprofile.SeccompProfileSpec{
+				DefaultAction: seccompprofile.ActErrno,
+				Syscalls: []seccompprofile.Syscall{
+					{Action: seccompprofile.ActAllow, Names: []string{"read", "write", "openat"}},
+				},
+			},
+		},
+		&seccompprofile.SeccompProfile{
+			ObjectMeta: metav1.ObjectMeta{Name: "b"},
+			Spec: seccompprofile.SeccompProfileSpec{
+				DefaultAction: seccompprofile.ActErrno,
+				Syscalls: []seccompprofile.Syscall{
+					{Action: seccompprofile.ActAllow, Names: []string{"read", "write", "socket"}},
+				},
+			},
+		},
+	}
+
+	merged, err := MergeProfiles(partials)
+	require.NoError(t, err)
+
+	// Verify that the merged profile still contains the same syscall union,
+	// regardless of how the merger groups syscall names into rules.
+	sorted := ifaceAsSortedSeccompProfile(merged)
+	require.NotNil(t, sorted)
+
+	names := make([]string, 0, len(sorted.Spec.Syscalls))
+
+	for _, rule := range sorted.Spec.Syscalls {
+		require.Equal(t, seccompprofile.ActAllow, rule.Action)
+		names = append(names, rule.Names...)
+	}
+
+	sort.Strings(names)
+
+	require.Equal(
+		t,
+		[]string{"openat", "read", "socket", "write"},
+		names,
+	)
+
+	// The merge itself never sets the coverage annotation; that is done in the
+	// controller path (createUpdateProfile), not in MergeProfiles.
+	require.NotContains(t, merged.GetAnnotations(), syscallCoverageAnnotation)
+}
+
+func TestSeccompCoverageAnnotation_MustRunBeforeMerge(t *testing.T) {
+	t.Parallel()
+
+	partials := []mergeableProfile{
+		seccompPartial("a", allow("read", "write")),
+		seccompPartial("b", allow("read", "socket")),
+	}
+
+	merged, err := mergeMergeableProfiles(partials)
+	require.NoError(t, err)
+	require.Same(t, partials[0], merged)
+
+	// This intentionally demonstrates the invalid ordering: merging mutates the
+	// first partial, so computing coverage afterward inflates socket's count.
+	coverageAnnotation, err := seccompCoverageAnnotation(partials)
+	require.NoError(t, err)
+
+	coverage := parseCoverage(t, coverageAnnotation)
+	require.Equal(t, 2, coverage.Syscalls["socket"])
+}
+
+func TestMergeTypedProfiles_ComputesCoverageBeforeMerge(t *testing.T) {
+	t.Parallel()
+
+	const (
+		recordingName = "rec"
+		namespace     = "ns"
+		containerName = "ctr"
+	)
+
+	partialLabels := map[string]string{
+		profilerecordingapi.ProfileToRecordingLabel:          recordingName,
+		profilerecordingapi.ProfileToRecordingNamespaceLabel: namespace,
+		profilerecordingapi.ProfileToContainerLabel:          containerName,
+		profilebase.ProfilePartialLabel:                      "true",
+	}
+	partialA := &seccompprofile.SeccompProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "a", Namespace: namespace, Labels: partialLabels},
+		Spec: seccompprofile.SeccompProfileSpec{
+			DefaultAction: seccompprofile.ActErrno,
+			Syscalls:      []seccompprofile.Syscall{allow("read", "write")},
+		},
+	}
+	partialB := &seccompprofile.SeccompProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "b", Namespace: namespace, Labels: partialLabels},
+		Spec: seccompprofile.SeccompProfileSpec{
+			DefaultAction: seccompprofile.ActErrno,
+			Syscalls:      []seccompprofile.Syscall{allow("read", "socket")},
+		},
+	}
+
+	cl := fake.NewClientBuilder().
+		WithScheme(coverageTestScheme(t)).
+		WithObjects(partialA, partialB).
+		Build()
+	reconciler := &PolicyMergeReconciler{client: cl, log: logr.Discard()}
+	recording := &profilerecordingapi.ProfileRecording{
+		ObjectMeta: metav1.ObjectMeta{Name: recordingName, Namespace: namespace},
+	}
+
+	createCalled := false
+	err := reconciler.mergeTypedProfiles(
+		context.Background(), recording,
+		func(
+			_ context.Context,
+			_ client.Client,
+			_ *profilerecordingapi.ProfileRecording,
+			_ string,
+			merged mergeableProfile,
+			coverageAnnotation string,
+		) (controllerutil.OperationResult, error) {
+			createCalled = true
+
+			coverage := parseCoverage(t, coverageAnnotation)
+			require.Equal(t, 2, coverage.Total)
+			require.Equal(t, map[string]int{"read": 2, "socket": 1, "write": 1}, coverage.Syscalls)
+
+			mergedProfile := ifaceAsSortedSeccompProfile(merged.getProfile())
+			require.NotNil(t, mergedProfile)
+
+			names := make([]string, 0, len(mergedProfile.Spec.Syscalls))
+			for _, syscall := range mergedProfile.Spec.Syscalls {
+				names = append(names, syscall.Names...)
+			}
+
+			sort.Strings(names)
+			require.Equal(t, []string{"read", "socket", "write"}, names)
+
+			return controllerutil.OperationResultNone, nil
+		},
+		&seccompprofile.SeccompProfile{},
+		&seccompprofile.SeccompProfileList{},
+	)
+	require.NoError(t, err)
+	require.True(t, createCalled)
+}
+
+func coverageTestScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, seccompprofile.AddToScheme(scheme))
+	require.NoError(t, selinuxprofileapi.AddToScheme(scheme))
+	require.NoError(t, apparmorprofileapi.AddToScheme(scheme))
+
+	return scheme
+}
+
+// Integration test around the actual controller wiring: createUpdateProfile must
+// set the coverage annotation only on merged SeccompProfiles, never on SELinux or
+// AppArmor, and must preserve pre-existing annotations on update.
+func TestCreateUpdateProfile_CoverageAnnotation(t *testing.T) {
+	t.Parallel()
+
+	const (
+		recordingName = "rec"
+		namespace     = "ns"
+		mergedName    = "rec-ctr"
+		coverage      = `{"version":"v1","total":2,"syscalls":{"read":2}}`
+	)
+
+	recording := &profilerecordingapi.ProfileRecording{
+		ObjectMeta: metav1.ObjectMeta{Name: recordingName, Namespace: namespace},
+	}
+
+	t.Run("seccomp merged profile receives the annotation", func(t *testing.T) {
+		t.Parallel()
+
+		cl := fake.NewClientBuilder().WithScheme(coverageTestScheme(t)).Build()
+
+		_, err := createUpdateProfile(
+			context.Background(), cl, recording, mergedName,
+			&mergeableSeccompProfile{}, profilerecordingapi.ProfileRecordingKindSeccompProfile, coverage)
+		require.NoError(t, err)
+
+		got := &seccompprofile.SeccompProfile{}
+		require.NoError(t, cl.Get(context.Background(),
+			client.ObjectKey{Name: mergedName, Namespace: namespace}, got))
+		require.JSONEq(t, coverage, got.GetAnnotations()[syscallCoverageAnnotation])
+	})
+
+	t.Run("selinux merged profile never receives the annotation", func(t *testing.T) {
+		t.Parallel()
+
+		cl := fake.NewClientBuilder().WithScheme(coverageTestScheme(t)).Build()
+
+		_, err := createUpdateProfile(
+			context.Background(), cl, recording, mergedName,
+			&MergeableSelinuxProfile{}, profilerecordingapi.ProfileRecordingKindSelinuxProfile, coverage)
+		require.NoError(t, err)
+
+		got := &selinuxprofileapi.SelinuxProfile{}
+		require.NoError(t, cl.Get(context.Background(),
+			client.ObjectKey{Name: mergedName, Namespace: namespace}, got))
+		require.NotContains(t, got.GetAnnotations(), syscallCoverageAnnotation)
+	})
+
+	t.Run("apparmor merged profile never receives the annotation", func(t *testing.T) {
+		t.Parallel()
+
+		cl := fake.NewClientBuilder().WithScheme(coverageTestScheme(t)).Build()
+
+		_, err := createUpdateProfile(
+			context.Background(), cl, recording, mergedName,
+			&mergeableAppArmorProfile{}, profilerecordingapi.ProfileRecordingKindAppArmorProfile, coverage)
+		require.NoError(t, err)
+
+		got := &apparmorprofileapi.AppArmorProfile{}
+		require.NoError(t, cl.Get(context.Background(),
+			client.ObjectKey{Name: mergedName, Namespace: namespace}, got))
+		require.NotContains(t, got.GetAnnotations(), syscallCoverageAnnotation)
+	})
+
+	t.Run("existing annotations are preserved on update", func(t *testing.T) {
+		t.Parallel()
+
+		existing := &seccompprofile.SeccompProfile{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        mergedName,
+				Namespace:   namespace,
+				Annotations: map[string]string{"user.example.com/keep": "yes"},
+			},
+		}
+		cl := fake.NewClientBuilder().
+			WithScheme(coverageTestScheme(t)).WithObjects(existing).Build()
+
+		_, err := createUpdateProfile(
+			context.Background(), cl, recording, mergedName,
+			&mergeableSeccompProfile{}, profilerecordingapi.ProfileRecordingKindSeccompProfile, coverage)
+		require.NoError(t, err)
+
+		got := &seccompprofile.SeccompProfile{}
+		require.NoError(t, cl.Get(context.Background(),
+			client.ObjectKey{Name: mergedName, Namespace: namespace}, got))
+		require.JSONEq(t, coverage, got.GetAnnotations()[syscallCoverageAnnotation])
+		require.Equal(t, "yes", got.GetAnnotations()["user.example.com/keep"])
+	})
+}

--- a/internal/pkg/manager/recordingmerger/recordingmerger.go
+++ b/internal/pkg/manager/recordingmerger/recordingmerger.go
@@ -165,6 +165,16 @@ func (r *PolicyMergeReconciler) mergeTypedProfiles(
 	for cntName, cntPartialProfiles := range partialProfiles {
 		r.log.Info("Merging profiles for container", "container", cntName)
 
+		// Informational only; empty for non-seccomp kinds.
+		coverageAnnotation, err := seccompCoverageAnnotation(cntPartialProfiles)
+		if err != nil {
+			// The current coverage schema contains only JSON-supported types, so
+			// this error is theoretical unless the schema changes.
+			r.log.Error(err, "Cannot compute syscall coverage", "container", cntName)
+
+			coverageAnnotation = ""
+		}
+
 		mergedProfile, err := mergeMergeableProfiles(cntPartialProfiles)
 		if err != nil {
 			return fmt.Errorf("cannot merge partial profiles: %w", err)
@@ -179,7 +189,10 @@ func (r *PolicyMergeReconciler) mergeTypedProfiles(
 
 		mergedRecordingName := mergedProfileName(profileRecording.Name, cntPartialProfiles[0])
 
-		res, err := createUpdateMergedProfile(ctx, r.client, profileRecording, mergedRecordingName, mergedProfile)
+		r.log.V(1).Info("Computed syscall coverage", "container", cntName, "coverage", coverageAnnotation)
+
+		res, err := createUpdateMergedProfile(
+			ctx, r.client, profileRecording, mergedRecordingName, mergedProfile, coverageAnnotation)
 		if err != nil {
 			r.record.Event(profileRecording, util.EventTypeWarning, reasonCannotCreateUpdate, err.Error())
 
@@ -198,6 +211,7 @@ type createUpdateFn func(
 	profileRecording *profilerecordingapi.ProfileRecording,
 	mergedRecordingName string,
 	mergedProfiles mergeableProfile,
+	coverageAnnotation string,
 ) (controllerutil.OperationResult, error)
 
 func (r *PolicyMergeReconciler) mergeSeccompProfiles(
@@ -243,6 +257,7 @@ func createUpdateSeccompProfile(
 	profileRecording *profilerecordingapi.ProfileRecording,
 	mergedRecordingName string,
 	mergedProfiles mergeableProfile,
+	coverageAnnotation string,
 ) (controllerutil.OperationResult, error) {
 	return createUpdateProfile(
 		ctx,
@@ -251,6 +266,7 @@ func createUpdateSeccompProfile(
 		mergedRecordingName,
 		mergedProfiles,
 		profilerecordingapi.ProfileRecordingKindSeccompProfile,
+		coverageAnnotation,
 	)
 }
 
@@ -260,6 +276,7 @@ func createUpdateSelinuxProfile(
 	profileRecording *profilerecordingapi.ProfileRecording,
 	mergedRecordingName string,
 	mergedProfiles mergeableProfile,
+	coverageAnnotation string,
 ) (controllerutil.OperationResult, error) {
 	return createUpdateProfile(
 		ctx,
@@ -268,6 +285,7 @@ func createUpdateSelinuxProfile(
 		mergedRecordingName,
 		mergedProfiles,
 		profilerecordingapi.ProfileRecordingKindSelinuxProfile,
+		coverageAnnotation,
 	)
 }
 
@@ -277,6 +295,7 @@ func createUpdateApparmorProfile(
 	profileRecording *profilerecordingapi.ProfileRecording,
 	mergedRecordingName string,
 	mergedProfiles mergeableProfile,
+	coverageAnnotation string,
 ) (controllerutil.OperationResult, error) {
 	return createUpdateProfile(
 		ctx,
@@ -285,6 +304,7 @@ func createUpdateApparmorProfile(
 		mergedRecordingName,
 		mergedProfiles,
 		profilerecordingapi.ProfileRecordingKindAppArmorProfile,
+		coverageAnnotation,
 	)
 }
 
@@ -295,6 +315,7 @@ func createUpdateProfile(
 	mergedRecordingName string,
 	mergedProfiles mergeableProfile,
 	kind profilerecordingapi.ProfileRecordingKind,
+	coverageAnnotation string,
 ) (controllerutil.OperationResult, error) {
 	switch kind {
 	case profilerecordingapi.ProfileRecordingKindSeccompProfile:
@@ -313,6 +334,8 @@ func createUpdateProfile(
 		return controllerutil.CreateOrUpdate(ctx, cl, mergedSp,
 			func() error {
 				mergedSp.Spec = *mergedSpec
+
+				setSyscallCoverageAnnotation(mergedSp, coverageAnnotation)
 
 				return nil
 			},


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

When partial `SeccompProfile` resources are merged from a `ProfileRecording`
using `mergeStrategy: Containers`, the resulting profile currently retains only
the final union of observed syscalls.

Consequently, the merge loses information about how many collected partial
profiles contained each syscall.

This PR preserves that information by adding the following informational
annotation to the merged `SeccompProfile`:

`spo.x-k8s.io/syscall-coverage`

For example:

```json
{
  "version": "v1",
  "total": 3,
  "syscalls": {
    "read": 3,
    "socket": 1,
    "write": 3
  }
}
```

In this representation:

- `total` is the number of collected partial profiles included in the merge;
- each syscall value is the number of those partial profiles containing that
  syscall;
- a syscall contributes at most once per partial profile, even if it appears
  multiple times or in multiple syscall rules.

The counts are computed in the existing recording-merger path before the
current syscall union discards the per-partial occurrence information.

The annotation is informational only. It does not modify:

- the merged syscall allowlist;
- the default seccomp action;
- profile architectures;
- enforcement behavior;
- the recording lifecycle.

The annotation describes observation coverage across collected partial
profiles. It does not represent syscall invocation frequency, probability,
statistical confidence, or independent executions.

The implementation is intentionally limited to merged `SeccompProfile`
resources. It does not modify API types, CRDs, the BPF recorder, the log
enricher, or the recording webhook.

#### Which issue(s) this PR fixes:

Fixes #3354

#### Does this PR have test?

Yes.

The following checks completed successfully:

- `go test ./internal/pkg/manager/recordingmerger/...`
- `go vet ./internal/pkg/manager/recordingmerger/...`
- related manager and `ProfileRecording` package tests
- `gofmt` verification

The tests cover:

- syscall counts across heterogeneous partial profiles;
- homogeneous partial profiles;
- a single partial profile;
- duplicate syscall names within one syscall rule;
- the same syscall appearing in multiple rules within one partial profile;
- deterministic JSON serialization;
- deterministic output when partial-profile ordering changes;
- source partial profiles remaining unmodified;
- unchanged syscall-union behavior;
- isolation between container merge groups;
- initialization of a nil annotations map;
- preservation of unrelated annotations;
- replacement of an existing controller-owned coverage annotation;
- exclusion of SELinux and AppArmor merge paths;
- integration through `createUpdateProfile` using the repository's fake-client
  pattern.

An end-to-end BPF recording test was also attempted.

The modified manager and SPOD images deployed successfully, the BPF recorder
was enabled, and the recording webhook annotated the test Pods. In the tested
environment, however, the recording pipeline did not produce partial
`SeccompProfile` resources. The recording-merger path therefore could not be
reached end to end.

This change consumes partial profiles already produced by the existing
recording pipeline and does not modify their collection or creation.

#### Special notes for your reviewer:

The JSON value is versioned so its format can be evolved explicitly if needed.

The annotation is deliberately described as observation coverage rather than
confidence. Recorded container instances may exercise different code paths and
are not necessarily statistically independent.

A low count must not be used automatically to remove a syscall from the merged
profile. A syscall observed in only one partial profile may still be required
by a valid but infrequently exercised code path.

The implementation remains additive and backward compatible:

- no API or CRD changes;
- no change to the generated seccomp specification;
- no changes to recorder or webhook components;
- no effect on SELinux or AppArmor profile merges.

#### Does this PR introduce a user-facing change?

```release-note
Merged SeccompProfiles generated from ProfileRecording using
mergeStrategy: Containers now include a spo.x-k8s.io/syscall-coverage
annotation containing per-syscall observation counts across the collected
partial profiles.
```
