### PR TITLE
feat: add support for custom selinux templates

### DIFF
--- a/api/spod/v1/spod_types.go
+++ b/api/spod/v1/spod_types.go
@@ -225,7 +225,8 @@ type SPODSelinuxConfig struct {
 	// files that replace the bundled selinuxd templates entirely. The ConfigMap
 	// must exist in the same namespace as the SPOD daemonset. Use this on
 	// distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-	// with the templates shipped with selinuxd.
+	// with the templates shipped with selinuxd. Note: changes to the ConfigMap
+	// contents require restarting the DaemonSet pods to take effect.
 	// +optional
 	// +kubebuilder:validation:MaxLength=253
 	CustomTemplatesConfigMap string `json:"customTemplatesConfigMap,omitempty"`

--- a/api/spod/v1/spod_types.go
+++ b/api/spod/v1/spod_types.go
@@ -229,6 +229,7 @@ type SPODSelinuxConfig struct {
 	// contents require restarting the DaemonSet pods to take effect.
 	// +optional
 	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 	CustomTemplatesConfigMap string `json:"customTemplatesConfigMap,omitempty"`
 }
 

--- a/api/spod/v1/spod_types.go
+++ b/api/spod/v1/spod_types.go
@@ -221,6 +221,14 @@ type SPODSelinuxConfig struct {
 	// +optional
 	// +default={}
 	Options SelinuxOptions `json:"options,omitzero,omitempty"`
+	// customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+	// files that replace the bundled selinuxd templates entirely. The ConfigMap
+	// must exist in the same namespace as the SPOD daemonset. Use this on
+	// distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+	// with the templates shipped with selinuxd.
+	// +optional
+	// +kubebuilder:validation:MaxLength=253
+	CustomTemplatesConfigMap string `json:"customTemplatesConfigMap,omitempty"`
 }
 
 // SPODEnricherConfig contains log enricher, JSON enricher, and BPF recorder configuration.

--- a/api/spod/v1alpha1/conversion.go
+++ b/api/spod/v1alpha1/conversion.go
@@ -76,6 +76,7 @@ func (src *SecurityProfilesOperatorDaemon) ConvertTo(dstRaw conversion.Hub) erro
 	dst.Spec.Selinux.EnableRawSelinuxProfiles = src.Spec.Selinux.EnableRawSelinuxProfiles
 	dst.Spec.Selinux.TypeTag = src.Spec.Selinux.TypeTag
 	dst.Spec.Selinux.Options.AllowedSystemProfiles = src.Spec.Selinux.Options.AllowedSystemProfiles
+	dst.Spec.Selinux.CustomTemplatesConfigMap = src.Spec.Selinux.CustomTemplatesConfigMap
 
 	// Enricher
 	dst.Spec.Enricher.EnableLogEnricher = src.Spec.Enricher.EnableLogEnricher
@@ -148,6 +149,7 @@ func (dst *SecurityProfilesOperatorDaemon) ConvertFrom(srcRaw conversion.Hub) er
 	dst.Spec.Selinux.EnableRawSelinuxProfiles = src.Spec.Selinux.EnableRawSelinuxProfiles
 	dst.Spec.Selinux.TypeTag = src.Spec.Selinux.TypeTag
 	dst.Spec.Selinux.Options.AllowedSystemProfiles = src.Spec.Selinux.Options.AllowedSystemProfiles
+	dst.Spec.Selinux.CustomTemplatesConfigMap = src.Spec.Selinux.CustomTemplatesConfigMap
 
 	// Enricher
 	dst.Spec.Enricher.EnableLogEnricher = src.Spec.Enricher.EnableLogEnricher

--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -177,7 +177,8 @@ type SPODSelinuxConfig struct {
 	// files that replace the bundled selinuxd templates entirely. The ConfigMap
 	// must exist in the same namespace as the SPOD daemonset. Use this on
 	// distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-	// with the templates shipped with selinuxd.
+	// with the templates shipped with selinuxd. Note: changes to the ConfigMap
+	// contents require restarting the DaemonSet pods to take effect.
 	// +optional
 	// +kubebuilder:validation:MaxLength=253
 	CustomTemplatesConfigMap string `json:"customTemplatesConfigMap,omitempty"`

--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -173,6 +173,14 @@ type SPODSelinuxConfig struct {
 	// +optional
 	// +default={}
 	Options SelinuxOptions `json:"options,omitzero,omitempty"`
+	// customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+	// files that replace the bundled selinuxd templates entirely. The ConfigMap
+	// must exist in the same namespace as the SPOD daemonset. Use this on
+	// distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+	// with the templates shipped with selinuxd.
+	// +optional
+	// +kubebuilder:validation:MaxLength=253
+	CustomTemplatesConfigMap string `json:"customTemplatesConfigMap,omitempty"`
 }
 
 // SPODEnricherConfig contains log enricher, JSON enricher, and BPF recorder configuration.

--- a/api/spod/v1alpha1/spod_types.go
+++ b/api/spod/v1alpha1/spod_types.go
@@ -181,6 +181,7 @@ type SPODSelinuxConfig struct {
 	// contents require restarting the DaemonSet pods to take effect.
 	// +optional
 	// +kubebuilder:validation:MaxLength=253
+	// +kubebuilder:validation:Pattern=`^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$`
 	CustomTemplatesConfigMap string `json:"customTemplatesConfigMap,omitempty"`
 }
 

--- a/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
@@ -1272,6 +1272,15 @@ spec:
               selinux:
                 description: selinux contains SELinux-specific configuration.
                 properties:
+                  customTemplatesConfigMap:
+                    description: |-
+                      customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+                      files that replace the bundled selinuxd templates entirely. The ConfigMap
+                      must exist in the same namespace as the SPOD daemonset. Use this on
+                      distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+                      with the templates shipped with selinuxd.
+                    maxLength: 253
+                    type: string
                   enable:
                     description: |-
                       enable tells the operator whether or not to enable SELinux support for
@@ -2813,6 +2822,15 @@ spec:
               selinux:
                 description: selinux contains SELinux-specific configuration.
                 properties:
+                  customTemplatesConfigMap:
+                    description: |-
+                      customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+                      files that replace the bundled selinuxd templates entirely. The ConfigMap
+                      must exist in the same namespace as the SPOD daemonset. Use this on
+                      distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+                      with the templates shipped with selinuxd.
+                    maxLength: 253
+                    type: string
                   enable:
                     description: |-
                       enable tells the operator whether or not to enable SELinux support for

--- a/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
@@ -1278,7 +1278,8 @@ spec:
                       files that replace the bundled selinuxd templates entirely. The ConfigMap
                       must exist in the same namespace as the SPOD daemonset. Use this on
                       distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-                      with the templates shipped with selinuxd.
+                      with the templates shipped with selinuxd. Note: changes to the ConfigMap
+                      contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
                     type: string
                   enable:
@@ -2828,7 +2829,8 @@ spec:
                       files that replace the bundled selinuxd templates entirely. The ConfigMap
                       must exist in the same namespace as the SPOD daemonset. Use this on
                       distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-                      with the templates shipped with selinuxd.
+                      with the templates shipped with selinuxd. Note: changes to the ConfigMap
+                      contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
                     type: string
                   enable:

--- a/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
@@ -1281,6 +1281,7 @@ spec:
                       with the templates shipped with selinuxd. Note: changes to the ConfigMap
                       contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   enable:
                     description: |-
@@ -2832,6 +2833,7 @@ spec:
                       with the templates shipped with selinuxd. Note: changes to the ConfigMap
                       contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   enable:
                     description: |-

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -2650,7 +2650,8 @@ spec:
                       files that replace the bundled selinuxd templates entirely. The ConfigMap
                       must exist in the same namespace as the SPOD daemonset. Use this on
                       distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-                      with the templates shipped with selinuxd.
+                      with the templates shipped with selinuxd. Note: changes to the ConfigMap
+                      contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
                     type: string
                   enable:
@@ -4200,7 +4201,8 @@ spec:
                       files that replace the bundled selinuxd templates entirely. The ConfigMap
                       must exist in the same namespace as the SPOD daemonset. Use this on
                       distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-                      with the templates shipped with selinuxd.
+                      with the templates shipped with selinuxd. Note: changes to the ConfigMap
+                      contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
                     type: string
                   enable:

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -2653,6 +2653,7 @@ spec:
                       with the templates shipped with selinuxd. Note: changes to the ConfigMap
                       contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   enable:
                     description: |-
@@ -4204,6 +4205,7 @@ spec:
                       with the templates shipped with selinuxd. Note: changes to the ConfigMap
                       contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   enable:
                     description: |-

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -2644,6 +2644,15 @@ spec:
               selinux:
                 description: selinux contains SELinux-specific configuration.
                 properties:
+                  customTemplatesConfigMap:
+                    description: |-
+                      customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+                      files that replace the bundled selinuxd templates entirely. The ConfigMap
+                      must exist in the same namespace as the SPOD daemonset. Use this on
+                      distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+                      with the templates shipped with selinuxd.
+                    maxLength: 253
+                    type: string
                   enable:
                     description: |-
                       enable tells the operator whether or not to enable SELinux support for
@@ -4185,6 +4194,15 @@ spec:
               selinux:
                 description: selinux contains SELinux-specific configuration.
                 properties:
+                  customTemplatesConfigMap:
+                    description: |-
+                      customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+                      files that replace the bundled selinuxd templates entirely. The ConfigMap
+                      must exist in the same namespace as the SPOD daemonset. Use this on
+                      distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+                      with the templates shipped with selinuxd.
+                    maxLength: 253
+                    type: string
                   enable:
                     description: |-
                       enable tells the operator whether or not to enable SELinux support for

--- a/deploy/helm/templates/config.yaml
+++ b/deploy/helm/templates/config.yaml
@@ -25,6 +25,9 @@ spec:
     options:
       {{- toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.selinux.customTemplatesConfigMap }}
+    customTemplatesConfigMap: {{ . | quote }}
+    {{- end }}
   enricher:
     enableLogEnricher: {{ .Values.enableLogEnricher }}
     enableJsonEnricher: {{ .Values.enableJsonEnricher }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -30,6 +30,7 @@ selinux:
   # enable: false # Overrides deprecated enableSelinux flag
   enableRawSelinuxProfiles: true
   typeTag: spc_t
+  customTemplatesConfigMap: ""
   options: {}
     # allowedSystemProfiles:
     #   - container
@@ -45,7 +46,6 @@ enableAppArmor: false
 enableBpfRecorder: false
 enableProfiling: false
 verbosity: 0
-
 
 nameOverride: ""
 fullnameOverride: ""

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2650,7 +2650,8 @@ spec:
                       files that replace the bundled selinuxd templates entirely. The ConfigMap
                       must exist in the same namespace as the SPOD daemonset. Use this on
                       distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-                      with the templates shipped with selinuxd.
+                      with the templates shipped with selinuxd. Note: changes to the ConfigMap
+                      contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
                     type: string
                   enable:
@@ -4200,7 +4201,8 @@ spec:
                       files that replace the bundled selinuxd templates entirely. The ConfigMap
                       must exist in the same namespace as the SPOD daemonset. Use this on
                       distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-                      with the templates shipped with selinuxd.
+                      with the templates shipped with selinuxd. Note: changes to the ConfigMap
+                      contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
                     type: string
                   enable:

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2653,6 +2653,7 @@ spec:
                       with the templates shipped with selinuxd. Note: changes to the ConfigMap
                       contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   enable:
                     description: |-
@@ -4204,6 +4205,7 @@ spec:
                       with the templates shipped with selinuxd. Note: changes to the ConfigMap
                       contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   enable:
                     description: |-

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -2644,6 +2644,15 @@ spec:
               selinux:
                 description: selinux contains SELinux-specific configuration.
                 properties:
+                  customTemplatesConfigMap:
+                    description: |-
+                      customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+                      files that replace the bundled selinuxd templates entirely. The ConfigMap
+                      must exist in the same namespace as the SPOD daemonset. Use this on
+                      distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+                      with the templates shipped with selinuxd.
+                    maxLength: 253
+                    type: string
                   enable:
                     description: |-
                       enable tells the operator whether or not to enable SELinux support for
@@ -4185,6 +4194,15 @@ spec:
               selinux:
                 description: selinux contains SELinux-specific configuration.
                 properties:
+                  customTemplatesConfigMap:
+                    description: |-
+                      customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+                      files that replace the bundled selinuxd templates entirely. The ConfigMap
+                      must exist in the same namespace as the SPOD daemonset. Use this on
+                      distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+                      with the templates shipped with selinuxd.
+                    maxLength: 253
+                    type: string
                   enable:
                     description: |-
                       enable tells the operator whether or not to enable SELinux support for

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3401,6 +3401,15 @@ spec:
               selinux:
                 description: selinux contains SELinux-specific configuration.
                 properties:
+                  customTemplatesConfigMap:
+                    description: |-
+                      customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+                      files that replace the bundled selinuxd templates entirely. The ConfigMap
+                      must exist in the same namespace as the SPOD daemonset. Use this on
+                      distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+                      with the templates shipped with selinuxd.
+                    maxLength: 253
+                    type: string
                   enable:
                     description: |-
                       enable tells the operator whether or not to enable SELinux support for
@@ -4947,6 +4956,15 @@ spec:
               selinux:
                 description: selinux contains SELinux-specific configuration.
                 properties:
+                  customTemplatesConfigMap:
+                    description: |-
+                      customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+                      files that replace the bundled selinuxd templates entirely. The ConfigMap
+                      must exist in the same namespace as the SPOD daemonset. Use this on
+                      distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+                      with the templates shipped with selinuxd.
+                    maxLength: 253
+                    type: string
                   enable:
                     description: |-
                       enable tells the operator whether or not to enable SELinux support for

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3410,6 +3410,7 @@ spec:
                       with the templates shipped with selinuxd. Note: changes to the ConfigMap
                       contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   enable:
                     description: |-
@@ -4966,6 +4967,7 @@ spec:
                       with the templates shipped with selinuxd. Note: changes to the ConfigMap
                       contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   enable:
                     description: |-

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3407,7 +3407,8 @@ spec:
                       files that replace the bundled selinuxd templates entirely. The ConfigMap
                       must exist in the same namespace as the SPOD daemonset. Use this on
                       distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-                      with the templates shipped with selinuxd.
+                      with the templates shipped with selinuxd. Note: changes to the ConfigMap
+                      contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
                     type: string
                   enable:
@@ -4962,7 +4963,8 @@ spec:
                       files that replace the bundled selinuxd templates entirely. The ConfigMap
                       must exist in the same namespace as the SPOD daemonset. Use this on
                       distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-                      with the templates shipped with selinuxd.
+                      with the templates shipped with selinuxd. Note: changes to the ConfigMap
+                      contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
                     type: string
                   enable:

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -2644,6 +2644,15 @@ spec:
               selinux:
                 description: selinux contains SELinux-specific configuration.
                 properties:
+                  customTemplatesConfigMap:
+                    description: |-
+                      customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+                      files that replace the bundled selinuxd templates entirely. The ConfigMap
+                      must exist in the same namespace as the SPOD daemonset. Use this on
+                      distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+                      with the templates shipped with selinuxd.
+                    maxLength: 253
+                    type: string
                   enable:
                     description: |-
                       enable tells the operator whether or not to enable SELinux support for
@@ -4190,6 +4199,15 @@ spec:
               selinux:
                 description: selinux contains SELinux-specific configuration.
                 properties:
+                  customTemplatesConfigMap:
+                    description: |-
+                      customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+                      files that replace the bundled selinuxd templates entirely. The ConfigMap
+                      must exist in the same namespace as the SPOD daemonset. Use this on
+                      distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+                      with the templates shipped with selinuxd.
+                    maxLength: 253
+                    type: string
                   enable:
                     description: |-
                       enable tells the operator whether or not to enable SELinux support for

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -2653,6 +2653,7 @@ spec:
                       with the templates shipped with selinuxd. Note: changes to the ConfigMap
                       contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   enable:
                     description: |-
@@ -4209,6 +4210,7 @@ spec:
                       with the templates shipped with selinuxd. Note: changes to the ConfigMap
                       contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   enable:
                     description: |-

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -2650,7 +2650,8 @@ spec:
                       files that replace the bundled selinuxd templates entirely. The ConfigMap
                       must exist in the same namespace as the SPOD daemonset. Use this on
                       distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-                      with the templates shipped with selinuxd.
+                      with the templates shipped with selinuxd. Note: changes to the ConfigMap
+                      contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
                     type: string
                   enable:
@@ -4205,7 +4206,8 @@ spec:
                       files that replace the bundled selinuxd templates entirely. The ConfigMap
                       must exist in the same namespace as the SPOD daemonset. Use this on
                       distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-                      with the templates shipped with selinuxd.
+                      with the templates shipped with selinuxd. Note: changes to the ConfigMap
+                      contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
                     type: string
                   enable:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2650,7 +2650,8 @@ spec:
                       files that replace the bundled selinuxd templates entirely. The ConfigMap
                       must exist in the same namespace as the SPOD daemonset. Use this on
                       distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-                      with the templates shipped with selinuxd.
+                      with the templates shipped with selinuxd. Note: changes to the ConfigMap
+                      contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
                     type: string
                   enable:
@@ -4200,7 +4201,8 @@ spec:
                       files that replace the bundled selinuxd templates entirely. The ConfigMap
                       must exist in the same namespace as the SPOD daemonset. Use this on
                       distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-                      with the templates shipped with selinuxd.
+                      with the templates shipped with selinuxd. Note: changes to the ConfigMap
+                      contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
                     type: string
                   enable:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2653,6 +2653,7 @@ spec:
                       with the templates shipped with selinuxd. Note: changes to the ConfigMap
                       contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   enable:
                     description: |-
@@ -4204,6 +4205,7 @@ spec:
                       with the templates shipped with selinuxd. Note: changes to the ConfigMap
                       contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   enable:
                     description: |-

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -2644,6 +2644,15 @@ spec:
               selinux:
                 description: selinux contains SELinux-specific configuration.
                 properties:
+                  customTemplatesConfigMap:
+                    description: |-
+                      customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+                      files that replace the bundled selinuxd templates entirely. The ConfigMap
+                      must exist in the same namespace as the SPOD daemonset. Use this on
+                      distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+                      with the templates shipped with selinuxd.
+                    maxLength: 253
+                    type: string
                   enable:
                     description: |-
                       enable tells the operator whether or not to enable SELinux support for
@@ -4185,6 +4194,15 @@ spec:
               selinux:
                 description: selinux contains SELinux-specific configuration.
                 properties:
+                  customTemplatesConfigMap:
+                    description: |-
+                      customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+                      files that replace the bundled selinuxd templates entirely. The ConfigMap
+                      must exist in the same namespace as the SPOD daemonset. Use this on
+                      distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+                      with the templates shipped with selinuxd.
+                    maxLength: 253
+                    type: string
                   enable:
                     description: |-
                       enable tells the operator whether or not to enable SELinux support for

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3407,7 +3407,8 @@ spec:
                       files that replace the bundled selinuxd templates entirely. The ConfigMap
                       must exist in the same namespace as the SPOD daemonset. Use this on
                       distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-                      with the templates shipped with selinuxd.
+                      with the templates shipped with selinuxd. Note: changes to the ConfigMap
+                      contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
                     type: string
                   enable:
@@ -4957,7 +4958,8 @@ spec:
                       files that replace the bundled selinuxd templates entirely. The ConfigMap
                       must exist in the same namespace as the SPOD daemonset. Use this on
                       distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
-                      with the templates shipped with selinuxd.
+                      with the templates shipped with selinuxd. Note: changes to the ConfigMap
+                      contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
                     type: string
                   enable:

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3410,6 +3410,7 @@ spec:
                       with the templates shipped with selinuxd. Note: changes to the ConfigMap
                       contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   enable:
                     description: |-
@@ -4961,6 +4962,7 @@ spec:
                       with the templates shipped with selinuxd. Note: changes to the ConfigMap
                       contents require restarting the DaemonSet pods to take effect.
                     maxLength: 253
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   enable:
                     description: |-

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3401,6 +3401,15 @@ spec:
               selinux:
                 description: selinux contains SELinux-specific configuration.
                 properties:
+                  customTemplatesConfigMap:
+                    description: |-
+                      customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+                      files that replace the bundled selinuxd templates entirely. The ConfigMap
+                      must exist in the same namespace as the SPOD daemonset. Use this on
+                      distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+                      with the templates shipped with selinuxd.
+                    maxLength: 253
+                    type: string
                   enable:
                     description: |-
                       enable tells the operator whether or not to enable SELinux support for
@@ -4942,6 +4951,15 @@ spec:
               selinux:
                 description: selinux contains SELinux-specific configuration.
                 properties:
+                  customTemplatesConfigMap:
+                    description: |-
+                      customTemplatesConfigMap if defined, names a ConfigMap containing .cil
+                      files that replace the bundled selinuxd templates entirely. The ConfigMap
+                      must exist in the same namespace as the SPOD daemonset. Use this on
+                      distributions (e.g. Flatcar Linux) whose SELinux policy base is incompatible
+                      with the templates shipped with selinuxd.
+                    maxLength: 253
+                    type: string
                   enable:
                     description: |-
                       enable tells the operator whether or not to enable SELinux support for

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -76,6 +76,7 @@ const (
 	ContainerPort                              int32 = 9443
 	metricsServerCert                                = "metrics-server-cert"
 	MetricsCertPath                                  = "/var/run/secrets/metrics"
+	SelinuxCustomTemplatesVolumeName                 = "selinux-custom-templates"
 )
 
 var DefaultSPOD = &spodapi.SecurityProfilesOperatorDaemon{
@@ -1013,5 +1014,20 @@ func CustomConfigMap(mountPath string, configVolSource *corev1.VolumeSource) (co
 			Name:      volumeName,
 			MountPath: mountPath,
 			ReadOnly:  false,
+		}
+}
+
+func CustomTemplatesVolume(configMapName string) (corev1.Volume, corev1.VolumeMount) {
+	return corev1.Volume{
+			Name: SelinuxCustomTemplatesVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				ConfigMap: &corev1.ConfigMapVolumeSource{
+					LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
+				},
+			},
+		}, corev1.VolumeMount{
+			Name:      SelinuxCustomTemplatesVolumeName,
+			MountPath: "/usr/share/selinuxd/templates",
+			ReadOnly:  true,
 		}
 }

--- a/internal/pkg/manager/spod/bindata/spod_test.go
+++ b/internal/pkg/manager/spod/bindata/spod_test.go
@@ -23,6 +23,18 @@ import (
 	corev1 "k8s.io/api/core/v1"
 )
 
+func Test_CustomTemplatesVolume(t *testing.T) {
+	t.Parallel()
+
+	vol, mount := CustomTemplatesVolume("test-templates")
+
+	require.Equal(t, SelinuxCustomTemplatesVolumeName, vol.Name)
+	require.Equal(t, "test-templates", vol.ConfigMap.Name)
+	require.Equal(t, SelinuxCustomTemplatesVolumeName, mount.Name)
+	require.Equal(t, "/usr/share/selinuxd/templates", mount.MountPath)
+	require.True(t, mount.ReadOnly)
+}
+
 func Test_CustomLogVolume(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -591,6 +591,8 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 
 			return nil, fmt.Errorf("unable to mount custom SELinux templates: %w", err)
 		}
+	} else if cfg.Spec.Selinux.CustomTemplatesConfigMap != "" {
+		r.log.Info("customTemplatesConfigMap is set but SELinux is disabled, the field will be ignored")
 	}
 
 	// Custom host proc volume

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -185,7 +185,11 @@ func (r *ReconcileSPOd) Reconcile(ctx context.Context, req reconcile.Request) (r
 		return reconcile.Result{}, fmt.Errorf("get ca inject type: %w", err)
 	}
 
-	configuredSPOd := r.getConfiguredSPOd(ctx, spod, image, pullPolicy, caInjectType)
+	configuredSPOd, err := r.getConfiguredSPOd(ctx, spod, image, pullPolicy, caInjectType)
+	if err != nil {
+		return reconcile.Result{}, fmt.Errorf("get configured SPOD: %w", err)
+	}
+
 	webhook := r.getConfiguredWebook(spod, image, pullPolicy, caInjectType)
 	metricsService := bindata.GetMetricsService(r.namespace, caInjectType)
 	serviceMonitor := bindata.ServiceMonitor(caInjectType,
@@ -525,7 +529,7 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 	image string,
 	pullPolicy corev1.PullPolicy,
 	caInjectType bindata.CAInjectType,
-) *appsv1.DaemonSet {
+) (*appsv1.DaemonSet, error) {
 	newSPOd := r.baseSPOd.DeepCopy()
 
 	newSPOd.SetName(cfg.GetName())
@@ -583,8 +587,9 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 			fmt.Sprintf("--with-raw-selinux=%t", enableRawSelinux))
 
 		if err := addSelinuxCustomTemplatesVolume(cfg, templateSpec); err != nil {
-			r.log.Info("Unable to mount custom SELinux templates", "error", err)
 			r.record.Event(cfg, util.EventTypeWarning, reasonCannotMountCustomTemplates, err.Error())
+
+			return nil, fmt.Errorf("unable to mount custom SELinux templates: %w", err)
 		}
 	}
 
@@ -809,7 +814,7 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 	templateSpec.ImagePullSecrets = cfg.Spec.ImagePullSecrets
 	templateSpec.PriorityClassName = cfg.Spec.Scheduling.PriorityClassName
 
-	return newSPOd
+	return newSPOd, nil
 }
 
 func (r *ReconcileSPOd) getConfiguredLogEnricher(cfg *spodapi.SecurityProfilesOperatorDaemon) {

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -581,13 +581,7 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 			templateSpec.Containers[bindata.ContainerIDDaemon].Args,
 			fmt.Sprintf("--with-raw-selinux=%t", enableRawSelinux))
 
-		if cfg.Spec.Selinux.CustomTemplatesConfigMap != "" {
-			vol, mount := bindata.CustomTemplatesVolume(cfg.Spec.Selinux.CustomTemplatesConfigMap)
-			templateSpec.Volumes = append(templateSpec.Volumes, vol)
-			idx := bindata.InitContainerIDSelinuxSharedPoliciesCopier
-			templateSpec.InitContainers[idx].VolumeMounts = append(
-				templateSpec.InitContainers[idx].VolumeMounts, mount)
-		}
+		addSelinuxCustomTemplatesVolume(cfg, templateSpec)
 	}
 
 	// Custom host proc volume
@@ -905,6 +899,26 @@ func (r *ReconcileSPOd) getConfiguredWebook(cfg *spodapi.SecurityProfilesOperato
 		pullPolicy, caInjectType, cfg.Spec.Scheduling.Tolerations, cfg.Spec.ImagePullSecrets, isJsonEnricherEnabled(cfg))
 
 	return webhook
+}
+
+func addSelinuxCustomTemplatesVolume(
+	cfg *spodapi.SecurityProfilesOperatorDaemon,
+	templateSpec *corev1.PodSpec,
+) {
+	if cfg.Spec.Selinux.CustomTemplatesConfigMap == "" {
+		return
+	}
+
+	idx := slices.IndexFunc(templateSpec.InitContainers, func(c corev1.Container) bool {
+		return c.Name == bindata.SelinuxPoliciesCopierContainerName
+	})
+	if idx == -1 {
+		return
+	}
+
+	vol, mount := bindata.CustomTemplatesVolume(cfg.Spec.Selinux.CustomTemplatesConfigMap)
+	templateSpec.Volumes = append(templateSpec.Volumes, vol)
+	templateSpec.InitContainers[idx].VolumeMounts = append(templateSpec.InitContainers[idx].VolumeMounts, mount)
 }
 
 func isLogEnricherEnabled(cfg *spodapi.SecurityProfilesOperatorDaemon) bool {

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -54,8 +54,9 @@ const (
 	// default reconcile timeout.
 	reconcileTimeout = 1 * time.Minute
 
-	reasonCannotCreateSPOD string = "CannotCreateSPOD"
-	reasonCannotUpdateSPOD string = "CannotUpdateSPOD"
+	reasonCannotCreateSPOD           string = "CannotCreateSPOD"
+	reasonCannotUpdateSPOD           string = "CannotUpdateSPOD"
+	reasonCannotMountCustomTemplates string = "CannotMountCustomTemplates"
 
 	appArmorAnnotation = "container.seccomp.security.alpha.kubernetes.io/security-profiles-operator"
 )
@@ -581,7 +582,10 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 			templateSpec.Containers[bindata.ContainerIDDaemon].Args,
 			fmt.Sprintf("--with-raw-selinux=%t", enableRawSelinux))
 
-		addSelinuxCustomTemplatesVolume(cfg, templateSpec)
+		if err := addSelinuxCustomTemplatesVolume(cfg, templateSpec); err != nil {
+			r.log.Info("Unable to mount custom SELinux templates", "error", err)
+			r.record.Event(cfg, util.EventTypeWarning, reasonCannotMountCustomTemplates, err.Error())
+		}
 	}
 
 	// Custom host proc volume
@@ -904,21 +908,26 @@ func (r *ReconcileSPOd) getConfiguredWebook(cfg *spodapi.SecurityProfilesOperato
 func addSelinuxCustomTemplatesVolume(
 	cfg *spodapi.SecurityProfilesOperatorDaemon,
 	templateSpec *corev1.PodSpec,
-) {
+) error {
 	if cfg.Spec.Selinux.CustomTemplatesConfigMap == "" {
-		return
+		return nil
 	}
 
 	idx := slices.IndexFunc(templateSpec.InitContainers, func(c corev1.Container) bool {
 		return c.Name == bindata.SelinuxPoliciesCopierContainerName
 	})
 	if idx == -1 {
-		return
+		return fmt.Errorf(
+			"customTemplatesConfigMap is set but %s init container was not found",
+			bindata.SelinuxPoliciesCopierContainerName,
+		)
 	}
 
 	vol, mount := bindata.CustomTemplatesVolume(cfg.Spec.Selinux.CustomTemplatesConfigMap)
 	templateSpec.Volumes = append(templateSpec.Volumes, vol)
 	templateSpec.InitContainers[idx].VolumeMounts = append(templateSpec.InitContainers[idx].VolumeMounts, mount)
+
+	return nil
 }
 
 func isLogEnricherEnabled(cfg *spodapi.SecurityProfilesOperatorDaemon) bool {

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -580,6 +580,14 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 		templateSpec.Containers[bindata.ContainerIDDaemon].Args = append(
 			templateSpec.Containers[bindata.ContainerIDDaemon].Args,
 			fmt.Sprintf("--with-raw-selinux=%t", enableRawSelinux))
+
+		if cfg.Spec.Selinux.CustomTemplatesConfigMap != "" {
+			vol, mount := bindata.CustomTemplatesVolume(cfg.Spec.Selinux.CustomTemplatesConfigMap)
+			templateSpec.Volumes = append(templateSpec.Volumes, vol)
+			idx := bindata.InitContainerIDSelinuxSharedPoliciesCopier
+			templateSpec.InitContainers[idx].VolumeMounts = append(
+				templateSpec.InitContainers[idx].VolumeMounts, mount)
+		}
 	}
 
 	// Custom host proc volume

--- a/internal/pkg/manager/spod/spod_controller_test.go
+++ b/internal/pkg/manager/spod/spod_controller_test.go
@@ -25,6 +25,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	spodapi "sigs.k8s.io/security-profiles-operator/api/spod/v1"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/manager/spod/bindata"
 )
 
 func Test_addAuditLogConfig(t *testing.T) {
@@ -141,6 +142,76 @@ func Test_getConfiguredJsonEnricherNilInterval(t *testing.T) {
 
 	require.True(t, containsString(r.baseSPOd.Spec.Template.Spec.Containers[4].Args,
 		"--audit-log-maxsize=10"))
+}
+
+func Test_addSelinuxCustomTemplatesVolumeEmpty(t *testing.T) {
+	t.Parallel()
+
+	cfg := &spodapi.SecurityProfilesOperatorDaemon{
+		Spec: spodapi.SPODSpec{
+			Selinux: spodapi.SPODSelinuxConfig{
+				CustomTemplatesConfigMap: "",
+			},
+		},
+	}
+
+	templateSpec := &v1.PodSpec{
+		InitContainers: []v1.Container{{Name: bindata.SelinuxPoliciesCopierContainerName}},
+	}
+
+	addSelinuxCustomTemplatesVolume(cfg, templateSpec)
+
+	require.Empty(t, templateSpec.Volumes)
+	require.Empty(t, templateSpec.InitContainers[0].VolumeMounts)
+}
+
+func Test_addSelinuxCustomTemplatesNoInitContainer(t *testing.T) {
+	t.Parallel()
+
+	cfg := &spodapi.SecurityProfilesOperatorDaemon{
+		Spec: spodapi.SPODSpec{
+			Selinux: spodapi.SPODSelinuxConfig{
+				CustomTemplatesConfigMap: "test-templates",
+			},
+		},
+	}
+
+	templateSpec := &v1.PodSpec{
+		InitContainers: []v1.Container{{Name: "some-other-container"}},
+	}
+
+	addSelinuxCustomTemplatesVolume(cfg, templateSpec)
+
+	require.Empty(t, templateSpec.Volumes)
+	require.Empty(t, templateSpec.InitContainers[0].VolumeMounts)
+}
+
+func Test_addSelinuxCustomTemplatesVolume(t *testing.T) {
+	t.Parallel()
+
+	cfg := &spodapi.SecurityProfilesOperatorDaemon{
+		Spec: spodapi.SPODSpec{
+			Selinux: spodapi.SPODSelinuxConfig{
+				CustomTemplatesConfigMap: "test-templates",
+			},
+		},
+	}
+
+	templateSpec := &v1.PodSpec{
+		InitContainers: []v1.Container{
+			{Name: "some-other-container"},
+			{Name: bindata.SelinuxPoliciesCopierContainerName},
+		},
+	}
+
+	addSelinuxCustomTemplatesVolume(cfg, templateSpec)
+
+	require.Len(t, templateSpec.Volumes, 1)
+	require.Equal(t, "test-templates", templateSpec.Volumes[0].ConfigMap.Name)
+	require.Empty(t, templateSpec.InitContainers[0].VolumeMounts)
+	require.Len(t, templateSpec.InitContainers[1].VolumeMounts, 1)
+	require.Equal(t, templateSpec.Volumes[0].Name, templateSpec.InitContainers[1].VolumeMounts[0].Name)
+	require.Equal(t, "/usr/share/selinuxd/templates", templateSpec.InitContainers[1].VolumeMounts[0].MountPath)
 }
 
 func containsString(slice []string, element string) bool {

--- a/internal/pkg/manager/spod/spod_controller_test.go
+++ b/internal/pkg/manager/spod/spod_controller_test.go
@@ -159,8 +159,9 @@ func Test_addSelinuxCustomTemplatesVolumeEmpty(t *testing.T) {
 		InitContainers: []v1.Container{{Name: bindata.SelinuxPoliciesCopierContainerName}},
 	}
 
-	addSelinuxCustomTemplatesVolume(cfg, templateSpec)
+	err := addSelinuxCustomTemplatesVolume(cfg, templateSpec)
 
+	require.NoError(t, err)
 	require.Empty(t, templateSpec.Volumes)
 	require.Empty(t, templateSpec.InitContainers[0].VolumeMounts)
 }
@@ -180,8 +181,9 @@ func Test_addSelinuxCustomTemplatesNoInitContainer(t *testing.T) {
 		InitContainers: []v1.Container{{Name: "some-other-container"}},
 	}
 
-	addSelinuxCustomTemplatesVolume(cfg, templateSpec)
+	err := addSelinuxCustomTemplatesVolume(cfg, templateSpec)
 
+	require.Error(t, err)
 	require.Empty(t, templateSpec.Volumes)
 	require.Empty(t, templateSpec.InitContainers[0].VolumeMounts)
 }
@@ -204,8 +206,9 @@ func Test_addSelinuxCustomTemplatesVolume(t *testing.T) {
 		},
 	}
 
-	addSelinuxCustomTemplatesVolume(cfg, templateSpec)
+	err := addSelinuxCustomTemplatesVolume(cfg, templateSpec)
 
+	require.NoError(t, err)
 	require.Len(t, templateSpec.Volumes, 1)
 	require.Equal(t, "test-templates", templateSpec.Volumes[0].ConfigMap.Name)
 	require.Empty(t, templateSpec.InitContainers[0].VolumeMounts)


### PR DESCRIPTION
#### What type of PR is this?

/kind feature
/kind api-change

#### What this PR does / why we need it:

Adds a `customTemplatesConfigMap` field to the `SPODSelinuxConfig` API that allows users to supply a ConfigMap containing `.cil` files which replace the bundled selinuxd templates directory entirely. This is required to make SPO functional on distributions such as Flatcar Linux, whose SELinux policy base (refpolicy) is incompatible with the templates shipped with selinuxd.

When `customTemplatesConfigMap` is set, the referenced ConfigMap is mounted over `/usr/share/selinuxd/templates/` in the `selinux-shared-policies-copier` init container.

#### Which issue(s) this PR fixes:

Fixes #3356

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

N/A

#### Does this PR introduce a user-facing change?

```release-note
Added `selinux.customTemplatesConfigMap` field to the SPOD API and Helm chart, allowing users to replace the bundled selinuxd CIL templates with a custom ConfigMap. This enables SPO to run on distributions whose SELinux policy base is incompatible with the shipped templates, such as Flatcar Linux.
```