### PR TITLE
Include profile kind in node status naming and validate SELinux profile names

### DIFF
--- a/internal/pkg/daemon/common/reconciler.go
+++ b/internal/pkg/daemon/common/reconciler.go
@@ -129,7 +129,7 @@ func EnsureNodeStatus(
 	}
 
 	if !exists {
-		if err := nsc.Create(ctx); err != nil {
+		if _, err := nsc.Create(ctx); err != nil {
 			return false, reconcile.Result{}, fmt.Errorf("cannot ensure node status: %w", err)
 		}
 

--- a/internal/pkg/daemon/common/reconciler_test.go
+++ b/internal/pkg/daemon/common/reconciler_test.go
@@ -259,6 +259,7 @@ func TestEnsureNodeStatus(t *testing.T) {
 				MockGet:                     util.NewMockGetFn(nil),
 				MockCreate:                  util.NewMockCreateFn(nil),
 				MockUpdate:                  util.NewMockUpdateFn(nil),
+				MockDelete:                  util.NewMockDeleteFn(nil),
 				MockSubResourceWriterUpdate: util.NewMockSubResourceWriterUpdateFn(nil),
 				MockScheme:                  util.NewMockSchemeFn(testScheme()),
 			},

--- a/internal/pkg/daemon/selinuxprofile/common_controller.go
+++ b/internal/pkg/daemon/selinuxprofile/common_controller.go
@@ -27,6 +27,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"time"
 
@@ -74,6 +75,7 @@ const (
 	reasonCannotContactSelinuxd    string = "CannotContactSelinuxd"
 	reasonCannotRemovePolicy       string = "CannotRemoveSelinuxPolicy"
 	reasonCannotInstallPolicy      string = "CannotSaveSelinuxPolicy"
+	reasonSystemModuleConflict     string = "SystemModuleConflict"
 	reasonCannotWritePolicyFile    string = "CannotWritePolicyFile"
 	reasonCannotGetPolicyStatus    string = "CannotGetPolicyStatus"
 	reasonCannotUpdatePolicyStatus string = "CannotUpdatePolicyStatus"
@@ -196,13 +198,18 @@ func (r *ReconcileSelinux) Reconcile(ctx context.Context, request reconcile.Requ
 			return reconcile.Result{}, fmt.Errorf("checking if node status exists: %w", existErr)
 		}
 
+		firstInstall := false
+
 		if !exists {
-			if err := nodeStatus.Create(ctx); err != nil {
-				return reconcile.Result{}, fmt.Errorf("cannot ensure node status: %w", err)
+			wasMigrated, createErr := nodeStatus.Create(ctx)
+			if createErr != nil {
+				return reconcile.Result{}, fmt.Errorf("cannot ensure node status: %w", createErr)
 			}
+
+			firstInstall = !wasMigrated
 		}
 
-		return r.reconcilePolicy(ctx, instance, oh, nodeStatus, reqLogger)
+		return r.reconcilePolicy(ctx, instance, oh, nodeStatus, firstInstall, reqLogger)
 	}
 
 	if err := nodeStatus.SetNodeStatus(ctx, secprofnodestatusapi.ProfileStateTerminating); err != nil {
@@ -254,6 +261,7 @@ func (r *ReconcileSelinux) reconcilePolicy(
 	sp selinuxprofileapi.SelinuxProfileObject,
 	oh SelinuxObjectHandler,
 	nodeStatus *nodestatus.StatusClient,
+	firstInstall bool,
 	l logr.Logger,
 ) (reconcile.Result, error) {
 	selinuxdReady, err := isSelinuxdReady(ctx, r.httpc)
@@ -289,6 +297,26 @@ func (r *ReconcileSelinux) reconcilePolicy(
 
 	if !sp.IsReconcilable() {
 		l.Info("Profile is partial or disabled, skipping")
+
+		return reconcile.Result{}, nil
+	}
+
+	if firstInstall && isSystemSELinuxModule(bindata.SelinuxModuleStorePath, sp.GetPolicyName()) {
+		if err := nodeStatus.SetNodeStatus(ctx, secprofnodestatusapi.ProfileStateError); err != nil {
+			r.metrics.IncSelinuxProfileError(reasonCannotUpdatePolicyStatus)
+			r.record.Event(sp, util.EventTypeWarning, reasonCannotUpdatePolicyStatus, err.Error())
+
+			return reconcile.Result{}, fmt.Errorf("setting node status to error: %w", err)
+		}
+
+		evstr := fmt.Sprintf(
+			"Profile name %q conflicts with a system SELinux module on %s; "+
+				"use a different name (e.g. %q)",
+			sp.GetPolicyName(), os.Getenv(config.NodeNameEnvKey), "custom-"+sp.GetPolicyName(),
+		)
+
+		r.metrics.IncSelinuxProfileError(reasonSystemModuleConflict)
+		r.record.Event(sp, util.EventTypeWarning, reasonSystemModuleConflict, evstr)
 
 		return reconcile.Result{}, nil
 	}
@@ -627,4 +655,40 @@ func writeFileIfDiffers(filePath string, contents []byte, l logr.Logger) (bool, 
 	l.Info("Updating policy file", "policyPath", filePath)
 
 	return true, os.WriteFile(filePath, contents, filePermissions)
+}
+
+// isSystemSELinuxModule checks whether an SELinux module with the given name
+// is already installed in the host's module store. The store layout is
+// /var/lib/selinux/<policy_type>/active/modules/<priority>/<module_name>/.
+func isSystemSELinuxModule(moduleStorePath, name string) bool {
+	policyTypes, err := os.ReadDir(moduleStorePath)
+	if err != nil {
+		return false
+	}
+
+	for _, pt := range policyTypes {
+		if !pt.IsDir() {
+			continue
+		}
+
+		modulesDir := filepath.Join(moduleStorePath, pt.Name(), "active", "modules")
+
+		priorities, err := os.ReadDir(modulesDir)
+		if err != nil {
+			continue
+		}
+
+		for _, prio := range priorities {
+			if !prio.IsDir() {
+				continue
+			}
+
+			moduleDir := filepath.Join(modulesDir, prio.Name(), name)
+			if fi, err := os.Stat(moduleDir); err == nil && fi.IsDir() {
+				return true
+			}
+		}
+	}
+
+	return false
 }

--- a/internal/pkg/daemon/selinuxprofile/common_controller_test.go
+++ b/internal/pkg/daemon/selinuxprofile/common_controller_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package selinuxprofile
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsSystemSELinuxModule(t *testing.T) {
+	t.Parallel()
+
+	setup := func(t *testing.T, modules ...string) string {
+		t.Helper()
+
+		store := t.TempDir()
+		modulesDir := filepath.Join(store, "targeted", "active", "modules", "100")
+		require.NoError(t, os.MkdirAll(modulesDir, 0o755))
+
+		for _, m := range modules {
+			require.NoError(t, os.Mkdir(filepath.Join(modulesDir, m), 0o755))
+		}
+
+		return store
+	}
+
+	cases := []struct {
+		name    string
+		modules []string
+		query   string
+		want    bool
+	}{
+		{
+			name:    "system module kerberos is detected",
+			modules: []string{"kerberos", "container"},
+			query:   "kerberos",
+			want:    true,
+		},
+		{
+			name:    "system module container is detected",
+			modules: []string{"kerberos", "container"},
+			query:   "container",
+			want:    true,
+		},
+		{
+			name:    "custom name does not conflict",
+			modules: []string{"kerberos", "container"},
+			query:   "my-custom-profile",
+			want:    false,
+		},
+		{
+			name:    "prefixed name does not conflict",
+			modules: []string{"kerberos"},
+			query:   "custom-kerberos",
+			want:    false,
+		},
+		{
+			name:    "empty module store",
+			modules: nil,
+			query:   "kerberos",
+			want:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			store := setup(t, tc.modules...)
+			got := isSystemSELinuxModule(store, tc.query)
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestIsSystemSELinuxModuleNonexistentPath(t *testing.T) {
+	t.Parallel()
+
+	got := isSystemSELinuxModule("/nonexistent/path", "kerberos")
+	require.False(t, got)
+}

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -77,6 +77,7 @@ const (
 	metricsServerCert                                = "metrics-server-cert"
 	MetricsCertPath                                  = "/var/run/secrets/metrics"
 	SelinuxCustomTemplatesVolumeName                 = "selinux-custom-templates"
+	SelinuxModuleStorePath                           = "/var/lib/selinux"
 )
 
 var DefaultSPOD = &spodapi.SecurityProfilesOperatorDaemon{

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -577,6 +577,14 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 			templateSpec.Containers,
 			r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDSelinuxd])
 
+		templateSpec.Containers[bindata.ContainerIDDaemon].VolumeMounts = append(
+			templateSpec.Containers[bindata.ContainerIDDaemon].VolumeMounts,
+			corev1.VolumeMount{
+				Name:      "host-varlibselinux-volume",
+				MountPath: bindata.SelinuxModuleStorePath,
+				ReadOnly:  true,
+			})
+
 		templateSpec.Containers[bindata.ContainerIDDaemon].Args = append(
 			templateSpec.Containers[bindata.ContainerIDDaemon].Args,
 			"--with-selinux=true")

--- a/internal/pkg/nodestatus/nodestatus.go
+++ b/internal/pkg/nodestatus/nodestatus.go
@@ -21,12 +21,14 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	profilebase "sigs.k8s.io/security-profiles-operator/api/profilebase/v1"
 	profilerecordingapi "sigs.k8s.io/security-profiles-operator/api/profilerecording/v1"
@@ -34,6 +36,8 @@ import (
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/util"
 )
+
+var log = logf.Log.WithName("nodestatus")
 
 const (
 	partialProfileFinalizer = "spo.x-k8s.io/partial-profile-finalizer"
@@ -61,28 +65,68 @@ func NewForProfile(pol profilebase.SecurityProfileBase, c client.Client) (*Statu
 }
 
 func (nsf *StatusClient) perNodeStatusName() string {
-	return nsf.pol.GetName() + "-" + nsf.nodeName
+	kind := strings.ToLower(nsf.pol.GetObjectKind().GroupVersionKind().Kind)
+
+	return util.DNSLengthName(kind, "%s-%s-%s", kind, nsf.pol.GetName(), nsf.nodeName)
 }
 
 func (nsf *StatusClient) perNodeStatusNamespacedName() types.NamespacedName {
 	return util.NamespacedName(nsf.perNodeStatusName(), nsf.pol.GetNamespace())
 }
 
-func (nsf *StatusClient) Create(ctx context.Context) error {
+func (nsf *StatusClient) Create(ctx context.Context) (bool, error) {
 	if err := nsf.createFinalizer(ctx); err != nil {
-		return fmt.Errorf("cannot create finalizer for %s: %w", nsf.pol.GetName(), err)
+		return false, fmt.Errorf("cannot create finalizer for %s: %w", nsf.pol.GetName(), err)
 	}
 
 	if err := nsf.createPolLabel(ctx); err != nil {
-		return fmt.Errorf("cannot create policy name label for %s: %w", nsf.pol.GetName(), err)
+		return false, fmt.Errorf("cannot create policy name label for %s: %w", nsf.pol.GetName(), err)
 	}
+
+	wasMigrated := nsf.removeLegacyNodeStatus(ctx)
 
 	// if object does not exist, add it
 	if err := nsf.createNodeStatus(ctx); err != nil {
-		return fmt.Errorf("cannot create node status for %s: %w", nsf.pol.GetName(), err)
+		return false, fmt.Errorf("cannot create node status for %s: %w", nsf.pol.GetName(), err)
 	}
 
-	return nil
+	return wasMigrated, nil
+}
+
+// removeLegacyNodeStatus removes old-format status objects that used
+// <profileName>-<nodeName> instead of <kind>-<profileName>-<nodeName>.
+// Returns true if a legacy status was found and removed (upgrade migration).
+func (nsf *StatusClient) removeLegacyNodeStatus(ctx context.Context) bool {
+	legacyName := nsf.pol.GetName() + "-" + nsf.nodeName
+	if legacyName == nsf.perNodeStatusName() {
+		return false
+	}
+
+	old := &secprofnodestatusapi.SecurityProfileNodeStatus{}
+	key := util.NamespacedName(legacyName, nsf.pol.GetNamespace())
+
+	if err := nsf.client.Get(ctx, key, old); err != nil {
+		if !kerrors.IsNotFound(err) {
+			log.Error(err, "failed to look up legacy node status", "name", legacyName)
+		}
+
+		return false
+	}
+
+	// Verify the object belongs to this profile. A profile named
+	// "<kind>-<other>" has a legacy name that collides with the
+	// new-format name of profile "<other>".
+	if old.Labels[secprofnodestatusapi.StatusToProfLabel] != util.KindBasedDNSLengthName(nsf.pol) {
+		return false
+	}
+
+	if err := nsf.client.Delete(ctx, old); err != nil && !kerrors.IsNotFound(err) {
+		log.Error(err, "failed to remove legacy node status", "name", legacyName)
+
+		return false
+	}
+
+	return true
 }
 
 func (nsf *StatusClient) createFinalizer(ctx context.Context) error {

--- a/internal/pkg/nodestatus/nodestatus_test.go
+++ b/internal/pkg/nodestatus/nodestatus_test.go
@@ -17,14 +17,22 @@ limitations under the License.
 package nodestatus
 
 import (
+	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	profilebase "sigs.k8s.io/security-profiles-operator/api/profilebase/v1"
 	seccompprofile "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1"
+	secprofnodestatusapi "sigs.k8s.io/security-profiles-operator/api/secprofnodestatus/v1"
+	selinuxprofile "sigs.k8s.io/security-profiles-operator/api/selinuxprofile/v1"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/util"
 )
 
 // Expected shorten the node name if length exceed the limit.
@@ -66,8 +74,170 @@ func TestShortenNodeName(t *testing.T) {
 	}
 }
 
+func TestPerNodeStatusNameIncludesKind(t *testing.T) {
+	cases := []struct {
+		name           string
+		nodeName       string
+		profile        profilebase.SecurityProfileBase
+		wantStatusName string
+	}{
+		{
+			name:           "SeccompProfile",
+			nodeName:       "worker-1",
+			profile:        regularSeccompProfile(),
+			wantStatusName: "seccompprofile-test-profile-worker-1",
+		},
+		{
+			name:     "SelinuxProfile",
+			nodeName: "worker-1",
+			profile: &selinuxprofile.SelinuxProfile{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "SelinuxProfile",
+					APIVersion: "security-profiles-operator.x-k8s.io/v1",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-profile",
+					Namespace: "test-namespace",
+				},
+			},
+			wantStatusName: "selinuxprofile-test-profile-worker-1",
+		},
+		{
+			name:           "LongNameGetsHashed",
+			nodeName:       "very-long-node-name-that-exceeds-limits.example.com",
+			profile:        regularSeccompProfile(),
+			wantStatusName: "seccompprofile-8c3d274dad49d118a4e9b7f4c1e835d3c45a23de6c59aec5",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(config.NodeNameEnvKey, tc.nodeName)
+			sc, err := NewForProfile(tc.profile, nil)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.wantStatusName, sc.perNodeStatusName())
+		})
+	}
+}
+
+func TestRemoveLegacyNodeStatus(t *testing.T) {
+	t.Parallel()
+
+	const nodeName = "worker-1"
+
+	cases := []struct {
+		name         string
+		profile      profilebase.SecurityProfileBase
+		mockGet      func(ctx context.Context, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error
+		mockDelete   func(ctx context.Context, obj client.Object, opts ...client.DeleteOption) error
+		wantMigrated bool
+	}{
+		{
+			name:    "LegacyStatusRemoved",
+			profile: regularSeccompProfile(),
+			mockGet: func(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				if key.Name == "test-profile-"+nodeName {
+					if ns, ok := obj.(*secprofnodestatusapi.SecurityProfileNodeStatus); ok {
+						ns.Labels = map[string]string{
+							secprofnodestatusapi.StatusToProfLabel: util.KindBasedDNSLengthName(regularSeccompProfile()),
+						}
+					}
+
+					return nil
+				}
+
+				return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
+			},
+			mockDelete: func(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
+				return nil
+			},
+			wantMigrated: true,
+		},
+		{
+			name:    "LegacyStatusNotFound",
+			profile: regularSeccompProfile(),
+			mockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return kerrors.NewNotFound(schema.GroupResource{}, "")
+			},
+			wantMigrated: false,
+		},
+		{
+			name:    "LegacyStatusWrongLabel",
+			profile: regularSeccompProfile(),
+			mockGet: func(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				if key.Name == "test-profile-"+nodeName {
+					if ns, ok := obj.(*secprofnodestatusapi.SecurityProfileNodeStatus); ok {
+						ns.Labels = map[string]string{
+							secprofnodestatusapi.StatusToProfLabel: "different-owner",
+						}
+					}
+
+					return nil
+				}
+
+				return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
+			},
+			wantMigrated: false,
+		},
+		{
+			name:    "GetError",
+			profile: regularSeccompProfile(),
+			mockGet: func(_ context.Context, _ client.ObjectKey, _ client.Object, _ ...client.GetOption) error {
+				return errors.New("api server error")
+			},
+			wantMigrated: false,
+		},
+		{
+			name:    "DeleteFailsReturnsNotMigrated",
+			profile: regularSeccompProfile(),
+			mockGet: func(_ context.Context, key client.ObjectKey, obj client.Object, _ ...client.GetOption) error {
+				if key.Name == "test-profile-"+nodeName {
+					if ns, ok := obj.(*secprofnodestatusapi.SecurityProfileNodeStatus); ok {
+						ns.Labels = map[string]string{
+							secprofnodestatusapi.StatusToProfLabel: util.KindBasedDNSLengthName(regularSeccompProfile()),
+						}
+					}
+
+					return nil
+				}
+
+				return kerrors.NewNotFound(schema.GroupResource{}, key.Name)
+			},
+			mockDelete: func(_ context.Context, _ client.Object, _ ...client.DeleteOption) error {
+				return errors.New("delete failed")
+			},
+			wantMigrated: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cl := &util.MockClient{
+				MockGet:    tc.mockGet,
+				MockDelete: tc.mockDelete,
+			}
+
+			sc := &StatusClient{
+				pol:      tc.profile,
+				nodeName: nodeName,
+				client:   cl,
+			}
+
+			got := sc.removeLegacyNodeStatus(context.Background())
+			require.Equal(t, tc.wantMigrated, got)
+		})
+	}
+}
+
 func regularSeccompProfile() *seccompprofile.SeccompProfile {
 	return &seccompprofile.SeccompProfile{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SeccompProfile",
+			APIVersion: "security-profiles-operator.x-k8s.io/v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-profile",
 			Namespace: "test-namespace",
@@ -77,6 +247,10 @@ func regularSeccompProfile() *seccompprofile.SeccompProfile {
 
 func partialSeccompProfile() *seccompprofile.SeccompProfile {
 	return &seccompprofile.SeccompProfile{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "SeccompProfile",
+			APIVersion: "security-profiles-operator.x-k8s.io/v1",
+		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-profile",
 			Namespace: "test-namespace",

--- a/internal/pkg/util/names.go
+++ b/internal/pkg/util/names.go
@@ -70,7 +70,7 @@ func lengthName(maxLen int, hashPrefix, format string, a ...any) (string, error)
 	return hashedName, nil
 }
 
-func dnsLengthName(hashPrefix, format string, a ...any) string {
+func DNSLengthName(hashPrefix, format string, a ...any) string {
 	//nolint:errcheck // (jhrozek): I think it makes sense to make the utility
 	// 					  function return error, but here I think it's OK to
 	// 					  just ignore
@@ -82,5 +82,5 @@ func dnsLengthName(hashPrefix, format string, a ...any) string {
 func KindBasedDNSLengthName(obj client.Object) string {
 	kind := obj.GetObjectKind().GroupVersionKind().Kind
 
-	return dnsLengthName(kind, "%s-%s", kind, obj.GetName())
+	return DNSLengthName(kind, "%s-%s", kind, obj.GetName())
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Two enhancements to improve profile management reliability:

1. **Include profile kind in SecurityProfileNodeStatus naming**: Changes status object names from `<profileName>-<nodeName>` to `<kind>-<profileName>-<nodeName>` (e.g., `seccompprofile-myprofile-worker-1`). This prevents collisions when a SelinuxProfile and SeccompProfile share the same name, which previously caused status objects to overwrite each other. Includes migration logic to clean up old-format objects on upgrade, with a label ownership check to prevent cross-profile deletion in edge cases.

2. **Validate SELinux profile names against system modules**: At reconcile time on each node, the daemon checks whether a SELinux profile name conflicts with an existing module in the host's module store (`/var/lib/selinux`). If a conflict is detected on first installation, the profile enters an error state with a descriptive event. The check is skipped on pod restarts and upgrades to avoid false positives.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Yes. Unit tests for kind-based naming (`TestPerNodeStatusNameIncludesKind`), legacy status migration (`TestRemoveLegacyNodeStatus`), and module conflict detection (`TestIsSystemSELinuxModule`).

#### Special notes for your reviewer:

The system module check only runs on first install (`firstInstall = !wasMigrated`). On upgrade, the legacy node status migration sets `wasMigrated = true`, suppressing the check. On pod restart, the node status CRD persists in etcd, so `Exists()` returns true and the check is skipped entirely.

#### Does this PR introduce a user-facing change?

```release-note
SecurityProfileNodeStatus objects now include the profile kind in their name to prevent collisions between different profile types. SELinux profile names that conflict with system SELinux policy modules are rejected at reconcile time with a descriptive error event.
```