### PR TITLE
fix(manager): avoid redundant profile status updates

### DIFF
--- a/internal/pkg/manager/nodestatus/nodestatus.go
+++ b/internal/pkg/manager/nodestatus/nodestatus.go
@@ -420,7 +420,26 @@ func (r *StatusReconciler) updateProfileStatus(
 }
 
 func profileStatusChanged(current, desired profilebaseapi.StatusBaseUser) bool {
-	return !reflect.DeepEqual(current, desired)
+	switch typedCurrent := current.(type) {
+	case *seccompprofileapi.SeccompProfile:
+		typedDesired, ok := desired.(*seccompprofileapi.SeccompProfile)
+
+		return !ok || !reflect.DeepEqual(typedCurrent.Status, typedDesired.Status)
+	case *selinuxprofileapi.SelinuxProfile:
+		typedDesired, ok := desired.(*selinuxprofileapi.SelinuxProfile)
+
+		return !ok || !reflect.DeepEqual(typedCurrent.Status, typedDesired.Status)
+	case *selinuxprofileapi.RawSelinuxProfile:
+		typedDesired, ok := desired.(*selinuxprofileapi.RawSelinuxProfile)
+
+		return !ok || !reflect.DeepEqual(typedCurrent.Status, typedDesired.Status)
+	case *apparmorapi.AppArmorProfile:
+		typedDesired, ok := desired.(*apparmorapi.AppArmorProfile)
+
+		return !ok || !reflect.DeepEqual(typedCurrent.Status, typedDesired.Status)
+	default:
+		return true
+	}
 }
 
 func daemonSetIsReady(ds *appsv1.DaemonSet) bool {

--- a/internal/pkg/manager/nodestatus/nodestatus.go
+++ b/internal/pkg/manager/nodestatus/nodestatus.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"reflect"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -32,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -348,6 +350,24 @@ func (r *StatusReconciler) reconcileStatus(
 	state secprofnodestatusapi.ProfileState,
 	l logr.Logger,
 ) error {
+	key := client.ObjectKeyFromObject(prof)
+
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		current := prof.DeepCopyToStatusBaseIf()
+		if err := r.client.Get(ctx, key, current); err != nil {
+			return client.IgnoreNotFound(err)
+		}
+
+		return r.updateProfileStatus(ctx, current, state, l)
+	})
+}
+
+func (r *StatusReconciler) updateProfileStatus(
+	ctx context.Context,
+	prof profilebaseapi.StatusBaseUser,
+	state secprofnodestatusapi.ProfileState,
+	l logr.Logger,
+) error {
 	pCopy := prof.DeepCopyToStatusBaseIf()
 
 	// We always set this status
@@ -385,6 +405,10 @@ func (r *StatusReconciler) reconcileStatus(
 		))
 	}
 
+	if !profileStatusChanged(prof, pCopy) {
+		return nil
+	}
+
 	l.V(config.VerboseLevel).Info("Updating status")
 
 	if updateErr := r.client.Status().Update(ctx, pCopy); updateErr != nil {
@@ -392,6 +416,10 @@ func (r *StatusReconciler) reconcileStatus(
 	}
 
 	return nil
+}
+
+func profileStatusChanged(current, desired profilebaseapi.StatusBaseUser) bool {
+	return !reflect.DeepEqual(current, desired)
 }
 
 func daemonSetIsReady(ds *appsv1.DaemonSet) bool {

--- a/internal/pkg/manager/nodestatus/nodestatus.go
+++ b/internal/pkg/manager/nodestatus/nodestatus.go
@@ -66,6 +66,7 @@ func NewController() controller.Controller {
 // A StatusReconciler monitors node changes and updates the profile status.
 type StatusReconciler struct {
 	client client.Client
+	reader client.Reader
 	log    logr.Logger
 	record record.EventRecorder
 }
@@ -354,7 +355,7 @@ func (r *StatusReconciler) reconcileStatus(
 
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
 		current := prof.DeepCopyToStatusBaseIf()
-		if err := r.client.Get(ctx, key, current); err != nil {
+		if err := r.reader.Get(ctx, key, current); err != nil {
 			return client.IgnoreNotFound(err)
 		}
 

--- a/internal/pkg/manager/nodestatus/nodestatus_test.go
+++ b/internal/pkg/manager/nodestatus/nodestatus_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2026 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/internal/pkg/manager/nodestatus/nodestatus_test.go
+++ b/internal/pkg/manager/nodestatus/nodestatus_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package nodestatus
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	profilebaseapi "sigs.k8s.io/security-profiles-operator/api/profilebase/v1"
+	seccompprofileapi "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1"
+	secprofnodestatusapi "sigs.k8s.io/security-profiles-operator/api/secprofnodestatus/v1"
+)
+
+func TestProfileStatusChanged(t *testing.T) {
+	t.Parallel()
+
+	current := &seccompprofileapi.SeccompProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
+		Status: seccompprofileapi.SeccompProfileStatus{
+			StatusBase: profilebaseapi.StatusBase{
+				Status: secprofnodestatusapi.ProfileStateInstalled,
+			},
+		},
+	}
+	desired := current.DeepCopy()
+
+	require.False(t, profileStatusChanged(current, desired))
+
+	desired.Status.Status = secprofnodestatusapi.ProfileStatePending
+	require.True(t, profileStatusChanged(current, desired))
+}
+
+func TestReconcileStatusRetriesConflictWithFreshGet(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	require.NoError(t, seccompprofileapi.AddToScheme(testScheme))
+
+	profile := &seccompprofileapi.SeccompProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
+	}
+
+	getCalls := 0
+	updateCalls := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithStatusSubresource(profile).
+		WithObjects(profile).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(
+				ctx context.Context,
+				c client.WithWatch,
+				key client.ObjectKey,
+				obj client.Object,
+				opts ...client.GetOption,
+			) error {
+				getCalls++
+
+				return c.Get(ctx, key, obj, opts...)
+			},
+			SubResourceUpdate: func(
+				ctx context.Context,
+				c client.Client,
+				subresource string,
+				obj client.Object,
+				opts ...client.SubResourceUpdateOption,
+			) error {
+				updateCalls++
+				if updateCalls == 1 {
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: seccompprofileapi.GroupVersion.Group, Resource: "seccompprofiles"},
+						obj.GetName(),
+						errors.New("simulated conflict"),
+					)
+				}
+
+				return c.SubResource(subresource).Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &StatusReconciler{client: fakeClient}
+	err := r.reconcileStatus(ctx, profile, secprofnodestatusapi.ProfileStateInstalled, logr.Discard())
+
+	require.NoError(t, err)
+	require.Equal(t, 2, updateCalls)
+	require.Equal(t, 2, getCalls)
+}

--- a/internal/pkg/manager/nodestatus/nodestatus_test.go
+++ b/internal/pkg/manager/nodestatus/nodestatus_test.go
@@ -31,28 +31,73 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
+	apparmorapi "sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1"
 	profilebaseapi "sigs.k8s.io/security-profiles-operator/api/profilebase/v1"
 	seccompprofileapi "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1"
 	secprofnodestatusapi "sigs.k8s.io/security-profiles-operator/api/secprofnodestatus/v1"
+	selinuxprofileapi "sigs.k8s.io/security-profiles-operator/api/selinuxprofile/v1"
 )
 
 func TestProfileStatusChanged(t *testing.T) {
 	t.Parallel()
 
-	current := &seccompprofileapi.SeccompProfile{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
-		Status: seccompprofileapi.SeccompProfileStatus{
-			StatusBase: profilebaseapi.StatusBase{
-				Status: secprofnodestatusapi.ProfileStateInstalled,
+	testCases := []struct {
+		name    string
+		current profilebaseapi.StatusBaseUser
+	}{
+		{
+			name: "SeccompProfile",
+			current: &seccompprofileapi.SeccompProfile{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
+				Status: seccompprofileapi.SeccompProfileStatus{
+					StatusBase: profilebaseapi.StatusBase{Status: secprofnodestatusapi.ProfileStateInstalled},
+				},
+			},
+		},
+		{
+			name: "SelinuxProfile",
+			current: &selinuxprofileapi.SelinuxProfile{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
+				Status: selinuxprofileapi.SelinuxProfileStatus{
+					StatusBase: profilebaseapi.StatusBase{Status: secprofnodestatusapi.ProfileStateInstalled},
+				},
+			},
+		},
+		{
+			name: "RawSelinuxProfile",
+			current: &selinuxprofileapi.RawSelinuxProfile{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
+				Status: selinuxprofileapi.SelinuxProfileStatus{
+					StatusBase: profilebaseapi.StatusBase{Status: secprofnodestatusapi.ProfileStateInstalled},
+				},
+			},
+		},
+		{
+			name: "AppArmorProfile",
+			current: &apparmorapi.AppArmorProfile{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
+				Status: apparmorapi.AppArmorProfileStatus{
+					StatusBase: profilebaseapi.StatusBase{Status: secprofnodestatusapi.ProfileStateInstalled},
+				},
 			},
 		},
 	}
-	desired := current.DeepCopy()
 
-	require.False(t, profileStatusChanged(current, desired))
+	for i := range testCases {
+		testCase := testCases[i]
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
 
-	desired.Status.Status = secprofnodestatusapi.ProfileStatePending
-	require.True(t, profileStatusChanged(current, desired))
+			desired := testCase.current.DeepCopyToStatusBaseIf()
+			require.False(t, profileStatusChanged(testCase.current, desired))
+
+			desired.SetAnnotations(map[string]string{"example": "value"})
+			require.False(t, profileStatusChanged(testCase.current, desired))
+
+			desired.GetStatusBase().Status = secprofnodestatusapi.ProfileStatePending
+			require.True(t, profileStatusChanged(testCase.current, desired))
+		})
+	}
 }
 
 func TestReconcileStatusRetriesConflictWithFreshGet(t *testing.T) {

--- a/internal/pkg/manager/nodestatus/nodestatus_test.go
+++ b/internal/pkg/manager/nodestatus/nodestatus_test.go
@@ -50,7 +50,9 @@ func TestProfileStatusChanged(t *testing.T) {
 			current: &seccompprofileapi.SeccompProfile{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
 				Status: seccompprofileapi.SeccompProfileStatus{
-					StatusBase: profilebaseapi.StatusBase{Status: secprofnodestatusapi.ProfileStateInstalled},
+					StatusBase: profilebaseapi.StatusBase{
+						Status: secprofnodestatusapi.ProfileStateInstalled,
+					},
 				},
 			},
 		},
@@ -59,7 +61,9 @@ func TestProfileStatusChanged(t *testing.T) {
 			current: &selinuxprofileapi.SelinuxProfile{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
 				Status: selinuxprofileapi.SelinuxProfileStatus{
-					StatusBase: profilebaseapi.StatusBase{Status: secprofnodestatusapi.ProfileStateInstalled},
+					StatusBase: profilebaseapi.StatusBase{
+						Status: secprofnodestatusapi.ProfileStateInstalled,
+					},
 				},
 			},
 		},
@@ -68,7 +72,9 @@ func TestProfileStatusChanged(t *testing.T) {
 			current: &selinuxprofileapi.RawSelinuxProfile{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
 				Status: selinuxprofileapi.SelinuxProfileStatus{
-					StatusBase: profilebaseapi.StatusBase{Status: secprofnodestatusapi.ProfileStateInstalled},
+					StatusBase: profilebaseapi.StatusBase{
+						Status: secprofnodestatusapi.ProfileStateInstalled,
+					},
 				},
 			},
 		},
@@ -77,7 +83,9 @@ func TestProfileStatusChanged(t *testing.T) {
 			current: &apparmorapi.AppArmorProfile{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
 				Status: apparmorapi.AppArmorProfileStatus{
-					StatusBase: profilebaseapi.StatusBase{Status: secprofnodestatusapi.ProfileStateInstalled},
+					StatusBase: profilebaseapi.StatusBase{
+						Status: secprofnodestatusapi.ProfileStateInstalled,
+					},
 				},
 			},
 		},
@@ -147,7 +155,10 @@ func TestReconcileStatusRetriesConflictWithFreshGet(t *testing.T) {
 				updateCalls++
 				if updateCalls == 1 {
 					return apierrors.NewConflict(
-						schema.GroupResource{Group: seccompprofileapi.GroupVersion.Group, Resource: "seccompprofiles"},
+						schema.GroupResource{
+							Group:    seccompprofileapi.GroupVersion.Group,
+							Resource: "seccompprofiles",
+						},
 						obj.GetName(),
 						errors.New("simulated conflict"),
 					)
@@ -159,7 +170,12 @@ func TestReconcileStatusRetriesConflictWithFreshGet(t *testing.T) {
 		Build()
 
 	r := &StatusReconciler{client: fakeClient, reader: apiReader}
-	err := r.reconcileStatus(ctx, profile, secprofnodestatusapi.ProfileStateInstalled, logr.Discard())
+	err := r.reconcileStatus(
+		ctx,
+		profile,
+		secprofnodestatusapi.ProfileStateInstalled,
+		logr.Discard(),
+	)
 
 	require.NoError(t, err)
 	require.Equal(t, 2, updateCalls)

--- a/internal/pkg/manager/nodestatus/nodestatus_test.go
+++ b/internal/pkg/manager/nodestatus/nodestatus_test.go
@@ -67,8 +67,7 @@ func TestReconcileStatusRetriesConflictWithFreshGet(t *testing.T) {
 	}
 
 	getCalls := 0
-	updateCalls := 0
-	fakeClient := fake.NewClientBuilder().
+	apiReader := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithStatusSubresource(profile).
 		WithObjects(profile).
@@ -84,6 +83,15 @@ func TestReconcileStatusRetriesConflictWithFreshGet(t *testing.T) {
 
 				return c.Get(ctx, key, obj, opts...)
 			},
+		}).
+		Build()
+
+	updateCalls := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithStatusSubresource(profile).
+		WithObjects(profile).
+		WithInterceptorFuncs(interceptor.Funcs{
 			SubResourceUpdate: func(
 				ctx context.Context,
 				c client.Client,
@@ -105,7 +113,7 @@ func TestReconcileStatusRetriesConflictWithFreshGet(t *testing.T) {
 		}).
 		Build()
 
-	r := &StatusReconciler{client: fakeClient}
+	r := &StatusReconciler{client: fakeClient, reader: apiReader}
 	err := r.reconcileStatus(ctx, profile, secprofnodestatusapi.ProfileStateInstalled, logr.Discard())
 
 	require.NoError(t, err)

--- a/internal/pkg/manager/nodestatus/setup.go
+++ b/internal/pkg/manager/nodestatus/setup.go
@@ -32,6 +32,7 @@ func (r *StatusReconciler) Setup(
 	_ *metrics.Metrics,
 ) error {
 	r.client = mgr.GetClient()
+	r.reader = mgr.GetAPIReader()
 	r.log = ctrl.Log.WithName(r.Name())
 	//nolint:staticcheck // TODO: migrate to GetEventRecorder
 	r.record = mgr.GetEventRecorderFor(

--- a/internal/pkg/manager/workloadannotator/setup.go
+++ b/internal/pkg/manager/workloadannotator/setup.go
@@ -41,6 +41,7 @@ func (r *PodReconciler) Setup(
 	const name = "pods"
 
 	r.client = mgr.GetClient()
+	r.reader = mgr.GetAPIReader()
 	r.log = ctrl.Log.WithName(r.Name())
 	//nolint:staticcheck // TODO: migrate to GetEventRecorder
 	r.record = mgr.GetEventRecorderFor(name)

--- a/internal/pkg/manager/workloadannotator/workloadannotator.go
+++ b/internal/pkg/manager/workloadannotator/workloadannotator.go
@@ -55,6 +55,7 @@ func NewController() controller.Controller {
 // A PodReconciler monitors pod changes and links them to SeccompProfiles.
 type PodReconciler struct {
 	client client.Client
+	reader client.Reader
 	log    logr.Logger
 	record record.EventRecorder
 }
@@ -237,7 +238,7 @@ func (r *PodReconciler) updatePodReferencesForSeccomp(
 	slices.Sort(podList)
 
 	if err := util.Retry(func() error {
-		if err := r.client.Get(ctx, util.NamespacedName(sp.GetName(), sp.GetNamespace()), sp); err != nil {
+		if err := r.reader.Get(ctx, util.NamespacedName(sp.GetName(), sp.GetNamespace()), sp); err != nil {
 			return fmt.Errorf("retrieving profile: %w", err)
 		}
 

--- a/internal/pkg/manager/workloadannotator/workloadannotator.go
+++ b/internal/pkg/manager/workloadannotator/workloadannotator.go
@@ -272,13 +272,13 @@ func (r *PodReconciler) updatePodReferencesForSeccomp(
 
 	if len(linkedPods.Items) > 0 {
 		if err := util.Retry(func() error {
-			return util.AddFinalizer(ctx, r.client, sp, util.HasActivePodsFinalizerString)
+			return client.IgnoreNotFound(util.AddFinalizer(ctx, r.client, sp, util.HasActivePodsFinalizerString))
 		}, util.IsNotFoundOrConflict); err != nil {
 			return fmt.Errorf("adding finalizer: %w", err)
 		}
 	} else {
 		if err := util.Retry(func() error {
-			return util.RemoveFinalizer(ctx, r.client, sp, util.HasActivePodsFinalizerString)
+			return client.IgnoreNotFound(util.RemoveFinalizer(ctx, r.client, sp, util.HasActivePodsFinalizerString))
 		}, util.IsNotFoundOrConflict); err != nil {
 			return fmt.Errorf("removing finalizer: %w", err)
 		}
@@ -358,13 +358,13 @@ func (r *PodReconciler) updatePodReferencesForSelinux(
 
 	if len(linkedPods.Items) > 0 {
 		if err := util.Retry(func() error {
-			return util.AddFinalizer(ctx, r.client, se, util.HasActivePodsFinalizerString)
+			return client.IgnoreNotFound(util.AddFinalizer(ctx, r.client, se, util.HasActivePodsFinalizerString))
 		}, util.IsNotFoundOrConflict); err != nil {
 			return fmt.Errorf("adding finalizer: %w", err)
 		}
 	} else {
 		if err := util.Retry(func() error {
-			return util.RemoveFinalizer(ctx, r.client, se, util.HasActivePodsFinalizerString)
+			return client.IgnoreNotFound(util.RemoveFinalizer(ctx, r.client, se, util.HasActivePodsFinalizerString))
 		}, util.IsNotFoundOrConflict); err != nil {
 			return fmt.Errorf("removing finalizer: %w", err)
 		}

--- a/internal/pkg/manager/workloadannotator/workloadannotator.go
+++ b/internal/pkg/manager/workloadannotator/workloadannotator.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -233,21 +234,21 @@ func (r *PodReconciler) updatePodReferencesForSeccomp(
 		pod := linkedPods.Items[i]
 		podList[i] = pod.Namespace + "/" + pod.Name
 	}
+	slices.Sort(podList)
 
 	if err := util.Retry(func() error {
-		sp.Status.ActiveWorkloads = podList
+		if err := r.client.Get(ctx, util.NamespacedName(sp.GetName(), sp.GetNamespace()), sp); err != nil {
+			return fmt.Errorf("retrieving profile: %w", err)
+		}
 
-		updateErr := r.client.Status().Update(ctx, sp)
-		if updateErr != nil {
-			if err := r.client.Get(
-				ctx,
-				util.NamespacedName(sp.GetName(), sp.GetNamespace()),
-				sp,
-			); err != nil {
-				return fmt.Errorf("retrieving profile: %w", err)
-			}
+		if sameActiveWorkloads(sp.Status.ActiveWorkloads, podList) {
+			return nil
+		}
 
-			return fmt.Errorf("updating profile: %w", updateErr)
+		sp.Status.ActiveWorkloads = slices.Clone(podList)
+
+		if err := r.client.Status().Update(ctx, sp); err != nil {
+			return fmt.Errorf("updating profile: %w", err)
 		}
 
 		return nil
@@ -270,6 +271,19 @@ func (r *PodReconciler) updatePodReferencesForSeccomp(
 	}
 
 	return nil
+}
+
+func sameActiveWorkloads(current, desired []string) bool {
+	if len(current) != len(desired) {
+		return false
+	}
+
+	currentCopy := slices.Clone(current)
+	desiredCopy := slices.Clone(desired)
+	slices.Sort(currentCopy)
+	slices.Sort(desiredCopy)
+
+	return slices.Equal(currentCopy, desiredCopy)
 }
 
 // updatePodReferencesForSelinux updates a SelinuxProfile with the identifiers of pods using it and ensures

--- a/internal/pkg/manager/workloadannotator/workloadannotator.go
+++ b/internal/pkg/manager/workloadannotator/workloadannotator.go
@@ -235,10 +235,19 @@ func (r *PodReconciler) updatePodReferencesForSeccomp(
 		pod := linkedPods.Items[i]
 		podList[i] = pod.Namespace + "/" + pod.Name
 	}
+
 	slices.Sort(podList)
+
+	profileDeleted := false
 
 	if err := util.Retry(func() error {
 		if err := r.reader.Get(ctx, util.NamespacedName(sp.GetName(), sp.GetNamespace()), sp); err != nil {
+			if errors.IsNotFound(err) {
+				profileDeleted = true
+
+				return nil
+			}
+
 			return fmt.Errorf("retrieving profile: %w", err)
 		}
 
@@ -255,6 +264,10 @@ func (r *PodReconciler) updatePodReferencesForSeccomp(
 		return nil
 	}, util.IsNotFoundOrConflict); err != nil {
 		return fmt.Errorf("updating SeccompProfile status: %w", err)
+	}
+
+	if profileDeleted {
+		return nil
 	}
 
 	if len(linkedPods.Items) > 0 {
@@ -281,6 +294,7 @@ func sameActiveWorkloads(current, desired []string) bool {
 
 	currentCopy := slices.Clone(current)
 	desiredCopy := slices.Clone(desired)
+
 	slices.Sort(currentCopy)
 	slices.Sort(desiredCopy)
 
@@ -308,25 +322,38 @@ func (r *PodReconciler) updatePodReferencesForSelinux(
 		podList[i] = pod.Namespace + "/" + pod.Name
 	}
 
-	if err := util.Retry(func() error {
-		se.Status.ActiveWorkloads = podList
+	slices.Sort(podList)
 
-		updateErr := r.client.Status().Update(ctx, se)
-		if updateErr != nil {
-			if err := r.client.Get(
-				ctx,
-				util.NamespacedName(se.GetName(), se.GetNamespace()),
-				se,
-			); err != nil {
-				return fmt.Errorf("retrieving profile: %w", err)
+	profileDeleted := false
+
+	if err := util.Retry(func() error {
+		if err := r.reader.Get(ctx, util.NamespacedName(se.GetName(), se.GetNamespace()), se); err != nil {
+			if errors.IsNotFound(err) {
+				profileDeleted = true
+
+				return nil
 			}
 
-			return fmt.Errorf("updating profile: %w", updateErr)
+			return fmt.Errorf("retrieving profile: %w", err)
+		}
+
+		if sameActiveWorkloads(se.Status.ActiveWorkloads, podList) {
+			return nil
+		}
+
+		se.Status.ActiveWorkloads = slices.Clone(podList)
+
+		if err := r.client.Status().Update(ctx, se); err != nil {
+			return fmt.Errorf("updating profile: %w", err)
 		}
 
 		return nil
 	}, util.IsNotFoundOrConflict); err != nil {
 		return fmt.Errorf("updating SelinuxProfile status: %w", err)
+	}
+
+	if profileDeleted {
+		return nil
 	}
 
 	if len(linkedPods.Items) > 0 {

--- a/internal/pkg/manager/workloadannotator/workloadannotator.go
+++ b/internal/pkg/manager/workloadannotator/workloadannotator.go
@@ -241,7 +241,11 @@ func (r *PodReconciler) updatePodReferencesForSeccomp(
 	profileDeleted := false
 
 	if err := util.Retry(func() error {
-		if err := r.reader.Get(ctx, util.NamespacedName(sp.GetName(), sp.GetNamespace()), sp); err != nil {
+		if err := r.reader.Get(
+			ctx,
+			util.NamespacedName(sp.GetName(), sp.GetNamespace()),
+			sp,
+		); err != nil {
 			if errors.IsNotFound(err) {
 				profileDeleted = true
 
@@ -272,13 +276,17 @@ func (r *PodReconciler) updatePodReferencesForSeccomp(
 
 	if len(linkedPods.Items) > 0 {
 		if err := util.Retry(func() error {
-			return client.IgnoreNotFound(util.AddFinalizer(ctx, r.client, sp, util.HasActivePodsFinalizerString))
+			return client.IgnoreNotFound(
+				util.AddFinalizer(ctx, r.client, sp, util.HasActivePodsFinalizerString),
+			)
 		}, util.IsNotFoundOrConflict); err != nil {
 			return fmt.Errorf("adding finalizer: %w", err)
 		}
 	} else {
 		if err := util.Retry(func() error {
-			return client.IgnoreNotFound(util.RemoveFinalizer(ctx, r.client, sp, util.HasActivePodsFinalizerString))
+			return client.IgnoreNotFound(
+				util.RemoveFinalizer(ctx, r.client, sp, util.HasActivePodsFinalizerString),
+			)
 		}, util.IsNotFoundOrConflict); err != nil {
 			return fmt.Errorf("removing finalizer: %w", err)
 		}
@@ -327,7 +335,11 @@ func (r *PodReconciler) updatePodReferencesForSelinux(
 	profileDeleted := false
 
 	if err := util.Retry(func() error {
-		if err := r.reader.Get(ctx, util.NamespacedName(se.GetName(), se.GetNamespace()), se); err != nil {
+		if err := r.reader.Get(
+			ctx,
+			util.NamespacedName(se.GetName(), se.GetNamespace()),
+			se,
+		); err != nil {
 			if errors.IsNotFound(err) {
 				profileDeleted = true
 
@@ -358,13 +370,17 @@ func (r *PodReconciler) updatePodReferencesForSelinux(
 
 	if len(linkedPods.Items) > 0 {
 		if err := util.Retry(func() error {
-			return client.IgnoreNotFound(util.AddFinalizer(ctx, r.client, se, util.HasActivePodsFinalizerString))
+			return client.IgnoreNotFound(
+				util.AddFinalizer(ctx, r.client, se, util.HasActivePodsFinalizerString),
+			)
 		}, util.IsNotFoundOrConflict); err != nil {
 			return fmt.Errorf("adding finalizer: %w", err)
 		}
 	} else {
 		if err := util.Retry(func() error {
-			return client.IgnoreNotFound(util.RemoveFinalizer(ctx, r.client, se, util.HasActivePodsFinalizerString))
+			return client.IgnoreNotFound(
+				util.RemoveFinalizer(ctx, r.client, se, util.HasActivePodsFinalizerString),
+			)
 		}, util.IsNotFoundOrConflict); err != nil {
 			return fmt.Errorf("removing finalizer: %w", err)
 		}

--- a/internal/pkg/manager/workloadannotator/workloadannotator_test.go
+++ b/internal/pkg/manager/workloadannotator/workloadannotator_test.go
@@ -17,12 +17,63 @@ limitations under the License.
 package workloadannotator
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	seccompprofileapi "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1"
 )
+
+func TestSameActiveWorkloads(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, sameActiveWorkloads(
+		[]string{"namespace/pod-b", "namespace/pod-a"},
+		[]string{"namespace/pod-a", "namespace/pod-b"},
+	))
+	require.False(t, sameActiveWorkloads(
+		[]string{"namespace/pod-a"},
+		[]string{"namespace/pod-a", "namespace/pod-b"},
+	))
+}
+
+func TestUpdatePodReferencesForSeccompRefreshesBeforeNoOpCheck(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(testScheme))
+	require.NoError(t, seccompprofileapi.AddToScheme(testScheme))
+
+	stored := &seccompprofileapi.SeccompProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
+		Status: seccompprofileapi.SeccompProfileStatus{
+			ActiveWorkloads: []string{"example/pod-a"},
+		},
+	}
+	stale := stored.DeepCopy()
+	stale.Status.ActiveWorkloads = nil
+
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithStatusSubresource(stored).
+		WithObjects(stored).
+		WithIndex(&corev1.Pod{}, spOwnerKey, func(client.Object) []string { return nil }).
+		Build()
+
+	r := &PodReconciler{client: fakeClient}
+	require.NoError(t, r.updatePodReferencesForSeccomp(ctx, stale))
+
+	updated := &seccompprofileapi.SeccompProfile{}
+	require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: stored.Name}, updated))
+	require.Empty(t, updated.Status.ActiveWorkloads)
+}
 
 func TestGetSeccompProfilesFromPod(t *testing.T) {
 	t.Parallel()

--- a/internal/pkg/manager/workloadannotator/workloadannotator_test.go
+++ b/internal/pkg/manager/workloadannotator/workloadannotator_test.go
@@ -206,6 +206,161 @@ func TestUpdatePodReferencesForSeccompIgnoresDeletedProfile(t *testing.T) {
 	require.NoError(t, r.updatePodReferencesForSeccomp(ctx, profile))
 }
 
+func TestUpdatePodReferencesIgnoresDeletionBeforeFinalizerUpdate(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name             string
+		profile          client.Object
+		ownerKey         string
+		profileReference string
+		update           func(context.Context, *PodReconciler, client.Object) error
+	}{
+		{
+			name: "SeccompProfile",
+			profile: &seccompprofileapi.SeccompProfile{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
+				Status: seccompprofileapi.SeccompProfileStatus{
+					ActiveWorkloads: []string{"example/pod"},
+				},
+			},
+			ownerKey:         spOwnerKey,
+			profileReference: "operator/test-profile.json",
+			update: func(ctx context.Context, r *PodReconciler, object client.Object) error {
+				profile, ok := object.(*seccompprofileapi.SeccompProfile)
+				if !ok {
+					return errors.New("object is not a SeccompProfile")
+				}
+
+				return r.updatePodReferencesForSeccomp(ctx, profile)
+			},
+		},
+		{
+			name: "SelinuxProfile",
+			profile: &selinuxprofileapi.SelinuxProfile{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
+				Status: selinuxprofileapi.SelinuxProfileStatus{
+					ActiveWorkloads: []string{"example/pod"},
+				},
+			},
+			ownerKey:         seOwnerKey,
+			profileReference: "test-profile.process",
+			update: func(ctx context.Context, r *PodReconciler, object client.Object) error {
+				profile, ok := object.(*selinuxprofileapi.SelinuxProfile)
+				if !ok {
+					return errors.New("object is not a SelinuxProfile")
+				}
+
+				return r.updatePodReferencesForSelinux(ctx, profile)
+			},
+		},
+	}
+
+	for i := range testCases {
+		testCase := testCases[i]
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			testScheme := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(testScheme))
+			require.NoError(t, seccompprofileapi.AddToScheme(testScheme))
+			require.NoError(t, selinuxprofileapi.AddToScheme(testScheme))
+
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "example", Name: "pod"}}
+			apiReader := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithStatusSubresource(testCase.profile).
+				WithObjects(testCase.profile).
+				Build()
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithObjects(pod).
+				WithIndex(&corev1.Pod{}, testCase.ownerKey, func(client.Object) []string {
+					return []string{testCase.profileReference}
+				}).
+				Build()
+
+			r := &PodReconciler{client: fakeClient, reader: apiReader}
+			require.NoError(t, testCase.update(ctx, r, testCase.profile))
+		})
+	}
+}
+
+func TestUpdatePodReferencesIgnoresDeletionBeforeFinalizerRemoval(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		profile  client.Object
+		ownerKey string
+		update   func(context.Context, *PodReconciler, client.Object) error
+	}{
+		{
+			name: "SeccompProfile",
+			profile: &seccompprofileapi.SeccompProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-profile",
+					Finalizers: []string{util.HasActivePodsFinalizerString},
+				},
+			},
+			ownerKey: spOwnerKey,
+			update: func(ctx context.Context, r *PodReconciler, object client.Object) error {
+				profile, ok := object.(*seccompprofileapi.SeccompProfile)
+				if !ok {
+					return errors.New("object is not a SeccompProfile")
+				}
+
+				return r.updatePodReferencesForSeccomp(ctx, profile)
+			},
+		},
+		{
+			name: "SelinuxProfile",
+			profile: &selinuxprofileapi.SelinuxProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "test-profile",
+					Finalizers: []string{util.HasActivePodsFinalizerString},
+				},
+			},
+			ownerKey: seOwnerKey,
+			update: func(ctx context.Context, r *PodReconciler, object client.Object) error {
+				profile, ok := object.(*selinuxprofileapi.SelinuxProfile)
+				if !ok {
+					return errors.New("object is not a SelinuxProfile")
+				}
+
+				return r.updatePodReferencesForSelinux(ctx, profile)
+			},
+		},
+	}
+
+	for i := range testCases {
+		testCase := testCases[i]
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			testScheme := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(testScheme))
+			require.NoError(t, seccompprofileapi.AddToScheme(testScheme))
+			require.NoError(t, selinuxprofileapi.AddToScheme(testScheme))
+
+			apiReader := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithStatusSubresource(testCase.profile).
+				WithObjects(testCase.profile).
+				Build()
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithIndex(&corev1.Pod{}, testCase.ownerKey, func(client.Object) []string { return nil }).
+				Build()
+
+			r := &PodReconciler{client: fakeClient, reader: apiReader}
+			require.NoError(t, testCase.update(ctx, r, testCase.profile))
+		})
+	}
+}
+
 func TestUpdatePodReferencesForSelinuxSkipsEquivalentStatusUpdate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pkg/manager/workloadannotator/workloadannotator_test.go
+++ b/internal/pkg/manager/workloadannotator/workloadannotator_test.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	seccompprofileapi "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1"
 )
@@ -60,6 +61,26 @@ func TestUpdatePodReferencesForSeccompRefreshesBeforeNoOpCheck(t *testing.T) {
 	stale := stored.DeepCopy()
 	stale.Status.ActiveWorkloads = nil
 
+	readerGetCalls := 0
+	apiReader := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithStatusSubresource(stored).
+		WithObjects(stored).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(
+				ctx context.Context,
+				c client.WithWatch,
+				key client.ObjectKey,
+				obj client.Object,
+				opts ...client.GetOption,
+			) error {
+				readerGetCalls++
+
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
 		WithStatusSubresource(stored).
@@ -67,8 +88,9 @@ func TestUpdatePodReferencesForSeccompRefreshesBeforeNoOpCheck(t *testing.T) {
 		WithIndex(&corev1.Pod{}, spOwnerKey, func(client.Object) []string { return nil }).
 		Build()
 
-	r := &PodReconciler{client: fakeClient}
+	r := &PodReconciler{client: fakeClient, reader: apiReader}
 	require.NoError(t, r.updatePodReferencesForSeccomp(ctx, stale))
+	require.Equal(t, 1, readerGetCalls)
 
 	updated := &seccompprofileapi.SeccompProfile{}
 	require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: stored.Name}, updated))

--- a/internal/pkg/manager/workloadannotator/workloadannotator_test.go
+++ b/internal/pkg/manager/workloadannotator/workloadannotator_test.go
@@ -18,6 +18,7 @@ package workloadannotator
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -29,6 +30,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 
 	seccompprofileapi "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1"
+	selinuxprofileapi "sigs.k8s.io/security-profiles-operator/api/selinuxprofile/v1"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/util"
 )
 
 func TestSameActiveWorkloads(t *testing.T) {
@@ -44,28 +47,18 @@ func TestSameActiveWorkloads(t *testing.T) {
 	))
 }
 
-func TestUpdatePodReferencesForSeccompRefreshesBeforeNoOpCheck(t *testing.T) {
-	t.Parallel()
+func newCountingReader(
+	t *testing.T,
+	testScheme *runtime.Scheme,
+	object client.Object,
+) (reader client.Reader, getCalls *int) {
+	t.Helper()
 
-	ctx := context.Background()
-	testScheme := runtime.NewScheme()
-	require.NoError(t, corev1.AddToScheme(testScheme))
-	require.NoError(t, seccompprofileapi.AddToScheme(testScheme))
-
-	stored := &seccompprofileapi.SeccompProfile{
-		ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
-		Status: seccompprofileapi.SeccompProfileStatus{
-			ActiveWorkloads: []string{"example/pod-a"},
-		},
-	}
-	stale := stored.DeepCopy()
-	stale.Status.ActiveWorkloads = nil
-
-	readerGetCalls := 0
-	apiReader := fake.NewClientBuilder().
+	calls := 0
+	countingReader := fake.NewClientBuilder().
 		WithScheme(testScheme).
-		WithStatusSubresource(stored).
-		WithObjects(stored).
+		WithStatusSubresource(object).
+		WithObjects(object).
 		WithInterceptorFuncs(interceptor.Funcs{
 			Get: func(
 				ctx context.Context,
@@ -74,27 +67,193 @@ func TestUpdatePodReferencesForSeccompRefreshesBeforeNoOpCheck(t *testing.T) {
 				obj client.Object,
 				opts ...client.GetOption,
 			) error {
-				readerGetCalls++
+				calls++
 
 				return c.Get(ctx, key, obj, opts...)
 			},
 		}).
 		Build()
 
+	return countingReader, &calls
+}
+
+//nolint:dupl // Seccomp and SELinux profiles intentionally exercise the same reconciliation contract.
+func TestUpdatePodReferencesRefreshesBeforeNoOpCheck(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name         string
+		addToScheme  func(*runtime.Scheme) error
+		ownerKey     string
+		profiles     func() (client.Object, client.Object)
+		update       func(context.Context, *PodReconciler, client.Object) error
+		assertStatus func(*testing.T, context.Context, client.Client)
+	}{
+		{
+			name:        "SeccompProfile",
+			addToScheme: seccompprofileapi.AddToScheme,
+			ownerKey:    spOwnerKey,
+			profiles: func() (client.Object, client.Object) {
+				stored := &seccompprofileapi.SeccompProfile{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
+					Status: seccompprofileapi.SeccompProfileStatus{
+						ActiveWorkloads: []string{"example/pod-a"},
+					},
+				}
+				stale := stored.DeepCopy()
+				stale.Status.ActiveWorkloads = nil
+
+				return stored, stale
+			},
+			update: func(ctx context.Context, r *PodReconciler, object client.Object) error {
+				profile, ok := object.(*seccompprofileapi.SeccompProfile)
+				if !ok {
+					return errors.New("object is not a SeccompProfile")
+				}
+
+				return r.updatePodReferencesForSeccomp(ctx, profile)
+			},
+			assertStatus: func(t *testing.T, ctx context.Context, c client.Client) {
+				t.Helper()
+
+				updated := &seccompprofileapi.SeccompProfile{}
+				require.NoError(t, c.Get(ctx, client.ObjectKey{Name: "test-profile"}, updated))
+				require.Empty(t, updated.Status.ActiveWorkloads)
+			},
+		},
+		{
+			name:        "SelinuxProfile",
+			addToScheme: selinuxprofileapi.AddToScheme,
+			ownerKey:    seOwnerKey,
+			profiles: func() (client.Object, client.Object) {
+				stored := &selinuxprofileapi.SelinuxProfile{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
+					Status: selinuxprofileapi.SelinuxProfileStatus{
+						ActiveWorkloads: []string{"example/pod-a"},
+					},
+				}
+				stale := stored.DeepCopy()
+				stale.Status.ActiveWorkloads = nil
+
+				return stored, stale
+			},
+			update: func(ctx context.Context, r *PodReconciler, object client.Object) error {
+				profile, ok := object.(*selinuxprofileapi.SelinuxProfile)
+				if !ok {
+					return errors.New("object is not a SelinuxProfile")
+				}
+
+				return r.updatePodReferencesForSelinux(ctx, profile)
+			},
+			assertStatus: func(t *testing.T, ctx context.Context, c client.Client) {
+				t.Helper()
+
+				updated := &selinuxprofileapi.SelinuxProfile{}
+				require.NoError(t, c.Get(ctx, client.ObjectKey{Name: "test-profile"}, updated))
+				require.Empty(t, updated.Status.ActiveWorkloads)
+			},
+		},
+	}
+
+	for i := range testCases {
+		testCase := testCases[i]
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			testScheme := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(testScheme))
+			require.NoError(t, testCase.addToScheme(testScheme))
+
+			stored, stale := testCase.profiles()
+			apiReader, readerGetCalls := newCountingReader(t, testScheme, stored)
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(testScheme).
+				WithStatusSubresource(stored).
+				WithObjects(stored).
+				WithIndex(&corev1.Pod{}, testCase.ownerKey, func(client.Object) []string { return nil }).
+				Build()
+
+			r := &PodReconciler{client: fakeClient, reader: apiReader}
+			require.NoError(t, testCase.update(ctx, r, stale))
+			require.Equal(t, 1, *readerGetCalls)
+			testCase.assertStatus(t, ctx, fakeClient)
+		})
+	}
+}
+
+func TestUpdatePodReferencesForSeccompIgnoresDeletedProfile(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(testScheme))
+	require.NoError(t, seccompprofileapi.AddToScheme(testScheme))
+
+	profile := &seccompprofileapi.SeccompProfile{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test-profile",
+			Finalizers: []string{util.HasActivePodsFinalizerString},
+		},
+	}
+	apiReader := fake.NewClientBuilder().WithScheme(testScheme).Build()
 	fakeClient := fake.NewClientBuilder().
 		WithScheme(testScheme).
-		WithStatusSubresource(stored).
-		WithObjects(stored).
 		WithIndex(&corev1.Pod{}, spOwnerKey, func(client.Object) []string { return nil }).
 		Build()
 
 	r := &PodReconciler{client: fakeClient, reader: apiReader}
-	require.NoError(t, r.updatePodReferencesForSeccomp(ctx, stale))
-	require.Equal(t, 1, readerGetCalls)
+	require.NoError(t, r.updatePodReferencesForSeccomp(ctx, profile))
+}
 
-	updated := &seccompprofileapi.SeccompProfile{}
-	require.NoError(t, fakeClient.Get(ctx, client.ObjectKey{Name: stored.Name}, updated))
-	require.Empty(t, updated.Status.ActiveWorkloads)
+func TestUpdatePodReferencesForSelinuxSkipsEquivalentStatusUpdate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	testScheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(testScheme))
+	require.NoError(t, selinuxprofileapi.AddToScheme(testScheme))
+
+	stored := &selinuxprofileapi.SelinuxProfile{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-profile"},
+		Status: selinuxprofileapi.SelinuxProfileStatus{
+			ActiveWorkloads: []string{"example/pod-b", "example/pod-a"},
+		},
+	}
+	podA := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "example", Name: "pod-a"}}
+	podB := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Namespace: "example", Name: "pod-b"}}
+	apiReader := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithStatusSubresource(stored).
+		WithObjects(stored).
+		Build()
+
+	statusUpdateCalls := 0
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(testScheme).
+		WithStatusSubresource(stored).
+		WithObjects(stored, podA, podB).
+		WithIndex(&corev1.Pod{}, seOwnerKey, func(client.Object) []string {
+			return []string{stored.GetPolicyUsage()}
+		}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(
+				ctx context.Context,
+				c client.Client,
+				subresource string,
+				obj client.Object,
+				opts ...client.SubResourceUpdateOption,
+			) error {
+				statusUpdateCalls++
+
+				return c.SubResource(subresource).Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &PodReconciler{client: fakeClient, reader: apiReader}
+	require.NoError(t, r.updatePodReferencesForSelinux(ctx, stored.DeepCopy()))
+	require.Zero(t, statusUpdateCalls)
 }
 
 func TestGetSeccompProfilesFromPod(t *testing.T) {

--- a/vendor/k8s.io/client-go/util/retry/OWNERS
+++ b/vendor/k8s.io/client-go/util/retry/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://go.k8s.io/owners
+
+reviewers:
+  - caesarxuchao

--- a/vendor/k8s.io/client-go/util/retry/util.go
+++ b/vendor/k8s.io/client-go/util/retry/util.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2016 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retry
+
+import (
+	"time"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// DefaultRetry is the recommended retry for a conflict where multiple clients
+// are making changes to the same resource.
+var DefaultRetry = wait.Backoff{
+	Steps:    5,
+	Duration: 10 * time.Millisecond,
+	Factor:   1.0,
+	Jitter:   0.1,
+}
+
+// DefaultBackoff is the recommended backoff for a conflict where a client
+// may be attempting to make an unrelated modification to a resource under
+// active management by one or more controllers.
+var DefaultBackoff = wait.Backoff{
+	Steps:    4,
+	Duration: 10 * time.Millisecond,
+	Factor:   5.0,
+	Jitter:   0.1,
+}
+
+// OnError allows the caller to retry fn in case the error returned by fn is retriable
+// according to the provided function. backoff defines the maximum retries and the wait
+// interval between two retries.
+func OnError(backoff wait.Backoff, retriable func(error) bool, fn func() error) error {
+	var lastErr error
+	err := wait.ExponentialBackoff(backoff, func() (bool, error) {
+		err := fn()
+		switch {
+		case err == nil:
+			return true, nil
+		case retriable(err):
+			lastErr = err
+			return false, nil
+		default:
+			return false, err
+		}
+	})
+	if wait.Interrupted(err) {
+		err = lastErr
+	}
+	return err
+}
+
+// RetryOnConflict is used to make an update to a resource when you have to worry about
+// conflicts caused by other code making unrelated updates to the resource at the same
+// time. fn should fetch the resource to be modified, make appropriate changes to it, try
+// to update it, and return (unmodified) the error from the update function. On a
+// successful update, RetryOnConflict will return nil. If the update function returns a
+// "Conflict" error, RetryOnConflict will wait some amount of time as described by
+// backoff, and then try again. On a non-"Conflict" error, or if it retries too many times
+// and gives up, RetryOnConflict will return an error to the caller.
+//
+//	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+//	    // Fetch the resource here; you need to refetch it on every try, since
+//	    // if you got a conflict on the last update attempt then you need to get
+//	    // the current version before making your own changes.
+//	    pod, err := c.Pods("mynamespace").Get(name, metav1.GetOptions{})
+//	    if err != nil {
+//	        return err
+//	    }
+//
+//	    // Make whatever updates to the resource are needed
+//	    pod.Status.Phase = v1.PodFailed
+//
+//	    // Try to update
+//	    _, err = c.Pods("mynamespace").UpdateStatus(pod)
+//	    // You have to return err itself here (not wrapped inside another error)
+//	    // so that RetryOnConflict can identify it correctly.
+//	    return err
+//	})
+//	if err != nil {
+//	    // May be conflict if max retries were hit, or may be something unrelated
+//	    // like permissions or a network error
+//	    return err
+//	}
+//	...
+//
+// TODO: Make Backoff an interface?
+func RetryOnConflict(backoff wait.Backoff, fn func() error) error {
+	return OnError(backoff, errors.IsConflict, fn)
+}

--- a/vendor/k8s.io/client-go/util/retry/util.go
+++ b/vendor/k8s.io/client-go/util/retry/util.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2016 The Kubernetes Authors.
+Copyright The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vendor/k8s.io/client-go/util/retry/util.go
+++ b/vendor/k8s.io/client-go/util/retry/util.go
@@ -1,5 +1,5 @@
 /*
-Copyright The Kubernetes Authors.
+Copyright 2016 The Kubernetes Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -2366,6 +2366,7 @@ k8s.io/client-go/util/flowcontrol
 k8s.io/client-go/util/homedir
 k8s.io/client-go/util/jsonpath
 k8s.io/client-go/util/keyutil
+k8s.io/client-go/util/retry
 k8s.io/client-go/util/watchlist
 k8s.io/client-go/util/workqueue
 # k8s.io/code-generator v0.36.3


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

This PR prevents redundant profile status writes and makes node status aggregation resilient to optimistic concurrency conflicts.

It:

- sorts `SeccompProfile.status.activeWorkloads` and `SelinuxProfile.status.activeWorkloads` before storing them;
- compares active workload sets and skips unchanged status updates for both profile types;
- rechecks each workload set after reading a fresh profile during conflict retries;
- exits workload status and finalizer reconciliation cleanly when a profile has been deleted;
- skips node status updates when the calculated status fields are unchanged;
- retries node status conflicts with `RetryOnConflict` and performs an uncached API read on every attempt;
- adds tests for order-independent workload comparison, no-op status detection, deleted profiles, and conflict retries with fresh reads.

#### Which issue(s) this PR fixes:

Fixes #3383

#### Does this PR have test?

Yes:

```text
go test ./internal/pkg/manager/... -count=1
```

#### Special notes for your reviewer:

The workload annotator continues to maintain the active workload finalizer. The change only suppresses status writes when the workload set is semantically unchanged.

Freshness-critical profile reads use `Manager.GetAPIReader()`. This adds one direct API server `GET` per relevant reconciliation, plus additional reads on conflict retries, and avoids stale cached no-op decisions and stale `resourceVersion` reuse.

#### Does this PR introduce a user-facing change?

```release-note
Avoid redundant security profile status writes and retry node status update conflicts using the latest resource version.
```
