### PR TITLE
fix(recording): avoid merged profile name collision

### DIFF
--- a/internal/pkg/daemon/profilerecorder/profilerecorder.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder.go
@@ -458,9 +458,11 @@ func (r *RecorderReconciler) collectLogProfiles(
 			return fmt.Errorf("parse profile raw annotation: %w", err)
 		}
 
-		profileNamespacedName := createProfileName(
-			parsedProfileAnnotation.cntName, replicaSuffix,
-			podName.Namespace, parsedProfileAnnotation.profileName)
+		profileNamespacedName, err := createProfileNameForRecording(
+			ctx, r, parsedProfileAnnotation, replicaSuffix, podName)
+		if err != nil {
+			return fmt.Errorf("create profile name: %w", err)
+		}
 
 		r.log.Info("Collecting profile", "name", profileNamespacedName, "kind", prf.kind)
 
@@ -727,9 +729,11 @@ func (r *RecorderReconciler) collectBpfProfiles(
 			return fmt.Errorf("parse profile raw annotation: %w", err)
 		}
 
-		profileNamespacedName := createProfileName(
-			parsedProfileName.cntName, replicaSuffix,
-			podName.Namespace, parsedProfileName.profileName)
+		profileNamespacedName, err := createProfileNameForRecording(
+			ctx, r, parsedProfileName, replicaSuffix, podName)
+		if err != nil {
+			return fmt.Errorf("create profile name: %w", err)
+		}
 
 		labels, err := profileLabels(
 			ctx,
@@ -1087,6 +1091,27 @@ func createProfileName(cntName, replicaSuffix, namespace, profileName string) ty
 		Name:      name,
 		Namespace: namespace,
 	}
+}
+
+func createProfileNameForRecording(
+	ctx context.Context,
+	r *RecorderReconciler,
+	profile *parsedAnnotation,
+	replicaSuffix string,
+	podName types.NamespacedName,
+) (types.NamespacedName, error) {
+	if replicaSuffix == "" {
+		partial, err := profilePartial(ctx, r, profile.profileName, podName.Namespace)
+		if err != nil {
+			return types.NamespacedName{}, fmt.Errorf("determine profile merge strategy: %w", err)
+		}
+
+		if partial {
+			replicaSuffix = podName.Name
+		}
+	}
+
+	return createProfileName(profile.cntName, replicaSuffix, podName.Namespace, profile.profileName), nil
 }
 
 // parseLogAnnotations parses the provided annotations and extracts the

--- a/internal/pkg/daemon/profilerecorder/profilerecorder_test.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder_test.go
@@ -35,6 +35,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -60,6 +61,108 @@ func TestName(t *testing.T) {
 
 	sut := NewController()
 	assert.Equal(t, "recorder-spod", sut.Name())
+}
+
+func TestCollectBpfProfilesProfileName(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name          string
+		mergeStrategy recordingapi.ProfileMergeStrategy
+		podName       string
+		replicaSuffix string
+		expected      string
+	}{
+		{
+			name:          "fixed pod with containers merge",
+			mergeStrategy: recordingapi.ProfileMergeContainers,
+			podName:       "fixed-pod",
+			expected:      "recording-container-fixed-pod",
+		},
+		{
+			name:          "fixed pod without merge",
+			mergeStrategy: recordingapi.ProfileMergeNone,
+			podName:       "fixed-pod",
+			expected:      "recording-container",
+		},
+		{
+			name:          "generated pod keeps replica suffix",
+			mergeStrategy: recordingapi.ProfileMergeContainers,
+			podName:       "generated-abcde",
+			replicaSuffix: "abcde",
+			expected:      "recording-container-abcde",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			recording := &recordingapi.ProfileRecording{
+				ObjectMeta: metav1.ObjectMeta{Name: "recording", Namespace: "recording-ns"},
+				Spec: recordingapi.ProfileRecordingSpec{
+					MergeStrategy: tc.mergeStrategy,
+				},
+			}
+			scheme := apiruntime.NewScheme()
+			require.NoError(t, recordingapi.AddToScheme(scheme))
+			kubeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(recording).Build()
+
+			mock := &profilerecorderfakes.FakeImpl{}
+			mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{
+				Spec: spodapi.SPODSpec{Enricher: spodapi.SPODEnricherConfig{EnableBpfRecorder: ptrTrue()}},
+			}, nil)
+			mock.DialBpfRecorderReturns(nil, nil)
+			mock.SyscallsForProfileReturns(&bpfrecorderapi.SyscallsResponse{
+				Syscalls: []string{"read"},
+				GoArch:   runtime.GOARCH,
+			}, nil)
+			mock.ClientGetCalls(func(
+				_ context.Context,
+				_ client.Client,
+				key types.NamespacedName,
+				obj client.Object,
+			) error {
+				recordingResult, ok := obj.(*recordingapi.ProfileRecording)
+				require.True(t, ok)
+				require.Equal(t, client.ObjectKeyFromObject(recording), key)
+
+				recording.DeepCopyInto(recordingResult)
+
+				return nil
+			})
+			mock.GetRecordingReturns(recording, nil)
+
+			createdName := ""
+
+			mock.CreateOrUpdateCalls(func(
+				_ context.Context,
+				_ client.Client,
+				obj client.Object,
+				mutate controllerutil.MutateFn,
+			) (controllerutil.OperationResult, error) {
+				createdName = obj.GetName()
+
+				return controllerutil.OperationResultCreated, mutate()
+			})
+
+			sut := &RecorderReconciler{
+				impl:   mock,
+				client: kubeClient,
+				log:    logr.Discard(),
+				record: record.NewFakeRecorder(10),
+			}
+			err := sut.collectBpfProfiles(
+				t.Context(),
+				tc.replicaSuffix,
+				types.NamespacedName{Name: tc.podName, Namespace: recording.Namespace},
+				[]profileToCollect{{
+					kind: recordingapi.ProfileRecordingKindSeccompProfile,
+					name: "recording_container_nonce_timestamp",
+				}},
+			)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, createdName)
+		})
+	}
 }
 
 func TestSchemeBuilder(t *testing.T) {

--- a/internal/pkg/daemon/profilerecorder/profilerecorder_test.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder_test.go
@@ -125,9 +125,11 @@ func TestCollectBpfProfilesProfileName(t *testing.T) {
 				case *recordingapi.ProfileRecording:
 					require.Equal(t, client.ObjectKeyFromObject(recording), key)
 					recording.DeepCopyInto(recordingResult)
+
 					return nil
 				default:
 					t.Fatalf("unexpected ClientGet for %T", obj)
+
 					return nil
 				}
 			})

--- a/internal/pkg/daemon/profilerecorder/profilerecorder_test.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder_test.go
@@ -121,13 +121,15 @@ func TestCollectBpfProfilesProfileName(t *testing.T) {
 				key types.NamespacedName,
 				obj client.Object,
 			) error {
-				recordingResult, ok := obj.(*recordingapi.ProfileRecording)
-				require.True(t, ok)
-				require.Equal(t, client.ObjectKeyFromObject(recording), key)
-
-				recording.DeepCopyInto(recordingResult)
-
-				return nil
+				switch recordingResult := obj.(type) {
+				case *recordingapi.ProfileRecording:
+					require.Equal(t, client.ObjectKeyFromObject(recording), key)
+					recording.DeepCopyInto(recordingResult)
+					return nil
+				default:
+					t.Fatalf("unexpected ClientGet for %T", obj)
+					return nil
+				}
 			})
 			mock.GetRecordingReturns(recording, nil)
 

--- a/internal/pkg/manager/recordingmerger/coverage_test.go
+++ b/internal/pkg/manager/recordingmerger/coverage_test.go
@@ -550,7 +550,7 @@ func TestCreateUpdateProfile_CoverageAnnotation(t *testing.T) {
 
 		got := &seccompprofile.SeccompProfile{}
 		require.NoError(t, cl.Get(context.Background(),
-			client.ObjectKey{Name: mergedName, Namespace: namespace}, got))
+			client.ObjectKey{Name: mergedName}, got))
 		require.JSONEq(t, coverage, got.GetAnnotations()[syscallCoverageAnnotation])
 	})
 
@@ -566,7 +566,7 @@ func TestCreateUpdateProfile_CoverageAnnotation(t *testing.T) {
 
 		got := &selinuxprofileapi.SelinuxProfile{}
 		require.NoError(t, cl.Get(context.Background(),
-			client.ObjectKey{Name: mergedName, Namespace: namespace}, got))
+			client.ObjectKey{Name: mergedName}, got))
 		require.NotContains(t, got.GetAnnotations(), syscallCoverageAnnotation)
 	})
 
@@ -582,7 +582,7 @@ func TestCreateUpdateProfile_CoverageAnnotation(t *testing.T) {
 
 		got := &apparmorprofileapi.AppArmorProfile{}
 		require.NoError(t, cl.Get(context.Background(),
-			client.ObjectKey{Name: mergedName, Namespace: namespace}, got))
+			client.ObjectKey{Name: mergedName}, got))
 		require.NotContains(t, got.GetAnnotations(), syscallCoverageAnnotation)
 	})
 
@@ -592,7 +592,6 @@ func TestCreateUpdateProfile_CoverageAnnotation(t *testing.T) {
 		existing := &seccompprofile.SeccompProfile{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        mergedName,
-				Namespace:   namespace,
 				Annotations: map[string]string{"user.example.com/keep": "yes"},
 			},
 		}
@@ -606,7 +605,7 @@ func TestCreateUpdateProfile_CoverageAnnotation(t *testing.T) {
 
 		got := &seccompprofile.SeccompProfile{}
 		require.NoError(t, cl.Get(context.Background(),
-			client.ObjectKey{Name: mergedName, Namespace: namespace}, got))
+			client.ObjectKey{Name: mergedName}, got))
 		require.JSONEq(t, coverage, got.GetAnnotations()[syscallCoverageAnnotation])
 		require.Equal(t, "yes", got.GetAnnotations()["user.example.com/keep"])
 	})

--- a/internal/pkg/manager/recordingmerger/merge_utils.go
+++ b/internal/pkg/manager/recordingmerger/merge_utils.go
@@ -37,8 +37,7 @@ import (
 
 func mergedObjectMeta(profileName, recordingName, namespace string) *metav1.ObjectMeta {
 	return &metav1.ObjectMeta{
-		Name:      profileName,
-		Namespace: namespace,
+		Name: profileName,
 		Labels: map[string]string{
 			profilerecordingapi.ProfileToRecordingLabel:          recordingName,
 			profilerecordingapi.ProfileToRecordingNamespaceLabel: namespace,

--- a/internal/pkg/manager/recordingmerger/merge_utils_test.go
+++ b/internal/pkg/manager/recordingmerger/merge_utils_test.go
@@ -47,6 +47,17 @@ func ifaceAsSortedSeccompProfile(iface client.Object) *seccompprofile.SeccompPro
 	return prof
 }
 
+func TestMergedObjectMetaIsClusterScoped(t *testing.T) {
+	t.Parallel()
+
+	meta := mergedObjectMeta("recording-container", "recording", "recording-ns")
+
+	require.Equal(t, "recording-container", meta.Name)
+	require.Empty(t, meta.Namespace)
+	require.Equal(t, "recording", meta.Labels["spo.x-k8s.io/recording-id"])
+	require.Equal(t, "recording-ns", meta.Labels["spo.x-k8s.io/recording-namespace"])
+}
+
 func ifaceAsSortedSelinuxProfile(iface client.Object) *selinuxprofileapi.SelinuxProfile {
 	prof, ok := iface.(*selinuxprofileapi.SelinuxProfile)
 	if !ok {


### PR DESCRIPTION
What type of PR is this?

/kind bug

What this PR does / why we need it:

Fixes #3328.

With `mergeStrategy: Containers`, a fixed-name Pod can produce a partial
profile named:

    <recording>-<container>

which is also the name used for the final merged profile.

This causes the recording merger to find the existing partial when creating
the merged profile.

There is a second object-identity issue on that path: merged profile resources
are cluster-scoped, but the merged object metadata carries the recording
namespace in `metadata.namespace`.

When `CreateOrUpdate` retrieves the existing cluster-scoped partial, the
returned object has an empty namespace. The resulting object-key mismatch
causes the merge to fail.

This change keeps the existing naming behavior for generated Pods and for
`mergeStrategy: None`, while giving fixed-name Pods under
`mergeStrategy: Containers` a distinct partial-profile name:

    <recording>-<container>-<pod-name>

The final merged profile remains:

    <recording>-<container>

Merged profile objects also no longer set `metadata.namespace`. The recording
namespace remains available through the existing
`spo.x-k8s.io/recording-namespace` label.

Partial-profile discovery and cleanup are unchanged because both are
label-driven rather than dependent on the partial profile object name.

The syscall coverage behavior for merged seccomp profiles is unchanged.

Which issue(s) this PR fixes:

Fixes #3328

Special notes for your reviewer:

The regression test exercises the existing `collectBpfProfiles` path.

Against the parent implementation, the test compiles and fails behaviorally
because the fixed-name Pod produces:

    recording-container

With this change, the same path produces:

    recording-container-fixed-pod

while the final merged profile remains:

    recording-container

The cluster-scope regression test also verifies that merged profile metadata
does not carry a Kubernetes namespace while retaining the recording namespace
label.

A fixed-name Pod recreated with the same name can still reuse the same partial
profile identity. This change intentionally follows SPO's existing Pod-name
based naming semantics rather than introducing Pod UID identity as part of
this bug fix.

Does this PR introduce a user-facing change?

```release-note
Fix profile merging for fixed-name Pods using `mergeStrategy: Containers` by
preventing partial profiles from colliding with the final merged profile.
```