### PR TITLE
Bump security-profiles-merger to v0.3.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.93.1
 	github.com/prometheus/client_golang v1.24.1
 	github.com/prometheus/client_model v0.6.2
-	github.com/saschagrunert/security-profiles-merger v0.3.2
+	github.com/saschagrunert/security-profiles-merger v0.3.6
 	github.com/seccomp/libseccomp-golang v0.11.1
 	github.com/sigstore/cosign/v2 v2.6.5
 	github.com/stretchr/testify v1.12.1

--- a/go.sum
+++ b/go.sum
@@ -673,8 +673,8 @@ github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkB
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=
 github.com/sagikazarmark/locafero v0.12.0 h1:/NQhBAkUb4+fH1jivKHWusDYFjMOOKU88eegjfxfHb4=
 github.com/sagikazarmark/locafero v0.12.0/go.mod h1:sZh36u/YSZ918v0Io+U9ogLYQJ9tLLBmM4eneO6WwsI=
-github.com/saschagrunert/security-profiles-merger v0.3.2 h1:0fqjP8tOzrgLFnRDHtjkHRFiHtaFnbY98n2L3x8Cp2U=
-github.com/saschagrunert/security-profiles-merger v0.3.2/go.mod h1:k+Metag22RGXY2RBf2aHXHzqQtqeZEORb+dMGhp1TQ4=
+github.com/saschagrunert/security-profiles-merger v0.3.6 h1:WMYpiTQUGhQZvAARsUZ/TvVJ2f5/yq6tehn3OMftd9g=
+github.com/saschagrunert/security-profiles-merger v0.3.6/go.mod h1:k+Metag22RGXY2RBf2aHXHzqQtqeZEORb+dMGhp1TQ4=
 github.com/sassoftware/relic v7.2.1+incompatible h1:Pwyh1F3I0r4clFJXkSI8bOyJINGqpgjJU3DYAZeI05A=
 github.com/sassoftware/relic v7.2.1+incompatible/go.mod h1:CWfAxv73/iLZ17rbyhIEq3K9hs5w6FpNMdUT//qR+zk=
 github.com/sassoftware/relic/v7 v7.6.2 h1:rS44Lbv9G9eXsukknS4mSjIAuuX+lMq/FnStgmZlUv4=

--- a/internal/pkg/util/union_syscalls_test.go
+++ b/internal/pkg/util/union_syscalls_test.go
@@ -87,30 +87,9 @@ func TestUnionSyscalls(t *testing.T) {
 				},
 			},
 			want: []seccompprofileapi.Syscall{
-				{
-					Names:  []string{"a"},
-					Action: seccompprofileapi.ActAllow,
-					Args: []seccompprofileapi.Arg{
-						{Index: ptr.To[int32](1), Value: 2},
-						{Index: ptr.To[int32](2), Value: 3},
-					},
-				},
-				{
-					Names:  []string{"b"},
-					Action: seccompprofileapi.ActAllow,
-					Args: []seccompprofileapi.Arg{
-						{Index: ptr.To[int32](1), Value: 2},
-						{Index: ptr.To[int32](2), Value: 3},
-					},
-				},
-				{
-					Names:  []string{"c"},
-					Action: seccompprofileapi.ActAllow,
-					Args: []seccompprofileapi.Arg{
-						{Index: ptr.To[int32](1), Value: 2},
-						{Index: ptr.To[int32](2), Value: 3},
-					},
-				},
+				{Names: []string{"a"}, Action: seccompprofileapi.ActAllow},
+				{Names: []string{"b"}, Action: seccompprofileapi.ActAllow},
+				{Names: []string{"c"}, Action: seccompprofileapi.ActAllow},
 			},
 		},
 		{

--- a/vendor/github.com/saschagrunert/security-profiles-merger/apparmor/diff.go
+++ b/vendor/github.com/saschagrunert/security-profiles-merger/apparmor/diff.go
@@ -1,0 +1,371 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package apparmor
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/saschagrunert/security-profiles-merger/internal/merge"
+)
+
+// ProfileDiff describes the differences between two AppArmor profiles.
+type ProfileDiff struct {
+	// Equal is true when the two profiles are identical.
+	Equal bool `json:"equal"`
+
+	// Executables is set when the allowed executables differ.
+	Executables *StringSliceDiff `json:"executables,omitempty"`
+
+	// Libraries is set when the allowed libraries differ.
+	Libraries *StringSliceDiff `json:"libraries,omitempty"`
+
+	// Filesystem is set when the filesystem rules differ.
+	Filesystem *FilesystemDiff `json:"filesystem,omitempty"`
+
+	// Network is set when the network rules differ.
+	Network *NetworkDiff `json:"network,omitempty"`
+
+	// Capabilities is set when the capabilities differ.
+	Capabilities *StringSliceDiff `json:"capabilities,omitempty"`
+}
+
+// IsEqual returns whether the two compared profiles are identical.
+func (d ProfileDiff) IsEqual() bool { return d.Equal }
+
+// StringSliceDiff represents added and removed items in a string slice.
+type StringSliceDiff = merge.SliceDiff[string]
+
+// FilesystemDiff describes differences in filesystem rules.
+type FilesystemDiff struct {
+	ReadOnly  *StringSliceDiff `json:"readOnly,omitempty"`
+	WriteOnly *StringSliceDiff `json:"writeOnly,omitempty"`
+	ReadWrite *StringSliceDiff `json:"readWrite,omitempty"`
+}
+
+// NetworkDiff describes differences in network rules.
+type NetworkDiff struct {
+	AllowRaw *BoolPtrDiff `json:"allowRaw,omitempty"`
+	AllowTCP *BoolPtrDiff `json:"allowTcp,omitempty"`
+	AllowUDP *BoolPtrDiff `json:"allowUdp,omitempty"`
+}
+
+// BoolPtrDiff represents a change in an optional boolean value.
+type BoolPtrDiff struct {
+	Left  *bool `json:"left"`
+	Right *bool `json:"right"`
+}
+
+// Diff compares two AppArmor profiles and returns a structured diff.
+// Unlike Intersect and Union, Diff does not validate profiles before comparing.
+// Paths are normalized and deduplicated before comparison to avoid false
+// positives from non-canonical representations (e.g. /foo/./bar vs /foo/bar).
+// Returns ErrNilProfile if either profile is nil.
+func Diff(left, right *Profile) (*ProfileDiff, error) {
+	if left == nil || right == nil {
+		return nil, ErrNilProfile
+	}
+
+	normLeft := normalizeProfile(left)
+	deduplicateProfile(normLeft)
+
+	normRight := normalizeProfile(right)
+	deduplicateProfile(normRight)
+
+	diff := &ProfileDiff{
+		Equal:        true,
+		Executables:  nil,
+		Libraries:    nil,
+		Filesystem:   nil,
+		Network:      nil,
+		Capabilities: nil,
+	}
+
+	diffExecutables(diff, normLeft, normRight)
+	diffFilesystem(diff, normLeft, normRight)
+	diffNetwork(diff, normLeft, normRight)
+	diffCapabilities(diff, normLeft, normRight)
+
+	return diff, nil
+}
+
+func diffExecutables(diff *ProfileDiff, left, right *Profile) {
+	if execDiff := diffStringSlice(executablePaths(left), executablePaths(right)); execDiff != nil {
+		diff.Equal = false
+		diff.Executables = execDiff
+	}
+
+	if libDiff := diffStringSlice(libraryPaths(left), libraryPaths(right)); libDiff != nil {
+		diff.Equal = false
+		diff.Libraries = libDiff
+	}
+}
+
+func executablePaths(profile *Profile) []string {
+	if profile.Executable == nil {
+		return nil
+	}
+
+	return profile.Executable.AllowedExecutables
+}
+
+func libraryPaths(profile *Profile) []string {
+	if profile.Executable == nil {
+		return nil
+	}
+
+	return profile.Executable.AllowedLibraries
+}
+
+func diffFilesystem(diff *ProfileDiff, left, right *Profile) {
+	roDiff := diffStringSlice(fsPaths(left, fsReadOnly), fsPaths(right, fsReadOnly))
+	woDiff := diffStringSlice(fsPaths(left, fsWriteOnly), fsPaths(right, fsWriteOnly))
+	rwDiff := diffStringSlice(fsPaths(left, fsReadWrite), fsPaths(right, fsReadWrite))
+
+	if roDiff != nil || woDiff != nil || rwDiff != nil {
+		diff.Equal = false
+		diff.Filesystem = &FilesystemDiff{
+			ReadOnly:  roDiff,
+			WriteOnly: woDiff,
+			ReadWrite: rwDiff,
+		}
+	}
+}
+
+type fsCategory int
+
+const (
+	fsReadOnly fsCategory = iota
+	fsWriteOnly
+	fsReadWrite
+)
+
+func fsPaths(profile *Profile, category fsCategory) []string {
+	if profile.Filesystem == nil {
+		return nil
+	}
+
+	switch category {
+	case fsReadOnly:
+		return profile.Filesystem.ReadOnlyPaths
+	case fsWriteOnly:
+		return profile.Filesystem.WriteOnlyPaths
+	case fsReadWrite:
+		return profile.Filesystem.ReadWritePaths
+	default:
+		return nil
+	}
+}
+
+func diffNetwork(diff *ProfileDiff, left, right *Profile) {
+	var networkDiff NetworkDiff
+
+	changed := false
+
+	rawGetter := func(net *NetworkRules) *bool { return net.AllowRaw }
+
+	if rawDiff := diffBoolPtr(
+		netBoolPtr(left, rawGetter), netBoolPtr(right, rawGetter),
+	); rawDiff != nil {
+		networkDiff.AllowRaw = rawDiff
+		changed = true
+	}
+
+	tcpGetter := func(proto *AllowedProtocols) *bool { return proto.AllowTCP }
+
+	if tcpDiff := diffBoolPtr(
+		protoBoolPtr(left, tcpGetter), protoBoolPtr(right, tcpGetter),
+	); tcpDiff != nil {
+		networkDiff.AllowTCP = tcpDiff
+		changed = true
+	}
+
+	udpGetter := func(proto *AllowedProtocols) *bool { return proto.AllowUDP }
+
+	if udpDiff := diffBoolPtr(
+		protoBoolPtr(left, udpGetter), protoBoolPtr(right, udpGetter),
+	); udpDiff != nil {
+		networkDiff.AllowUDP = udpDiff
+		changed = true
+	}
+
+	if changed {
+		diff.Equal = false
+		diff.Network = &networkDiff
+	}
+}
+
+func netBoolPtr(profile *Profile, getter func(*NetworkRules) *bool) *bool {
+	if profile.Network == nil {
+		return nil
+	}
+
+	return getter(profile.Network)
+}
+
+func protoBoolPtr(profile *Profile, getter func(*AllowedProtocols) *bool) *bool {
+	if profile.Network == nil || profile.Network.Protocols == nil {
+		return nil
+	}
+
+	return getter(profile.Network.Protocols)
+}
+
+func diffBoolPtr(left, right *bool) *BoolPtrDiff {
+	if left == nil && right == nil {
+		return nil
+	}
+
+	if left == nil || right == nil || *left != *right {
+		return &BoolPtrDiff{
+			Left:  merge.ClonePtr(left),
+			Right: merge.ClonePtr(right),
+		}
+	}
+
+	return nil
+}
+
+func diffCapabilities(diff *ProfileDiff, left, right *Profile) {
+	var leftCaps, rightCaps []string
+
+	if left.Capabilities != nil {
+		leftCaps = left.Capabilities.AllowedCapabilities
+	}
+
+	if right.Capabilities != nil {
+		rightCaps = right.Capabilities.AllowedCapabilities
+	}
+
+	if capDiff := diffStringSlice(leftCaps, rightCaps); capDiff != nil {
+		diff.Equal = false
+		diff.Capabilities = capDiff
+	}
+}
+
+func diffStringSlice(left, right []string) *StringSliceDiff {
+	added, removed := merge.DiffSlice(left, right)
+	if len(added) == 0 && len(removed) == 0 {
+		return nil
+	}
+
+	return &StringSliceDiff{Added: added, Removed: removed}
+}
+
+// FormatDiff returns a human-readable representation of an AppArmor profile diff.
+func FormatDiff(diff *ProfileDiff) string {
+	if diff == nil {
+		return "Diff{<nil>}"
+	}
+
+	if diff.Equal {
+		return "Diff{equal}"
+	}
+
+	var parts []string
+
+	parts = appendExecDiffs(parts, diff)
+	parts = appendFSDiffs(parts, diff)
+
+	if diff.Network != nil {
+		parts = append(parts, formatNetworkDiff(diff.Network))
+	}
+
+	if diff.Capabilities != nil {
+		parts = append(parts, formatStringSliceDiff("caps", diff.Capabilities))
+	}
+
+	return fmt.Sprintf("Diff{%s}", strings.Join(parts, " "))
+}
+
+func appendExecDiffs(parts []string, diff *ProfileDiff) []string {
+	if diff.Executables != nil {
+		parts = append(parts, formatStringSliceDiff("exec", diff.Executables))
+	}
+
+	if diff.Libraries != nil {
+		parts = append(parts, formatStringSliceDiff("lib", diff.Libraries))
+	}
+
+	return parts
+}
+
+func appendFSDiffs(parts []string, diff *ProfileDiff) []string {
+	if diff.Filesystem == nil {
+		return parts
+	}
+
+	if diff.Filesystem.ReadOnly != nil {
+		parts = append(parts, formatStringSliceDiff("r", diff.Filesystem.ReadOnly))
+	}
+
+	if diff.Filesystem.WriteOnly != nil {
+		parts = append(parts, formatStringSliceDiff("w", diff.Filesystem.WriteOnly))
+	}
+
+	if diff.Filesystem.ReadWrite != nil {
+		parts = append(parts, formatStringSliceDiff("rw", diff.Filesystem.ReadWrite))
+	}
+
+	return parts
+}
+
+func formatStringSliceDiff(prefix string, sliceDiff *StringSliceDiff) string {
+	return merge.FormatDiffItems(prefix, sliceDiff.Removed, sliceDiff.Added)
+}
+
+func formatNetworkDiff(networkDiff *NetworkDiff) string {
+	var parts []string
+
+	if networkDiff.AllowRaw != nil {
+		parts = append(parts, fmt.Sprintf(
+			"raw:%s->%s",
+			formatBoolPtrShort(networkDiff.AllowRaw.Left),
+			formatBoolPtrShort(networkDiff.AllowRaw.Right),
+		))
+	}
+
+	if networkDiff.AllowTCP != nil {
+		parts = append(parts, fmt.Sprintf(
+			"tcp:%s->%s",
+			formatBoolPtrShort(networkDiff.AllowTCP.Left),
+			formatBoolPtrShort(networkDiff.AllowTCP.Right),
+		))
+	}
+
+	if networkDiff.AllowUDP != nil {
+		parts = append(parts, fmt.Sprintf(
+			"udp:%s->%s",
+			formatBoolPtrShort(networkDiff.AllowUDP.Left),
+			formatBoolPtrShort(networkDiff.AllowUDP.Right),
+		))
+	}
+
+	return "net:" + strings.Join(parts, ",")
+}
+
+func formatBoolPtrShort(boolPtr *bool) string {
+	if boolPtr == nil {
+		return "<nil>"
+	}
+
+	if *boolPtr {
+		return "true"
+	}
+
+	return "false"
+}

--- a/vendor/github.com/saschagrunert/security-profiles-merger/apparmor/glob.go
+++ b/vendor/github.com/saschagrunert/security-profiles-merger/apparmor/glob.go
@@ -21,7 +21,6 @@ import (
 	"slices"
 	"strings"
 	"sync"
-	"sync/atomic"
 )
 
 var (
@@ -31,14 +30,11 @@ var (
 	// neverMatchRe is a fallback regex that matches nothing.
 	neverMatchRe = regexp.MustCompile(`^(?:$.)$`)
 
-	// globRegexCache caches compiled glob patterns for reuse.
-	globRegexCache sync.Map //nolint:gochecknoglobals // process-wide cache
+	// globCacheMu protects globCacheEntries.
+	globCacheMu sync.RWMutex
 
-	// globRegexCacheCount tracks the number of entries in the cache.
-	globRegexCacheCount atomic.Int64 //nolint:gochecknoglobals // tracks cache size
-
-	// globCacheEvicting prevents concurrent eviction storms.
-	globCacheEvicting atomic.Bool //nolint:gochecknoglobals // guards eviction
+	// globCacheEntries stores compiled glob regexes keyed by pattern.
+	globCacheEntries = make(map[string]*regexp.Regexp)
 )
 
 const (
@@ -48,28 +44,32 @@ const (
 )
 
 func globToRegex(pattern string) *regexp.Regexp {
-	if cached, ok := globRegexCache.Load(pattern); ok {
-		compiled, _ := cached.(*regexp.Regexp)
+	globCacheMu.RLock()
 
-		return compiled
+	if cached, ok := globCacheEntries[pattern]; ok {
+		globCacheMu.RUnlock()
+
+		return cached
 	}
+
+	globCacheMu.RUnlock()
 
 	compiled := compileGlob(pattern)
 
-	actual, loaded := globRegexCache.LoadOrStore(pattern, compiled)
-	if !loaded {
-		if globRegexCacheCount.Add(1) > maxGlobCacheEntries &&
-			globCacheEvicting.CompareAndSwap(false, true) {
-			globRegexCache.Clear()
-			globRegexCacheCount.Store(1)
-			globRegexCache.Store(pattern, compiled)
-			globCacheEvicting.Store(false)
-		}
+	globCacheMu.Lock()
+	defer globCacheMu.Unlock()
+
+	if cached, ok := globCacheEntries[pattern]; ok {
+		return cached
 	}
 
-	stored, _ := actual.(*regexp.Regexp)
+	if len(globCacheEntries) >= maxGlobCacheEntries {
+		globCacheEntries = make(map[string]*regexp.Regexp)
+	}
 
-	return stored
+	globCacheEntries[pattern] = compiled
+
+	return compiled
 }
 
 func compileGlob(pattern string) *regexp.Regexp {
@@ -137,89 +137,88 @@ type apparmorPath struct {
 }
 
 type pathSet struct {
-	paths    []apparmorPath
+	globs    []apparmorPath
 	literals map[string]struct{}
 }
 
 func newPathSet(patterns []string) pathSet {
-	set := pathSet{paths: nil, literals: make(map[string]struct{})}
+	set := pathSet{
+		globs:    make([]apparmorPath, 0, len(patterns)),
+		literals: make(map[string]struct{}, len(patterns)),
+	}
+
+	seen := make(map[string]struct{}, len(patterns))
 
 	for _, pat := range patterns {
-		set.add(pat)
+		if _, ok := seen[pat]; ok {
+			continue
+		}
+
+		seen[pat] = struct{}{}
+
+		if globTokenRe.MatchString(pat) {
+			set.globs = append(set.globs, apparmorPath{
+				pattern: pat, expr: globToRegex(pat),
+			})
+		} else {
+			set.literals[pat] = struct{}{}
+		}
 	}
 
 	return set
 }
 
-// findMatch returns the index of the first entry whose regex matches path,
-// or whose pattern equals path exactly. Only checks forward matching
-// (existing pattern covers incoming path).
-func (set *pathSet) findMatch(path string) int {
-	if _, ok := set.literals[path]; ok {
-		for idx, entry := range set.paths {
-			if entry.pattern == path {
-				return idx
-			}
-		}
-	}
-
-	for idx, entry := range set.paths {
-		if entry.expr.MatchString(path) {
-			return idx
-		}
-	}
-
-	return -1
-}
-
 func (set *pathSet) matches(path string) bool {
-	return set.findMatch(path) >= 0
-}
-
-func (set *pathSet) removeAt(idx int) {
-	removed := set.paths[idx]
-	if !globTokenRe.MatchString(removed.pattern) {
-		delete(set.literals, removed.pattern)
+	if _, ok := set.literals[path]; ok {
+		return true
 	}
 
-	set.paths = slices.Delete(set.paths, idx, idx+1)
+	for _, entry := range set.globs {
+		if entry.expr.MatchString(path) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (set *pathSet) add(pattern string) {
-	expr := globToRegex(pattern)
+	if globTokenRe.MatchString(pattern) {
+		expr := globToRegex(pattern)
 
-	// Prune exact duplicates and non-glob entries subsumed by the new
-	// pattern. Glob-vs-glob subsumption is not attempted because matching
-	// a glob pattern string against another glob's regex does not reliably
-	// indicate language inclusion.
-	set.paths = slices.DeleteFunc(set.paths, func(existing apparmorPath) bool {
-		if existing.pattern == pattern {
-			return true
+		// Remove exact duplicate glob.
+		set.globs = slices.DeleteFunc(set.globs, func(existing apparmorPath) bool {
+			return existing.pattern == pattern
+		})
+
+		// Prune literals subsumed by this glob. Glob-vs-glob
+		// subsumption is not attempted because matching a glob
+		// pattern string against another glob's regex does not
+		// reliably indicate language inclusion.
+		for lit := range set.literals {
+			if expr.MatchString(lit) {
+				delete(set.literals, lit)
+			}
 		}
 
-		pruned := !globTokenRe.MatchString(existing.pattern) &&
-			expr.MatchString(existing.pattern)
-		if pruned {
-			delete(set.literals, existing.pattern)
-		}
-
-		return pruned
-	})
-
-	set.paths = append(set.paths, apparmorPath{
-		pattern: pattern,
-		expr:    expr,
-	})
-
-	if !globTokenRe.MatchString(pattern) {
+		set.globs = append(set.globs, apparmorPath{
+			pattern: pattern, expr: expr,
+		})
+	} else {
 		set.literals[pattern] = struct{}{}
 	}
 }
 
 func (set *pathSet) popExact(path string) bool {
-	for idx, entry := range set.paths {
+	if _, ok := set.literals[path]; ok {
+		delete(set.literals, path)
+
+		return true
+	}
+
+	for idx, entry := range set.globs {
 		if entry.pattern == path {
-			set.removeAt(idx)
+			set.globs = slices.Delete(set.globs, idx, idx+1)
 
 			return true
 		}
@@ -233,29 +232,32 @@ func (set *pathSet) popCoveredLiterals(glob string) []string {
 
 	var popped []string
 
-	set.paths = slices.DeleteFunc(set.paths, func(existing apparmorPath) bool {
-		matched := !globTokenRe.MatchString(existing.pattern) &&
-			expr.MatchString(existing.pattern)
-		if matched {
-			delete(set.literals, existing.pattern)
-
-			popped = append(popped, existing.pattern)
+	for lit := range set.literals {
+		if expr.MatchString(lit) {
+			popped = append(popped, lit)
 		}
+	}
 
-		return matched
-	})
+	for _, lit := range popped {
+		delete(set.literals, lit)
+	}
 
 	return popped
 }
 
 func (set *pathSet) patterns() []string {
-	if len(set.paths) == 0 {
+	total := len(set.globs) + len(set.literals)
+	if total == 0 {
 		return nil
 	}
 
-	ret := make([]string, 0, len(set.paths))
+	ret := make([]string, 0, total)
 
-	for _, entry := range set.paths {
+	for lit := range set.literals {
+		ret = append(ret, lit)
+	}
+
+	for _, entry := range set.globs {
 		ret = append(ret, entry.pattern)
 	}
 
@@ -324,10 +326,15 @@ func buildFsEntries(perms map[string]fsPermission) []fsPathEntry {
 	entries := make([]fsPathEntry, 0, len(perms))
 
 	for path, perm := range perms {
+		var expr *regexp.Regexp
+		if globTokenRe.MatchString(path) {
+			expr = globToRegex(path)
+		}
+
 		entries = append(entries, fsPathEntry{
 			path: path,
 			perm: perm,
-			expr: globToRegex(path),
+			expr: expr,
 		})
 	}
 
@@ -343,19 +350,16 @@ func matchIntersectPaths(left, right fsPathEntry) string {
 		return left.path
 	}
 
-	leftIsGlob := globTokenRe.MatchString(left.path)
-	rightIsGlob := globTokenRe.MatchString(right.path)
-
 	switch {
-	case !leftIsGlob && rightIsGlob:
+	case left.expr == nil && right.expr != nil:
 		if right.expr.MatchString(left.path) {
 			return left.path
 		}
-	case leftIsGlob && !rightIsGlob:
+	case left.expr != nil && right.expr == nil:
 		if left.expr.MatchString(right.path) {
 			return right.path
 		}
-	case leftIsGlob && rightIsGlob:
+	case left.expr != nil && right.expr != nil:
 		return narrowGlobs(left.path, right.path)
 	}
 

--- a/vendor/github.com/saschagrunert/security-profiles-merger/apparmor/merge.go
+++ b/vendor/github.com/saschagrunert/security-profiles-merger/apparmor/merge.go
@@ -120,99 +120,94 @@ func mergeTwo(left, right *Profile, mergeStrategy strategy) *Profile {
 	}
 }
 
-func mergeExecutable(left, right *ExecutableRules, mergeStrategy strategy) *ExecutableRules {
+func mergeOptional[T any](
+	left, right *T,
+	cloneFn func(*T) *T,
+	mergeFn func(*T, *T) *T,
+) *T {
 	if left == nil && right == nil {
 		return nil
 	}
 
 	if left == nil {
-		return cloneExecutable(right)
+		return cloneFn(right)
 	}
 
 	if right == nil {
-		return cloneExecutable(left)
+		return cloneFn(left)
 	}
 
-	return &ExecutableRules{
-		AllowedExecutables: mergeStrategy.mergePaths(
-			left.AllowedExecutables,
-			right.AllowedExecutables,
-		),
-		AllowedLibraries: mergeStrategy.mergePaths(
-			left.AllowedLibraries,
-			right.AllowedLibraries,
-		),
-	}
+	return mergeFn(left, right)
+}
+
+func mergeExecutable(left, right *ExecutableRules, mergeStrategy strategy) *ExecutableRules {
+	return mergeOptional(
+		left,
+		right,
+		cloneExecutable,
+		func(lhs, rhs *ExecutableRules) *ExecutableRules {
+			return &ExecutableRules{
+				AllowedExecutables: mergeStrategy.mergePaths(
+					lhs.AllowedExecutables,
+					rhs.AllowedExecutables,
+				),
+				AllowedLibraries: mergeStrategy.mergePaths(
+					lhs.AllowedLibraries,
+					rhs.AllowedLibraries,
+				),
+			}
+		},
+	)
 }
 
 func mergeFilesystem(left, right *FilesystemRules, mergeStrategy strategy) *FilesystemRules {
-	if left == nil && right == nil {
-		return nil
-	}
-
-	if left == nil {
-		return cloneFilesystem(right)
-	}
-
-	if right == nil {
-		return cloneFilesystem(left)
-	}
-
-	return mergeStrategy.mergeFilesystem(left, right)
+	return mergeOptional(
+		left,
+		right,
+		cloneFilesystem,
+		func(lhs, rhs *FilesystemRules) *FilesystemRules {
+			return mergeStrategy.mergeFilesystem(lhs, rhs)
+		},
+	)
 }
 
 func mergeNetwork(left, right *NetworkRules, mergeStrategy strategy) *NetworkRules {
-	if left == nil && right == nil {
-		return nil
-	}
-
-	if left == nil {
-		return cloneNetwork(right)
-	}
-
-	if right == nil {
-		return cloneNetwork(left)
-	}
-
-	result := &NetworkRules{
-		AllowRaw:  mergeStrategy.mergeBool(left.AllowRaw, right.AllowRaw),
-		Protocols: nil,
-	}
-
-	switch {
-	case left.Protocols != nil && right.Protocols != nil:
-		result.Protocols = &AllowedProtocols{
-			AllowTCP: mergeStrategy.mergeBool(left.Protocols.AllowTCP, right.Protocols.AllowTCP),
-			AllowUDP: mergeStrategy.mergeBool(left.Protocols.AllowUDP, right.Protocols.AllowUDP),
+	return mergeOptional(left, right, cloneNetwork, func(lhs, rhs *NetworkRules) *NetworkRules {
+		result := &NetworkRules{
+			AllowRaw:  mergeStrategy.mergeBool(lhs.AllowRaw, rhs.AllowRaw),
+			Protocols: nil,
 		}
-	case left.Protocols != nil:
-		result.Protocols = cloneProtocols(left.Protocols)
-	case right.Protocols != nil:
-		result.Protocols = cloneProtocols(right.Protocols)
-	}
 
-	return result
+		switch {
+		case lhs.Protocols != nil && rhs.Protocols != nil:
+			result.Protocols = &AllowedProtocols{
+				AllowTCP: mergeStrategy.mergeBool(lhs.Protocols.AllowTCP, rhs.Protocols.AllowTCP),
+				AllowUDP: mergeStrategy.mergeBool(lhs.Protocols.AllowUDP, rhs.Protocols.AllowUDP),
+			}
+		case lhs.Protocols != nil:
+			result.Protocols = cloneProtocols(lhs.Protocols)
+		case rhs.Protocols != nil:
+			result.Protocols = cloneProtocols(rhs.Protocols)
+		}
+
+		return result
+	})
 }
 
 func mergeCapabilities(left, right *CapabilityRules, mergeStrategy strategy) *CapabilityRules {
-	if left == nil && right == nil {
-		return nil
-	}
-
-	if left == nil {
-		return cloneCapabilities(right)
-	}
-
-	if right == nil {
-		return cloneCapabilities(left)
-	}
-
-	return &CapabilityRules{
-		AllowedCapabilities: mergeStrategy.mergeStrings(
-			left.AllowedCapabilities,
-			right.AllowedCapabilities,
-		),
-	}
+	return mergeOptional(
+		left,
+		right,
+		cloneCapabilities,
+		func(lhs, rhs *CapabilityRules) *CapabilityRules {
+			return &CapabilityRules{
+				AllowedCapabilities: mergeStrategy.mergeStrings(
+					lhs.AllowedCapabilities,
+					rhs.AllowedCapabilities,
+				),
+			}
+		},
+	)
 }
 
 // intersectStrategy implements intersection (AND) semantics.
@@ -228,11 +223,11 @@ func (intersectStrategy) mergePaths(left, right []string) []string {
 
 func (intersectStrategy) mergeBool(left, right *bool) *bool {
 	if left == nil {
-		return copyBool(right)
+		return merge.ClonePtr(right)
 	}
 
 	if right == nil {
-		return copyBool(left)
+		return merge.ClonePtr(left)
 	}
 
 	val := *left && *right
@@ -274,10 +269,11 @@ func (intersectStrategy) mergeFilesystem(left, right *FilesystemRules) *Filesyst
 	return collapseFsPerms(merged)
 }
 
-//nolint:nonamedreturns // names required to distinguish two same-typed returns
-func splitGlobEntries(entries []fsPathEntry) (globs, literals []fsPathEntry) {
+func splitGlobEntries(entries []fsPathEntry) ([]fsPathEntry, []fsPathEntry) {
+	var globs, literals []fsPathEntry
+
 	for _, entry := range entries {
-		if globTokenRe.MatchString(entry.path) {
+		if entry.expr != nil {
 			globs = append(globs, entry)
 		} else {
 			literals = append(literals, entry)
@@ -333,11 +329,11 @@ func (unionStrategy) mergePaths(left, right []string) []string {
 
 func (unionStrategy) mergeBool(left, right *bool) *bool {
 	if left == nil {
-		return copyBool(right)
+		return merge.ClonePtr(right)
 	}
 
 	if right == nil {
-		return copyBool(left)
+		return merge.ClonePtr(left)
 	}
 
 	val := *left || *right
@@ -414,13 +410,15 @@ func addReadOnlyPaths(
 			continue
 		}
 
-		if !globTokenRe.MatchString(path) && writeSet.matches(path) {
+		isGlob := globTokenRe.MatchString(path)
+
+		if !isGlob && writeSet.matches(path) {
 			rwSet.add(path)
 
 			continue
 		}
 
-		if globTokenRe.MatchString(path) {
+		if isGlob {
 			promoteCoveredLiterals(path, writeSet, rwSet)
 		}
 
@@ -443,13 +441,15 @@ func addWriteOnlyPaths(
 			continue
 		}
 
-		if !globTokenRe.MatchString(path) && readSet.matches(path) {
+		isGlob := globTokenRe.MatchString(path)
+
+		if !isGlob && readSet.matches(path) {
 			rwSet.add(path)
 
 			continue
 		}
 
-		if globTokenRe.MatchString(path) {
+		if isGlob {
 			promoteCoveredLiterals(path, readSet, rwSet)
 		}
 
@@ -526,16 +526,6 @@ func collapseFsPerms(perms map[string]fsPermission) *FilesystemRules {
 	}
 }
 
-func copyBool(boolVal *bool) *bool {
-	if boolVal == nil {
-		return nil
-	}
-
-	val := *boolVal
-
-	return &val
-}
-
 func cloneProfile(profile *Profile) *Profile {
 	clone := &Profile{
 		Executable:   nil,
@@ -580,7 +570,7 @@ func cloneFilesystem(fsRules *FilesystemRules) *FilesystemRules {
 
 func cloneNetwork(network *NetworkRules) *NetworkRules {
 	clone := &NetworkRules{
-		AllowRaw:  copyBool(network.AllowRaw),
+		AllowRaw:  merge.ClonePtr(network.AllowRaw),
 		Protocols: nil,
 	}
 
@@ -593,8 +583,8 @@ func cloneNetwork(network *NetworkRules) *NetworkRules {
 
 func cloneProtocols(proto *AllowedProtocols) *AllowedProtocols {
 	return &AllowedProtocols{
-		AllowTCP: copyBool(proto.AllowTCP),
-		AllowUDP: copyBool(proto.AllowUDP),
+		AllowTCP: merge.ClonePtr(proto.AllowTCP),
+		AllowUDP: merge.ClonePtr(proto.AllowUDP),
 	}
 }
 
@@ -623,47 +613,31 @@ func normalizeProfile(profile *Profile) *Profile {
 
 func deduplicateProfile(profile *Profile) {
 	if profile.Executable != nil {
-		profile.Executable.AllowedExecutables = deduplicatePaths(
+		profile.Executable.AllowedExecutables = merge.DeduplicateSlice(
 			profile.Executable.AllowedExecutables,
 		)
-		profile.Executable.AllowedLibraries = deduplicatePaths(
+		profile.Executable.AllowedLibraries = merge.DeduplicateSlice(
 			profile.Executable.AllowedLibraries,
 		)
 	}
 
 	if profile.Filesystem != nil {
-		profile.Filesystem.ReadOnlyPaths = deduplicatePaths(
+		profile.Filesystem.ReadOnlyPaths = merge.DeduplicateSlice(
 			profile.Filesystem.ReadOnlyPaths,
 		)
-		profile.Filesystem.WriteOnlyPaths = deduplicatePaths(
+		profile.Filesystem.WriteOnlyPaths = merge.DeduplicateSlice(
 			profile.Filesystem.WriteOnlyPaths,
 		)
-		profile.Filesystem.ReadWritePaths = deduplicatePaths(
+		profile.Filesystem.ReadWritePaths = merge.DeduplicateSlice(
 			profile.Filesystem.ReadWritePaths,
 		)
 	}
-}
 
-func deduplicatePaths(paths []string) []string {
-	if len(paths) == 0 {
-		return paths
+	if profile.Capabilities != nil {
+		profile.Capabilities.AllowedCapabilities = merge.DeduplicateSlice(
+			profile.Capabilities.AllowedCapabilities,
+		)
 	}
-
-	seen := make(map[string]struct{}, len(paths))
-
-	result := paths[:0]
-
-	for _, path := range paths {
-		if _, ok := seen[path]; ok {
-			continue
-		}
-
-		seen[path] = struct{}{}
-
-		result = append(result, path)
-	}
-
-	return result
 }
 
 func normalizeGlobPath(path string) string {

--- a/vendor/github.com/saschagrunert/security-profiles-merger/apparmor/types.go
+++ b/vendor/github.com/saschagrunert/security-profiles-merger/apparmor/types.go
@@ -53,8 +53,8 @@ type NetworkRules struct {
 
 // AllowedProtocols defines which network protocols are permitted.
 type AllowedProtocols struct {
-	AllowTCP *bool `json:"allowTcp,omitempty"` //nolint:tagliatelle // matches SPO CRD
-	AllowUDP *bool `json:"allowUdp,omitempty"` //nolint:tagliatelle // matches SPO CRD
+	AllowTCP *bool `json:"allowTcp,omitempty"`
+	AllowUDP *bool `json:"allowUdp,omitempty"`
 }
 
 // CapabilityRules defines which Linux capabilities are permitted.

--- a/vendor/github.com/saschagrunert/security-profiles-merger/apparmor/validate.go
+++ b/vendor/github.com/saschagrunert/security-profiles-merger/apparmor/validate.go
@@ -19,6 +19,9 @@ package apparmor
 import (
 	"errors"
 	"fmt"
+	"strings"
+
+	"github.com/saschagrunert/security-profiles-merger/internal/merge"
 )
 
 var (
@@ -34,8 +37,12 @@ var (
 	// more than once in AllowedCapabilities.
 	ErrDuplicateCapability = errors.New("duplicate capability")
 
+	// ErrUnknownCapability is returned when a profile contains a
+	// capability name not in the known set of Linux capabilities.
+	ErrUnknownCapability = errors.New("unknown capability")
+
 	// ErrEmptyPath is returned when a path rule contains an empty string.
-	ErrEmptyPath = errors.New("empty path")
+	ErrEmptyPath = merge.ErrEmptyPath
 
 	// ErrEmptyCapability is returned when a capability entry is an empty
 	// string.
@@ -46,10 +53,27 @@ var (
 	ErrDuplicateExecutablePath = errors.New("duplicate executable path")
 )
 
+func isKnownCapability(name string) bool {
+	switch strings.ToUpper(name) {
+	case "CHOWN", "DAC_OVERRIDE", "DAC_READ_SEARCH", "FOWNER", "FSETID",
+		"KILL", "SETGID", "SETUID", "SETPCAP", "LINUX_IMMUTABLE",
+		"NET_BIND_SERVICE", "NET_BROADCAST", "NET_ADMIN", "NET_RAW",
+		"IPC_LOCK", "IPC_OWNER", "SYS_MODULE", "SYS_RAWIO",
+		"SYS_CHROOT", "SYS_PTRACE", "SYS_PACCT", "SYS_ADMIN",
+		"SYS_BOOT", "SYS_NICE", "SYS_RESOURCE", "SYS_TIME",
+		"SYS_TTY_CONFIG", "MKNOD", "LEASE", "AUDIT_WRITE",
+		"AUDIT_CONTROL", "SETFCAP", "MAC_OVERRIDE", "MAC_ADMIN",
+		"SYSLOG", "WAKE_ALARM", "BLOCK_SUSPEND", "AUDIT_READ",
+		"PERFMON", "BPF", "CHECKPOINT_RESTORE":
+		return true
+	default:
+		return false
+	}
+}
+
 // Validate checks an AppArmor profile for structural issues.
-// Capability names are not validated against a fixed set because the
-// kernel may support capabilities unknown to this library. Filesystem
-// paths and executable paths are also not validated.
+// Capability names are validated against the known set of Linux
+// capabilities. Filesystem paths and executable paths are not validated.
 //
 // The checks catch issues that would produce confusing merge results:
 // duplicate paths across filesystem categories, which expand into
@@ -88,6 +112,13 @@ func Validate(profile *Profile) error {
 		}
 
 		err = validateDuplicateCapabilities(
+			profile.Capabilities.AllowedCapabilities,
+		)
+		if err != nil {
+			errs = append(errs, err)
+		}
+
+		err = validateCapabilityNames(
 			profile.Capabilities.AllowedCapabilities,
 		)
 		if err != nil {
@@ -243,6 +274,20 @@ func validateDuplicateCapabilities(caps []string) error {
 	return errors.Join(validateDuplicatesInSlice(
 		"AllowedCapabilities", caps, ErrDuplicateCapability,
 	)...)
+}
+
+func validateCapabilityNames(caps []string) error {
+	var errs []error
+
+	for idx, cap := range caps {
+		if cap != "" && !isKnownCapability(cap) {
+			errs = append(errs, fmt.Errorf(
+				"AllowedCapabilities[%d]: %q: %w", idx, cap, ErrUnknownCapability,
+			))
+		}
+	}
+
+	return errors.Join(errs...)
 }
 
 func validateDuplicatesInSlice(

--- a/vendor/github.com/saschagrunert/security-profiles-merger/internal/merge/merge.go
+++ b/vendor/github.com/saschagrunert/security-profiles-merger/internal/merge/merge.go
@@ -18,9 +18,11 @@ limitations under the License.
 package merge
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"slices"
+	"strings"
 )
 
 var (
@@ -28,6 +30,8 @@ var (
 	ErrNoProfiles = errors.New("at least one profile is required")
 	// ErrNilProfile is returned when a nil profile is provided.
 	ErrNilProfile = errors.New("profile must not be nil")
+	// ErrEmptyPath is returned when a path rule contains an empty string.
+	ErrEmptyPath = errors.New("empty path")
 )
 
 // Fold validates and merges a slice of profiles using pairwise reduction.
@@ -64,6 +68,65 @@ func Fold[T any](
 	}
 
 	return result, nil
+}
+
+// FormatDiffItems formats added and removed items as a prefixed diff string.
+func FormatDiffItems[T ~string](prefix string, removed, added []T) string {
+	items := make([]string, 0, len(removed)+len(added))
+
+	for _, r := range removed {
+		items = append(items, "-"+string(r))
+	}
+
+	for _, a := range added {
+		items = append(items, "+"+string(a))
+	}
+
+	return prefix + ":" + strings.Join(items, ",")
+}
+
+// DiffSlice returns elements added to and removed from left relative to right.
+// Both slices are treated as sets; duplicates within a slice are ignored.
+// Results are sorted. Returns nil, nil when the sets are equal.
+func DiffSlice[T cmp.Ordered](left, right []T) ([]T, []T) {
+	if len(left) == 0 && len(right) == 0 {
+		return nil, nil
+	}
+
+	leftSet := make(map[T]struct{}, len(left))
+	for _, item := range left {
+		leftSet[item] = struct{}{}
+	}
+
+	rightSet := make(map[T]struct{}, len(right))
+	for _, item := range right {
+		rightSet[item] = struct{}{}
+	}
+
+	var added, removed []T
+
+	for item := range leftSet {
+		if _, ok := rightSet[item]; !ok {
+			removed = append(removed, item)
+		}
+	}
+
+	for item := range rightSet {
+		if _, ok := leftSet[item]; !ok {
+			added = append(added, item)
+		}
+	}
+
+	slices.Sort(added)
+	slices.Sort(removed)
+
+	return added, removed
+}
+
+// SliceDiff represents added and removed items in a set-like slice.
+type SliceDiff[T comparable] struct {
+	Added   []T `json:"added,omitempty"`
+	Removed []T `json:"removed,omitempty"`
 }
 
 const smallSliceThreshold = 16
@@ -149,7 +212,7 @@ func unionSliceSmall[T comparable](left, right []T) []T {
 
 func unionSliceLarge[T comparable](left, right []T) []T {
 	result := make([]T, 0, len(left)+len(right))
-	seen := make(map[T]struct{})
+	seen := make(map[T]struct{}, len(left)+len(right))
 
 	for _, val := range left {
 		if _, ok := seen[val]; !ok {
@@ -162,6 +225,37 @@ func unionSliceLarge[T comparable](left, right []T) []T {
 		if _, ok := seen[val]; !ok {
 			seen[val] = struct{}{}
 			result = append(result, val)
+		}
+	}
+
+	return result
+}
+
+// ClonePtr returns a shallow copy of the pointed-to value, or nil if ptr is nil.
+func ClonePtr[T any](ptr *T) *T {
+	if ptr == nil {
+		return nil
+	}
+
+	val := *ptr
+
+	return &val
+}
+
+// DeduplicateSlice returns a new slice with duplicate elements removed,
+// preserving the order of first occurrence.
+func DeduplicateSlice[T comparable](items []T) []T {
+	if len(items) == 0 {
+		return items
+	}
+
+	seen := make(map[T]struct{}, len(items))
+	result := make([]T, 0, len(items))
+
+	for _, item := range items {
+		if _, ok := seen[item]; !ok {
+			seen[item] = struct{}{}
+			result = append(result, item)
 		}
 	}
 

--- a/vendor/github.com/saschagrunert/security-profiles-merger/seccomp/action.go
+++ b/vendor/github.com/saschagrunert/security-profiles-merger/seccomp/action.go
@@ -19,6 +19,11 @@ package seccomp
 
 import specs "github.com/opencontainers/runtime-spec/specs-go"
 
+// Restrictiveness levels, ordered from most restrictive (kill) to least
+// (allow). Notify sits between Errno and Trace: it blocks the syscall pending
+// a supervisor decision, making it more restrictive than Trace (which traps to
+// a ptrace tracer) but less restrictive than Errno (which fails outright
+// without supervisor intervention).
 const (
 	levelKillProcess = iota
 	levelKillThread
@@ -72,10 +77,10 @@ func restrictiveness(action specs.LinuxSeccompAction) int {
 		return levelTrap
 	case specs.ActErrno:
 		return levelErrno
-	case specs.ActTrace:
-		return levelTrace
 	case specs.ActNotify:
 		return levelNotify
+	case specs.ActTrace:
+		return levelTrace
 	case specs.ActLog:
 		return levelLog
 	case specs.ActAllow:

--- a/vendor/github.com/saschagrunert/security-profiles-merger/seccomp/diff.go
+++ b/vendor/github.com/saschagrunert/security-profiles-merger/seccomp/diff.go
@@ -1,0 +1,559 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package seccomp
+
+import (
+	"cmp"
+	"fmt"
+	"maps"
+	"slices"
+	"strconv"
+	"strings"
+
+	specs "github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/saschagrunert/security-profiles-merger/internal/merge"
+)
+
+// ProfileDiff describes the differences between two seccomp profiles.
+type ProfileDiff struct {
+	// Equal is true when the two profiles are identical.
+	Equal bool `json:"equal"`
+
+	// DefaultAction is set when the default actions differ.
+	DefaultAction *ActionDiff `json:"defaultAction,omitempty"`
+
+	// DefaultErrnoRet is set when the default errno return values differ.
+	DefaultErrnoRet *UintPtrDiff `json:"defaultErrnoRet,omitempty"`
+
+	// Architectures is set when the architecture lists differ.
+	Architectures *SliceDiff[specs.Arch] `json:"architectures,omitempty"`
+
+	// Flags is set when the flag lists differ.
+	Flags *SliceDiff[specs.LinuxSeccompFlag] `json:"flags,omitempty"`
+
+	// ListenerPath is set when the listener paths differ.
+	ListenerPath *StringDiff `json:"listenerPath,omitempty"`
+
+	// ListenerMetadata is set when the listener metadata differs.
+	ListenerMetadata *StringDiff `json:"listenerMetadata,omitempty"`
+
+	// Syscalls is set when the syscall entries differ.
+	Syscalls *SyscallsDiff `json:"syscalls,omitempty"`
+}
+
+// IsEqual returns whether the two compared profiles are identical.
+func (d ProfileDiff) IsEqual() bool { return d.Equal }
+
+// ActionDiff represents a change in seccomp action.
+type ActionDiff struct {
+	Left  specs.LinuxSeccompAction `json:"left"`
+	Right specs.LinuxSeccompAction `json:"right"`
+}
+
+// UintPtrDiff represents a change in an optional uint value.
+type UintPtrDiff struct {
+	Left  *uint `json:"left"`
+	Right *uint `json:"right"`
+}
+
+// StringDiff represents a change in a string value.
+type StringDiff struct {
+	Left  string `json:"left"`
+	Right string `json:"right"`
+}
+
+// SliceDiff represents added and removed items in a set-like slice.
+type SliceDiff[T comparable] = merge.SliceDiff[T]
+
+// SyscallsDiff describes differences in the syscall entries.
+type SyscallsDiff struct {
+	Added   []SyscallEntry  `json:"added,omitempty"`
+	Removed []SyscallEntry  `json:"removed,omitempty"`
+	Changed []SyscallChange `json:"changed,omitempty"`
+}
+
+// SyscallEntry represents a single syscall with its action and arguments.
+type SyscallEntry struct {
+	Name     string                   `json:"name"`
+	Action   specs.LinuxSeccompAction `json:"action"`
+	ErrnoRet *uint                    `json:"errnoRet,omitempty"`
+	Args     []specs.LinuxSeccompArg  `json:"args,omitempty"`
+}
+
+// SyscallChange represents a syscall present in both profiles with differences.
+type SyscallChange struct {
+	Name  string          `json:"name"`
+	Left  []SyscallDetail `json:"left"`
+	Right []SyscallDetail `json:"right"`
+}
+
+// SyscallDetail holds the action, errno, and args of a syscall entry.
+type SyscallDetail struct {
+	Action   specs.LinuxSeccompAction `json:"action"`
+	ErrnoRet *uint                    `json:"errnoRet,omitempty"`
+	Args     []specs.LinuxSeccompArg  `json:"args,omitempty"`
+}
+
+// Diff compares two seccomp profiles and returns a structured diff.
+// Unlike Intersect and Union, Diff does not validate profiles before comparing.
+// Returns ErrNilProfile if either profile is nil.
+func Diff(left, right *specs.LinuxSeccomp) (*ProfileDiff, error) {
+	if left == nil || right == nil {
+		return nil, ErrNilProfile
+	}
+
+	diff := &ProfileDiff{
+		Equal:            true,
+		DefaultAction:    nil,
+		DefaultErrnoRet:  nil,
+		Architectures:    nil,
+		Flags:            nil,
+		ListenerPath:     nil,
+		ListenerMetadata: nil,
+		Syscalls:         nil,
+	}
+
+	diffDefaultAction(diff, left, right)
+	diffDefaultErrnoRet(diff, left, right)
+	diffArchitectures(diff, left, right)
+	diffFlags(diff, left, right)
+	diffListener(diff, left, right)
+	diffSyscallEntries(diff, left, right)
+
+	return diff, nil
+}
+
+func diffDefaultAction(
+	diff *ProfileDiff, left, right *specs.LinuxSeccomp,
+) {
+	leftAction := canonicalAction(left.DefaultAction)
+	rightAction := canonicalAction(right.DefaultAction)
+
+	if leftAction != rightAction {
+		diff.Equal = false
+		diff.DefaultAction = &ActionDiff{
+			Left:  leftAction,
+			Right: rightAction,
+		}
+	}
+}
+
+func diffDefaultErrnoRet(
+	diff *ProfileDiff, left, right *specs.LinuxSeccomp,
+) {
+	if !equalUintPtr(left.DefaultErrnoRet, right.DefaultErrnoRet) {
+		diff.Equal = false
+		diff.DefaultErrnoRet = &UintPtrDiff{
+			Left:  left.DefaultErrnoRet,
+			Right: right.DefaultErrnoRet,
+		}
+	}
+}
+
+func equalUintPtr(first, second *uint) bool {
+	if first == nil && second == nil {
+		return true
+	}
+
+	if first == nil || second == nil {
+		return false
+	}
+
+	return *first == *second
+}
+
+func diffArchitectures(
+	diff *ProfileDiff, left, right *specs.LinuxSeccomp,
+) {
+	added, removed := merge.DiffSlice(left.Architectures, right.Architectures)
+	if len(added) > 0 || len(removed) > 0 {
+		diff.Equal = false
+		diff.Architectures = &SliceDiff[specs.Arch]{Added: added, Removed: removed}
+	}
+}
+
+func diffFlags(
+	diff *ProfileDiff, left, right *specs.LinuxSeccomp,
+) {
+	added, removed := merge.DiffSlice(left.Flags, right.Flags)
+	if len(added) > 0 || len(removed) > 0 {
+		diff.Equal = false
+		diff.Flags = &SliceDiff[specs.LinuxSeccompFlag]{Added: added, Removed: removed}
+	}
+}
+
+func diffListener(
+	diff *ProfileDiff, left, right *specs.LinuxSeccomp,
+) {
+	if left.ListenerPath != right.ListenerPath {
+		diff.Equal = false
+		diff.ListenerPath = &StringDiff{
+			Left:  left.ListenerPath,
+			Right: right.ListenerPath,
+		}
+	}
+
+	if left.ListenerMetadata != right.ListenerMetadata {
+		diff.Equal = false
+		diff.ListenerMetadata = &StringDiff{
+			Left:  left.ListenerMetadata,
+			Right: right.ListenerMetadata,
+		}
+	}
+}
+
+func diffSyscallEntries(
+	diff *ProfileDiff, left, right *specs.LinuxSeccomp,
+) {
+	leftMap := buildSyscallMap(left.Syscalls)
+	rightMap := buildSyscallMap(right.Syscalls)
+
+	var syscallsDiff SyscallsDiff
+
+	leftNames := slices.Sorted(maps.Keys(leftMap))
+	collectRemovedSyscalls(&syscallsDiff, leftNames, leftMap, rightMap)
+	collectAddedSyscalls(&syscallsDiff, slices.Sorted(maps.Keys(rightMap)), leftMap, rightMap)
+	collectChangedSyscalls(&syscallsDiff, leftNames, leftMap, rightMap)
+
+	if len(syscallsDiff.Added) > 0 ||
+		len(syscallsDiff.Removed) > 0 ||
+		len(syscallsDiff.Changed) > 0 {
+		diff.Equal = false
+		diff.Syscalls = &syscallsDiff
+	}
+}
+
+func collectRemovedSyscalls(
+	syscallsDiff *SyscallsDiff,
+	names []string,
+	leftMap, rightMap map[string][]SyscallEntry,
+) {
+	for _, name := range names {
+		if _, ok := rightMap[name]; !ok {
+			syscallsDiff.Removed = append(syscallsDiff.Removed, leftMap[name]...)
+		}
+	}
+}
+
+func collectAddedSyscalls(
+	syscallsDiff *SyscallsDiff,
+	names []string,
+	leftMap, rightMap map[string][]SyscallEntry,
+) {
+	for _, name := range names {
+		if _, ok := leftMap[name]; !ok {
+			syscallsDiff.Added = append(syscallsDiff.Added, rightMap[name]...)
+		}
+	}
+}
+
+func collectChangedSyscalls(
+	syscallsDiff *SyscallsDiff,
+	names []string,
+	leftMap, rightMap map[string][]SyscallEntry,
+) {
+	for _, name := range names {
+		leftEntries := leftMap[name]
+
+		rightEntries, ok := rightMap[name]
+		if !ok {
+			continue
+		}
+
+		if !equalSyscallEntrySlices(leftEntries, rightEntries) {
+			syscallsDiff.Changed = append(syscallsDiff.Changed, SyscallChange{
+				Name:  name,
+				Left:  entriesToDetails(leftEntries),
+				Right: entriesToDetails(rightEntries),
+			})
+		}
+	}
+}
+
+func buildSyscallMap(
+	syscalls []specs.LinuxSyscall,
+) map[string][]SyscallEntry {
+	result := make(map[string][]SyscallEntry)
+
+	for _, syscall := range syscalls {
+		action := canonicalAction(syscall.Action)
+
+		for _, name := range syscall.Names {
+			entry := SyscallEntry{
+				Name:     name,
+				Action:   action,
+				ErrnoRet: merge.ClonePtr(syscall.ErrnoRet),
+				Args:     slices.Clone(syscall.Args),
+			}
+
+			if !containsSyscallEntry(result[name], entry) {
+				result[name] = append(result[name], entry)
+			}
+		}
+	}
+
+	return result
+}
+
+func canonicalAction(
+	action specs.LinuxSeccompAction,
+) specs.LinuxSeccompAction {
+	if action == specs.ActKillThread {
+		return specs.ActKill
+	}
+
+	return action
+}
+
+func containsSyscallEntry(entries []SyscallEntry, entry SyscallEntry) bool {
+	for _, existing := range entries {
+		if equalSyscallEntry(existing, entry) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func entriesToDetails(entries []SyscallEntry) []SyscallDetail {
+	details := make([]SyscallDetail, 0, len(entries))
+
+	for _, entry := range entries {
+		details = append(details, SyscallDetail{
+			Action:   entry.Action,
+			ErrnoRet: entry.ErrnoRet,
+			Args:     entry.Args,
+		})
+	}
+
+	return details
+}
+
+func equalSyscallEntrySlices(left, right []SyscallEntry) bool {
+	if len(left) != len(right) {
+		return false
+	}
+
+	left = slices.Clone(left)
+	right = slices.Clone(right)
+
+	sortSyscallEntries(left)
+	sortSyscallEntries(right)
+
+	for idx := range left {
+		if !equalSyscallEntry(left[idx], right[idx]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func sortSyscallEntries(entries []SyscallEntry) {
+	slices.SortFunc(entries, func(left, right SyscallEntry) int {
+		if result := cmp.Compare(left.Action, right.Action); result != 0 {
+			return result
+		}
+
+		if result := compareUintPtr(left.ErrnoRet, right.ErrnoRet); result != 0 {
+			return result
+		}
+
+		return compareSyscallArgs(left.Args, right.Args)
+	})
+}
+
+func compareUintPtr(left, right *uint) int {
+	if left == nil && right == nil {
+		return 0
+	}
+
+	if left == nil {
+		return -1
+	}
+
+	if right == nil {
+		return 1
+	}
+
+	return cmp.Compare(*left, *right)
+}
+
+func compareSyscallArgs(left, right []specs.LinuxSeccompArg) int {
+	for idx := range min(len(left), len(right)) {
+		if result := cmp.Compare(left[idx].Index, right[idx].Index); result != 0 {
+			return result
+		}
+
+		if result := cmp.Compare(left[idx].Value, right[idx].Value); result != 0 {
+			return result
+		}
+
+		if result := cmp.Compare(left[idx].ValueTwo, right[idx].ValueTwo); result != 0 {
+			return result
+		}
+
+		if result := cmp.Compare(left[idx].Op, right[idx].Op); result != 0 {
+			return result
+		}
+	}
+
+	return cmp.Compare(len(left), len(right))
+}
+
+func equalSyscallEntry(first, second SyscallEntry) bool {
+	if first.Action != second.Action {
+		return false
+	}
+
+	if !equalUintPtr(first.ErrnoRet, second.ErrnoRet) {
+		return false
+	}
+
+	return slices.Equal(first.Args, second.Args)
+}
+
+// FormatDiff returns a human-readable representation of a seccomp profile diff.
+func FormatDiff(diff *ProfileDiff) string {
+	if diff == nil {
+		return "Diff{<nil>}"
+	}
+
+	if diff.Equal {
+		return "Diff{equal}"
+	}
+
+	var parts []string
+
+	parts = appendScalarDiffs(parts, diff)
+	parts = appendSliceDiffs(parts, diff)
+	parts = appendListenerDiffs(parts, diff)
+
+	if diff.Syscalls != nil {
+		parts = append(parts, formatSyscallsDiff(diff.Syscalls)...)
+	}
+
+	return fmt.Sprintf("Diff{%s}", strings.Join(parts, " "))
+}
+
+func appendScalarDiffs(parts []string, diff *ProfileDiff) []string {
+	if diff.DefaultAction != nil {
+		parts = append(parts, fmt.Sprintf(
+			"default:%s->%s",
+			diff.DefaultAction.Left,
+			diff.DefaultAction.Right,
+		))
+	}
+
+	if diff.DefaultErrnoRet != nil {
+		parts = append(parts, fmt.Sprintf(
+			"defaultErrno:%s->%s",
+			formatUintPtr(diff.DefaultErrnoRet.Left),
+			formatUintPtr(diff.DefaultErrnoRet.Right),
+		))
+	}
+
+	return parts
+}
+
+func appendSliceDiffs(parts []string, diff *ProfileDiff) []string {
+	if diff.Architectures != nil {
+		parts = append(parts, formatSliceDiff("arch", diff.Architectures))
+	}
+
+	if diff.Flags != nil {
+		parts = append(parts, formatSliceDiff("flags", diff.Flags))
+	}
+
+	return parts
+}
+
+func appendListenerDiffs(parts []string, diff *ProfileDiff) []string {
+	if diff.ListenerPath != nil {
+		parts = append(parts, fmt.Sprintf(
+			"listener:%s->%s",
+			formatQuotedOrNone(diff.ListenerPath.Left),
+			formatQuotedOrNone(diff.ListenerPath.Right),
+		))
+	}
+
+	if diff.ListenerMetadata != nil {
+		parts = append(parts, fmt.Sprintf(
+			"listenerMeta:%s->%s",
+			formatQuotedOrNone(diff.ListenerMetadata.Left),
+			formatQuotedOrNone(diff.ListenerMetadata.Right),
+		))
+	}
+
+	return parts
+}
+
+func formatUintPtr(val *uint) string {
+	if val == nil {
+		return "<nil>"
+	}
+
+	return strconv.FormatUint(uint64(*val), 10)
+}
+
+func formatQuotedOrNone(str string) string {
+	if str == "" {
+		return "<none>"
+	}
+
+	return str
+}
+
+func formatSliceDiff[T ~string](prefix string, sliceDiff *SliceDiff[T]) string {
+	return merge.FormatDiffItems(prefix, sliceDiff.Removed, sliceDiff.Added)
+}
+
+func formatSyscallsDiff(syscallsDiff *SyscallsDiff) []string {
+	parts := make([]string, 0,
+		len(syscallsDiff.Removed)+len(syscallsDiff.Added)+len(syscallsDiff.Changed),
+	)
+
+	for _, entry := range syscallsDiff.Removed {
+		parts = append(parts, "-"+entry.Name+"->"+string(entry.Action))
+	}
+
+	for _, entry := range syscallsDiff.Added {
+		parts = append(parts, "+"+entry.Name+"->"+string(entry.Action))
+	}
+
+	for _, change := range syscallsDiff.Changed {
+		parts = append(parts, fmt.Sprintf(
+			"~%s:%s->%s",
+			change.Name,
+			formatDetailActions(change.Left),
+			formatDetailActions(change.Right),
+		))
+	}
+
+	return parts
+}
+
+func formatDetailActions(details []SyscallDetail) string {
+	actions := make([]string, 0, len(details))
+
+	for _, detail := range details {
+		actions = append(actions, string(detail.Action))
+	}
+
+	return strings.Join(actions, ",")
+}

--- a/vendor/github.com/saschagrunert/security-profiles-merger/seccomp/merge.go
+++ b/vendor/github.com/saschagrunert/security-profiles-merger/seccomp/merge.go
@@ -98,6 +98,11 @@ func foldProfiles(
 		return nil, fmt.Errorf("fold: %w", err)
 	}
 
+	// Remove before sort: SortFunc below accesses Names[0] unconditionally.
+	result.Syscalls = slices.DeleteFunc(result.Syscalls, func(s specs.LinuxSyscall) bool {
+		return len(s.Names) == 0
+	})
+
 	slices.SortFunc(result.Syscalls, func(a, b specs.LinuxSyscall) int {
 		return cmp.Compare(a.Names[0], b.Names[0])
 	})
@@ -114,23 +119,25 @@ func mergeTwo(
 ) *specs.LinuxSeccomp {
 	pick := strategy.pick
 
+	defaultErrnoRet := mergeErrnoRet(
+		left.DefaultErrnoRet,
+		right.DefaultErrnoRet,
+		left.DefaultAction,
+		right.DefaultAction,
+		pick,
+	)
+
 	merged := &specs.LinuxSeccomp{
-		DefaultAction: pick(left.DefaultAction, right.DefaultAction),
-		DefaultErrnoRet: mergeErrnoRet(
-			left.DefaultErrnoRet,
-			right.DefaultErrnoRet,
-			left.DefaultAction,
-			right.DefaultAction,
-			pick,
-		),
-		Syscalls:         mergeSyscalls(left, right, strategy),
+		DefaultAction:    pick(left.DefaultAction, right.DefaultAction),
+		DefaultErrnoRet:  defaultErrnoRet,
+		Syscalls:         mergeSyscalls(left, right, strategy, defaultErrnoRet),
 		ListenerPath:     left.ListenerPath,
 		ListenerMetadata: left.ListenerMetadata,
 	}
 
 	if strategy.isIntersect {
-		merged.Architectures = intersectArchitectures(left.Architectures, right.Architectures)
-		merged.Flags = intersectFlags(left.Flags, right.Flags)
+		merged.Architectures = intersectWithEmpty(left.Architectures, right.Architectures)
+		merged.Flags = intersectWithEmpty(left.Flags, right.Flags)
 	} else {
 		merged.Architectures = merge.UnionSlice(left.Architectures, right.Architectures)
 		merged.Flags = merge.UnionSlice(left.Flags, right.Flags)
@@ -139,19 +146,7 @@ func mergeTwo(
 	return merged
 }
 
-func intersectFlags(left, right []specs.LinuxSeccompFlag) []specs.LinuxSeccompFlag {
-	if len(left) == 0 {
-		return slices.Clone(right)
-	}
-
-	if len(right) == 0 {
-		return slices.Clone(left)
-	}
-
-	return merge.IntersectSlice(left, right)
-}
-
-func intersectArchitectures(left, right []specs.Arch) []specs.Arch {
+func intersectWithEmpty[T comparable](left, right []T) []T {
 	if len(left) == 0 {
 		return slices.Clone(right)
 	}
@@ -174,8 +169,8 @@ func intersectArchitectures(left, right []specs.Arch) []specs.Arch {
 // Validate on the enclosing profile first.
 func UnionSyscalls(left, right []specs.LinuxSyscall) []specs.LinuxSyscall {
 	strategy := mergeStrategy{pick: LessRestrictive, isIntersect: false}
-	leftMap := normalizeSyscallList(left, strategy)
-	rightMap := normalizeSyscallList(right, strategy)
+	leftMap := normalizeSyscallList(left)
+	rightMap := normalizeSyscallList(right)
 
 	result := make([]specs.LinuxSyscall, 0, len(leftMap)+len(rightMap))
 
@@ -212,8 +207,8 @@ func UnionSyscalls(left, right []specs.LinuxSyscall) []specs.LinuxSyscall {
 // Validate on the enclosing profile first.
 func IntersectSyscalls(left, right []specs.LinuxSyscall) []specs.LinuxSyscall {
 	strategy := mergeStrategy{pick: MoreRestrictive, isIntersect: true}
-	leftMap := normalizeSyscallList(left, strategy)
-	rightMap := normalizeSyscallList(right, strategy)
+	leftMap := normalizeSyscallList(left)
+	rightMap := normalizeSyscallList(right)
 
 	result := make([]specs.LinuxSyscall, 0, min(len(leftMap), len(rightMap)))
 
@@ -237,17 +232,19 @@ func cloneSyscall(syscall *specs.LinuxSyscall) specs.LinuxSyscall {
 		Args:   slices.Clone(syscall.Args),
 	}
 
-	if syscall.ErrnoRet != nil {
-		clone.ErrnoRet = copyErrnoRet(syscall.ErrnoRet)
-	}
+	clone.ErrnoRet = merge.ClonePtr(syscall.ErrnoRet)
 
 	return clone
 }
 
+// normalizeSyscallList splits multi-name entries into one-name-per-entry and
+// merges duplicates. The most permissive action wins to capture the profile's
+// full permission envelope, regardless of entry ordering.
 func normalizeSyscallList(
 	syscalls []specs.LinuxSyscall,
-	strategy mergeStrategy,
 ) map[string]*specs.LinuxSyscall {
+	withinProfile := mergeStrategy{pick: LessRestrictive, isIntersect: false}
+
 	normalized := make(map[string]*specs.LinuxSyscall)
 
 	for idx := range syscalls {
@@ -257,12 +254,12 @@ func normalizeSyscallList(
 			single := &specs.LinuxSyscall{
 				Names:    []string{name},
 				Action:   entry.Action,
-				ErrnoRet: entry.ErrnoRet,
-				Args:     entry.Args,
+				ErrnoRet: merge.ClonePtr(entry.ErrnoRet),
+				Args:     slices.Clone(entry.Args),
 			}
 
 			if existing, ok := normalized[name]; ok {
-				normalized[name] = pickSyscall(existing, single, strategy)
+				normalized[name] = pickSyscall(existing, single, withinProfile)
 			} else {
 				normalized[name] = single
 			}
@@ -274,18 +271,18 @@ func normalizeSyscallList(
 
 func normalizeSyscalls(
 	profile *specs.LinuxSeccomp,
-	strategy mergeStrategy,
 ) map[string]*specs.LinuxSyscall {
-	return normalizeSyscallList(profile.Syscalls, strategy)
+	return normalizeSyscallList(profile.Syscalls)
 }
 
 func mergeSyscalls(
 	left, right *specs.LinuxSeccomp,
 	strategy mergeStrategy,
+	mergedDefaultErrnoRet *uint,
 ) []specs.LinuxSyscall {
 	pick := strategy.pick
-	leftMap := normalizeSyscalls(left, strategy)
-	rightMap := normalizeSyscalls(right, strategy)
+	leftMap := normalizeSyscalls(left)
+	rightMap := normalizeSyscalls(right)
 
 	mergedDefault := pick(left.DefaultAction, right.DefaultAction)
 
@@ -295,7 +292,8 @@ func mergeSyscalls(
 		entry := mergeSyscallEntry(
 			leftEntry, rightMap[name],
 			left.DefaultAction, right.DefaultAction,
-			mergedDefault, strategy,
+			left.DefaultErrnoRet, right.DefaultErrnoRet,
+			mergedDefault, mergedDefaultErrnoRet, strategy,
 		)
 		if entry != nil {
 			result = append(result, *entry)
@@ -310,7 +308,8 @@ func mergeSyscalls(
 		entry := mergeSyscallEntry(
 			nil, rightEntry,
 			left.DefaultAction, right.DefaultAction,
-			mergedDefault, strategy,
+			left.DefaultErrnoRet, right.DefaultErrnoRet,
+			mergedDefault, mergedDefaultErrnoRet, strategy,
 		)
 		if entry != nil {
 			result = append(result, *entry)
@@ -322,28 +321,42 @@ func mergeSyscalls(
 
 func mergeSyscallEntry(
 	leftEntry, rightEntry *specs.LinuxSyscall,
-	leftDefault, rightDefault, mergedDefault specs.LinuxSeccompAction,
+	leftDefault, rightDefault specs.LinuxSeccompAction,
+	leftDefaultErrnoRet, rightDefaultErrnoRet *uint,
+	mergedDefault specs.LinuxSeccompAction,
+	mergedDefaultErrnoRet *uint,
 	strategy mergeStrategy,
 ) *specs.LinuxSyscall {
 	pick := strategy.pick
 
 	switch {
 	case leftEntry != nil && rightEntry != nil:
-		return mergeMatchedSyscall(leftEntry, rightEntry, mergedDefault, strategy)
+		return mergeMatchedSyscall(
+			leftEntry, rightEntry, mergedDefault, mergedDefaultErrnoRet, strategy,
+		)
 	case leftEntry != nil:
-		return mergeUnmatchedSyscall(leftEntry, rightDefault, mergedDefault, pick)
+		return mergeUnmatchedSyscall(
+			leftEntry, rightDefault, rightDefaultErrnoRet,
+			mergedDefault, mergedDefaultErrnoRet, pick,
+		)
 	default:
-		return mergeUnmatchedSyscall(rightEntry, leftDefault, mergedDefault, pick)
+		return mergeUnmatchedSyscall(
+			rightEntry, leftDefault, leftDefaultErrnoRet,
+			mergedDefault, mergedDefaultErrnoRet, pick,
+		)
 	}
 }
 
 func mergeMatchedSyscall(
 	left, right *specs.LinuxSyscall,
 	mergedDefault specs.LinuxSeccompAction,
+	mergedDefaultErrnoRet *uint,
 	strategy mergeStrategy,
 ) *specs.LinuxSyscall {
 	merged := pickSyscall(left, right, strategy)
-	if !actionsEquivalent(merged.Action, mergedDefault) || len(merged.Args) > 0 {
+	if !actionsEquivalent(merged.Action, mergedDefault) ||
+		len(merged.Args) > 0 ||
+		!equalUintPtr(merged.ErrnoRet, mergedDefaultErrnoRet) {
 		return merged
 	}
 
@@ -352,22 +365,26 @@ func mergeMatchedSyscall(
 
 func mergeUnmatchedSyscall(
 	entry *specs.LinuxSyscall,
-	otherDefault, mergedDefault specs.LinuxSeccompAction,
+	otherDefault specs.LinuxSeccompAction,
+	otherDefaultErrnoRet *uint,
+	mergedDefault specs.LinuxSeccompAction,
+	mergedDefaultErrnoRet *uint,
 	pick func(first, second specs.LinuxSeccompAction) specs.LinuxSeccompAction,
 ) *specs.LinuxSyscall {
 	effective := pick(entry.Action, otherDefault)
-	if !actionsEquivalent(effective, mergedDefault) || len(entry.Args) > 0 {
-		// When the picked action came from the other side's default,
-		// clear ErrnoRet because the default action's ErrnoRet is
-		// already captured in the profile-level DefaultErrnoRet.
-		// Safe to use actionsEquivalent here: pick() returns entry.Action
-		// when levels tie, and the only same-level pair (ActKill/ActKillThread)
-		// ignores ErrnoRet.
-		var errnoRet *uint
-		if actionsEquivalent(effective, entry.Action) {
-			errnoRet = copyErrnoRet(entry.ErrnoRet)
-		}
 
+	// pick() returns entry.Action when levels tie, and the only
+	// same-level pair (ActKill/ActKillThread) ignores ErrnoRet.
+	var errnoRet *uint
+	if actionsEquivalent(effective, entry.Action) {
+		errnoRet = merge.ClonePtr(entry.ErrnoRet)
+	} else {
+		errnoRet = merge.ClonePtr(otherDefaultErrnoRet)
+	}
+
+	if !actionsEquivalent(effective, mergedDefault) ||
+		len(entry.Args) > 0 ||
+		!equalUintPtr(errnoRet, mergedDefaultErrnoRet) {
 		return &specs.LinuxSyscall{
 			Names:    slices.Clone(entry.Names),
 			Action:   effective,
@@ -391,11 +408,10 @@ func pickSyscall(
 		Action: pickedAction,
 	}
 
-	// Uses == (not actionsEquivalent) to check which literal input pick returned.
-	if pickedAction == left.Action {
-		result.ErrnoRet = copyErrnoRet(left.ErrnoRet)
+	if actionsEquivalent(pickedAction, left.Action) {
+		result.ErrnoRet = merge.ClonePtr(left.ErrnoRet)
 	} else {
-		result.ErrnoRet = copyErrnoRet(right.ErrnoRet)
+		result.ErrnoRet = merge.ClonePtr(right.ErrnoRet)
 	}
 
 	args, denied := mergeArgs(left.Args, right.Args, strategy.isIntersect)
@@ -485,9 +501,10 @@ func mergeArgsByIndex(
 func sortArgs(args []specs.LinuxSeccompArg) {
 	slices.SortFunc(args, func(left, right specs.LinuxSeccompArg) int {
 		return cmp.Or(
+			cmp.Compare(left.Index, right.Index),
 			cmp.Compare(left.Value, right.Value),
 			cmp.Compare(left.ValueTwo, right.ValueTwo),
-			cmp.Compare(string(left.Op), string(right.Op)),
+			cmp.Compare(left.Op, right.Op),
 		)
 	})
 }
@@ -507,27 +524,30 @@ func groupArgsByIndex(
 // unionArgs combines argument filters from two syscall entries. No args means
 // "match unconditionally", which is already the most permissive state.
 // Unioning with an unconstrained side yields unconstrained.
+//
+// When both sides have identical args the shared filters are preserved.
+// When args differ, the result drops to unconstrained (no args) because
+// OCI seccomp AND-joins args within a single entry and cannot express OR.
+// Dropping args over-approximates in the permissive direction, which is
+// correct for union semantics.
 func unionArgs(
 	leftArgs, rightArgs []specs.LinuxSeccompArg,
 ) ([]specs.LinuxSeccompArg, bool) {
-	if len(leftArgs) == 0 && len(rightArgs) == 0 {
-		return nil, false
-	}
-
 	if len(leftArgs) == 0 || len(rightArgs) == 0 {
 		return nil, false
 	}
 
-	combined := make([]specs.LinuxSeccompArg, 0, len(leftArgs)+len(rightArgs))
-	combined = append(combined, leftArgs...)
+	leftSorted := slices.Clone(leftArgs)
+	rightSorted := slices.Clone(rightArgs)
 
-	for _, rightArg := range rightArgs {
-		if !slices.Contains(leftArgs, rightArg) {
-			combined = append(combined, rightArg)
-		}
+	sortArgs(leftSorted)
+	sortArgs(rightSorted)
+
+	if slices.Equal(leftSorted, rightSorted) {
+		return slices.Clone(leftArgs), false
 	}
 
-	return combined, false
+	return nil, false
 }
 
 func mergeErrnoRet(
@@ -538,28 +558,24 @@ func mergeErrnoRet(
 	// When both actions are equivalent, leftmost wins unconditionally,
 	// even if left's ErrnoRet is nil (meaning "no errno override").
 	if actionsEquivalent(leftAction, rightAction) {
-		return copyErrnoRet(leftRet)
+		return merge.ClonePtr(leftRet)
 	}
 
 	picked := pick(leftAction, rightAction)
 
 	if actionsEquivalent(picked, leftAction) {
-		return copyErrnoRet(leftRet)
+		return merge.ClonePtr(leftRet)
 	}
 
-	return copyErrnoRet(rightRet)
+	return merge.ClonePtr(rightRet)
 }
 
 func cloneProfile(profile *specs.LinuxSeccomp) *specs.LinuxSeccomp {
 	clone := &specs.LinuxSeccomp{
 		DefaultAction:    profile.DefaultAction,
+		DefaultErrnoRet:  merge.ClonePtr(profile.DefaultErrnoRet),
 		ListenerPath:     profile.ListenerPath,
 		ListenerMetadata: profile.ListenerMetadata,
-	}
-
-	if profile.DefaultErrnoRet != nil {
-		ret := *profile.DefaultErrnoRet
-		clone.DefaultErrnoRet = &ret
 	}
 
 	clone.Architectures = slices.Clone(profile.Architectures)
@@ -571,14 +587,4 @@ func cloneProfile(profile *specs.LinuxSeccomp) *specs.LinuxSeccomp {
 	}
 
 	return clone
-}
-
-func copyErrnoRet(ret *uint) *uint {
-	if ret == nil {
-		return nil
-	}
-
-	val := *ret
-
-	return &val
 }

--- a/vendor/github.com/saschagrunert/security-profiles-merger/seccomp/string.go
+++ b/vendor/github.com/saschagrunert/security-profiles-merger/seccomp/string.go
@@ -70,6 +70,48 @@ func FormatProfile(profile *specs.LinuxSeccomp) string {
 	return fmt.Sprintf("Profile{%s}", strings.Join(parts, " "))
 }
 
+// String returns a human-readable representation of the syscall entry.
+func (e SyscallEntry) String() string {
+	action := string(e.Action)
+	if e.ErrnoRet != nil {
+		action = fmt.Sprintf("%s(errno:%d)", action, *e.ErrnoRet)
+	}
+
+	if len(e.Args) == 0 {
+		return e.Name + "->" + action
+	}
+
+	return fmt.Sprintf("%s(%s)->%s", e.Name, formatArgs(e.Args), action)
+}
+
+// String returns a human-readable representation of the syscall detail.
+func (d SyscallDetail) String() string {
+	action := string(d.Action)
+	if d.ErrnoRet != nil {
+		action = fmt.Sprintf("%s(errno:%d)", action, *d.ErrnoRet)
+	}
+
+	if len(d.Args) == 0 {
+		return action
+	}
+
+	return fmt.Sprintf("(%s)->%s", formatArgs(d.Args), action)
+}
+
+func formatArgs(args []specs.LinuxSeccompArg) string {
+	parts := make([]string, len(args))
+
+	for idx, arg := range args {
+		if arg.Op == specs.OpMaskedEqual {
+			parts[idx] = fmt.Sprintf("[%d]%s:%d:%d", arg.Index, arg.Op, arg.Value, arg.ValueTwo)
+		} else {
+			parts[idx] = fmt.Sprintf("[%d]%s:%d", arg.Index, arg.Op, arg.Value)
+		}
+	}
+
+	return strings.Join(parts, ",")
+}
+
 func formatSyscall(syscall specs.LinuxSyscall) string {
 	names := strings.Join(syscall.Names, ",")
 	action := string(syscall.Action)
@@ -82,14 +124,5 @@ func formatSyscall(syscall specs.LinuxSyscall) string {
 		return names + "->" + action
 	}
 
-	args := make([]string, len(syscall.Args))
-	for idx, arg := range syscall.Args {
-		if arg.Op == specs.OpMaskedEqual {
-			args[idx] = fmt.Sprintf("[%d]%s:%d:%d", arg.Index, arg.Op, arg.Value, arg.ValueTwo)
-		} else {
-			args[idx] = fmt.Sprintf("[%d]%s:%d", arg.Index, arg.Op, arg.Value)
-		}
-	}
-
-	return fmt.Sprintf("%s(%s)->%s", names, strings.Join(args, ","), action)
+	return fmt.Sprintf("%s(%s)->%s", names, formatArgs(syscall.Args), action)
 }

--- a/vendor/github.com/saschagrunert/security-profiles-merger/seccomp/validate.go
+++ b/vendor/github.com/saschagrunert/security-profiles-merger/seccomp/validate.go
@@ -24,6 +24,8 @@ import (
 	specs "github.com/opencontainers/runtime-spec/specs-go"
 )
 
+const maxSyscallArgIndex = 5
+
 var (
 	// ErrUnknownAction is returned when a profile contains an unrecognized
 	// seccomp action.
@@ -36,6 +38,24 @@ var (
 	// ErrDuplicateSyscallName is returned when the same syscall name
 	// appears in more than one syscall entry.
 	ErrDuplicateSyscallName = errors.New("duplicate syscall name")
+	// ErrUnknownOperator is returned when a syscall arg contains an
+	// unrecognized comparison operator.
+	ErrUnknownOperator = errors.New("unknown seccomp operator")
+	// ErrArgIndexOutOfRange is returned when a syscall arg index exceeds
+	// the maximum (5).
+	ErrArgIndexOutOfRange = errors.New("syscall arg index out of range")
+	// ErrUnknownArch is returned when a profile contains an unrecognized
+	// architecture.
+	ErrUnknownArch = errors.New("unknown architecture")
+	// ErrDuplicateArch is returned when the same architecture appears
+	// more than once.
+	ErrDuplicateArch = errors.New("duplicate architecture")
+	// ErrUnknownFlag is returned when a profile contains an unrecognized
+	// seccomp flag.
+	ErrUnknownFlag = errors.New("unknown seccomp flag")
+	// ErrDuplicateFlag is returned when the same flag appears more than
+	// once.
+	ErrDuplicateFlag = errors.New("duplicate seccomp flag")
 )
 
 // Validate checks that a seccomp profile contains only known actions.
@@ -81,11 +101,12 @@ func Validate(profile *specs.LinuxSeccomp) error {
 }
 
 // ValidateStrict performs all checks from Validate and additionally detects
-// duplicate syscall names across entries. The OCI runtime-spec allows the
-// same syscall to appear in multiple entries (for example with different
-// argument filters), so the merge path uses Validate which permits this.
-// ValidateStrict is intended for user-authored profiles where duplicates
-// are likely mistakes.
+// duplicate syscall names across entries, unknown architectures, unknown
+// flags, unknown arg operators, and out-of-range arg indices. The OCI
+// runtime-spec allows the same syscall to appear in multiple entries (for
+// example with different argument filters), so the merge path uses Validate
+// which permits this. ValidateStrict is intended for user-authored profiles
+// where duplicates are likely mistakes.
 func ValidateStrict(profile *specs.LinuxSeccomp) error {
 	var errs []error
 
@@ -99,6 +120,31 @@ func ValidateStrict(profile *specs.LinuxSeccomp) error {
 	}
 
 	err = validateDuplicateSyscallNames(profile.Syscalls)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	err = validateArchitectures(profile.Architectures)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	err = validateDuplicateArchitectures(profile.Architectures)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	err = validateFlags(profile.Flags)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	err = validateDuplicateFlags(profile.Flags)
+	if err != nil {
+		errs = append(errs, err)
+	}
+
+	err = validateSyscallArgs(profile.Syscalls)
 	if err != nil {
 		errs = append(errs, err)
 	}
@@ -133,4 +179,131 @@ func validateAction(action specs.LinuxSeccompAction, context string) error {
 	}
 
 	return nil
+}
+
+func isKnownOperator(op specs.LinuxSeccompOperator) bool {
+	switch op {
+	case specs.OpNotEqual, specs.OpLessThan, specs.OpLessEqual,
+		specs.OpEqualTo, specs.OpGreaterEqual, specs.OpGreaterThan,
+		specs.OpMaskedEqual:
+		return true
+	default:
+		return false
+	}
+}
+
+func isKnownArch(arch specs.Arch) bool {
+	switch arch {
+	case specs.ArchX86, specs.ArchX86_64, specs.ArchX32,
+		specs.ArchARM, specs.ArchAARCH64,
+		specs.ArchMIPS, specs.ArchMIPS64, specs.ArchMIPS64N32,
+		specs.ArchMIPSEL, specs.ArchMIPSEL64, specs.ArchMIPSEL64N32,
+		specs.ArchPPC, specs.ArchPPC64, specs.ArchPPC64LE,
+		specs.ArchS390, specs.ArchS390X,
+		specs.ArchPARISC, specs.ArchPARISC64,
+		specs.ArchRISCV64, specs.ArchLOONGARCH64,
+		specs.ArchM68K, specs.ArchSH, specs.ArchSHEB:
+		return true
+	default:
+		return false
+	}
+}
+
+func isKnownFlag(flag specs.LinuxSeccompFlag) bool {
+	switch flag {
+	case specs.LinuxSeccompFlagLog,
+		specs.LinuxSeccompFlagSpecAllow,
+		specs.LinuxSeccompFlagWaitKillableRecv:
+		return true
+	default:
+		return false
+	}
+}
+
+func validateArchitectures(archs []specs.Arch) error {
+	var errs []error
+
+	for _, arch := range archs {
+		if !isKnownArch(arch) {
+			errs = append(errs, fmt.Errorf(
+				"architecture: %w %q", ErrUnknownArch, arch,
+			))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func validateFlags(flags []specs.LinuxSeccompFlag) error {
+	var errs []error
+
+	for _, flag := range flags {
+		if !isKnownFlag(flag) {
+			errs = append(errs, fmt.Errorf(
+				"flag: %w %q", ErrUnknownFlag, flag,
+			))
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func validateDuplicateArchitectures(archs []specs.Arch) error {
+	seen := make(map[specs.Arch]struct{}, len(archs))
+
+	var errs []error
+
+	for _, arch := range archs {
+		if _, ok := seen[arch]; ok {
+			errs = append(errs, fmt.Errorf(
+				"architecture: %w %q", ErrDuplicateArch, arch,
+			))
+		} else {
+			seen[arch] = struct{}{}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func validateDuplicateFlags(flags []specs.LinuxSeccompFlag) error {
+	seen := make(map[specs.LinuxSeccompFlag]struct{}, len(flags))
+
+	var errs []error
+
+	for _, flag := range flags {
+		if _, ok := seen[flag]; ok {
+			errs = append(errs, fmt.Errorf(
+				"flag: %w %q", ErrDuplicateFlag, flag,
+			))
+		} else {
+			seen[flag] = struct{}{}
+		}
+	}
+
+	return errors.Join(errs...)
+}
+
+func validateSyscallArgs(syscalls []specs.LinuxSyscall) error {
+	var errs []error
+
+	for idx, sc := range syscalls {
+		for argIdx, arg := range sc.Args {
+			if !isKnownOperator(arg.Op) {
+				errs = append(errs, fmt.Errorf(
+					"syscall entry %d arg %d: %w %q",
+					idx, argIdx, ErrUnknownOperator, arg.Op,
+				))
+			}
+
+			if arg.Index > maxSyscallArgIndex {
+				errs = append(errs, fmt.Errorf(
+					"syscall entry %d arg %d: %w %d",
+					idx, argIdx, ErrArgIndexOutOfRange, arg.Index,
+				))
+			}
+		}
+	}
+
+	return errors.Join(errs...)
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1190,7 +1190,7 @@ github.com/russross/blackfriday/v2
 ## explicit; go 1.23.0
 github.com/sagikazarmark/locafero
 github.com/sagikazarmark/locafero/internal/queue
-# github.com/saschagrunert/security-profiles-merger v0.3.2
+# github.com/saschagrunert/security-profiles-merger v0.3.6
 ## explicit; go 1.25.0
 github.com/saschagrunert/security-profiles-merger/apparmor
 github.com/saschagrunert/security-profiles-merger/internal/merge


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Bumps github.com/saschagrunert/security-profiles-merger from v0.3.2 to v0.3.6.
v0.3.6 fixes a regression where AppArmor capability validation rejected lowercase names (e.g. `sys_admin`, `net_admin`).
Also updates the `TestUnionSyscalls/Args` expectation to match the corrected union semantics for args (OCI seccomp AND-joins args within a single entry, so differing args drop to unconstrained).

#### Which issue(s) this PR fixes:

None

#### Special notes for your reviewer:

#### Does this PR introduce a user-facing change?

```release-note
NONE
```