### PR TITLE
fix(apparmor): allow metrics socket access in bpfrecorder profile

### DIFF
--- a/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
+++ b/bundle/manifests/security-profiles-operator-profile_v1_configmap.yaml
@@ -151,6 +151,7 @@ data:
           readWritePaths:
           - "ptrace (read),\n# ugly template injection hack"
           - /var/run/grpc/bpf-recorder.sock
+          - /var/run/grpc/metrics.sock
         network:
           allowedProtocols:
             allowTcp: true

--- a/deploy/base/profiles/bpfrecorder-apparmor.yaml
+++ b/deploy/base/profiles/bpfrecorder-apparmor.yaml
@@ -33,6 +33,7 @@ spec:
       readWritePaths:
       - "ptrace (read),\n# ugly template injection hack"
       - /var/run/grpc/bpf-recorder.sock
+      - /var/run/grpc/metrics.sock
     network:
       allowedProtocols:
         allowTcp: true

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -851,6 +851,7 @@ data:
           readWritePaths:
           - "ptrace (read),\n# ugly template injection hack"
           - /var/run/grpc/bpf-recorder.sock
+          - /var/run/grpc/metrics.sock
         network:
           allowedProtocols:
             allowTcp: true

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -6364,6 +6364,7 @@ data:
           readWritePaths:
           - "ptrace (read),\n# ugly template injection hack"
           - /var/run/grpc/bpf-recorder.sock
+          - /var/run/grpc/metrics.sock
         network:
           allowedProtocols:
             allowTcp: true

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -6351,6 +6351,7 @@ data:
           readWritePaths:
           - "ptrace (read),\n# ugly template injection hack"
           - /var/run/grpc/bpf-recorder.sock
+          - /var/run/grpc/metrics.sock
         network:
           allowedProtocols:
             allowTcp: true

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -6382,6 +6382,7 @@ data:
           readWritePaths:
           - "ptrace (read),\n# ugly template injection hack"
           - /var/run/grpc/bpf-recorder.sock
+          - /var/run/grpc/metrics.sock
         network:
           allowedProtocols:
             allowTcp: true

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -6364,6 +6364,7 @@ data:
           readWritePaths:
           - "ptrace (read),\n# ugly template injection hack"
           - /var/run/grpc/bpf-recorder.sock
+          - /var/run/grpc/metrics.sock
         network:
           allowedProtocols:
             allowTcp: true

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -6335,6 +6335,7 @@ data:
           readWritePaths:
           - "ptrace (read),\n# ugly template injection hack"
           - /var/run/grpc/bpf-recorder.sock
+          - /var/run/grpc/metrics.sock
         network:
           allowedProtocols:
             allowTcp: true


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The BPF recorder connects to the metrics GRPC server at `/var/run/grpc/metrics.sock` on startup (`bpfrecorder.go:connectMetrics()`), but the `bpfrecorder-apparmor` profile did not include this path in its `readWritePaths`. On systems with AppArmor enabled, this caused the `bpf-recorder` container to enter `CrashLoopBackOff` with:
```
rpc error: code = Unavailable desc = connection error: desc = "transport: Error while dialing: dial unix /var/run/grpc/metrics.sock: connect: permission denied"
```
This adds `/var/run/grpc/metrics.sock` to the bpfrecorder AppArmor profile's `readWritePaths`, matching how `spo-apparmor` already permits this socket.

#### Which issue(s) this PR fixes:

Fixes #3362

#### Does this PR have test?

N/A - AppArmor profile change only, verified by inspecting the denied AppArmor audit log from the issue report against the profile definition.

#### Special notes for your reviewer:

The `spo-apparmor` profile (used by the main daemon container) already includes `/var/run/grpc/metrics.sock` in its `readWritePaths`. The `bpfrecorder-apparmor` profile was simply missing it.

#### Does this PR introduce a user-facing change?

```release-note
Fixed BPF recorder CrashLoopBackOff on AppArmor-enabled systems by adding the metrics socket path to the bpfrecorder AppArmor profile.
```