### PR TITLE
Fix bugs, improve reliability, and reduce technical debt

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,12 @@ general k8s resources
 
 ## Prerequisites
 
-- [go](https://golang.org/dl/) version v1.15+.
-- [docker](https://docs.docker.com/install/) version 17.03+.
-- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.19+.
-- Access to a Kubernetes v1.19+ cluster.
+- [go](https://golang.org/dl/) version v1.26+.
+- [docker](https://docs.docker.com/install/) version 24.0+ or [podman](https://podman.io/getting-started/installation) version 4.0+.
+- [kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/) version v1.30+.
+- Access to a Kubernetes v1.30+ cluster.
+
+For detailed development setup and build instructions, see [hacking.md](hacking.md).
 
 ## Contributing steps
 

--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -31,9 +31,12 @@ RUN mkdir -p build
 
 # Use latest golang
 RUN ARCH=$(arch | sed 's|x86_64|amd64|g' | sed 's|aarch64|arm64|g') && \
-    GO_VERSION=$(curl -sSfL https://go.dev/VERSION?m=text | head -n1) && \
-    curl -sSfL https://go.dev/dl/${GO_VERSION}.linux-${ARCH}.tar.gz | \
-    tar -xzf - -C /usr/local
+    GO_VERSION=$(curl --proto '=https' --tlsv1.2 -sSfL https://go.dev/VERSION?m=text | head -n1) && \
+    curl --proto '=https' --tlsv1.2 -sSfL "https://go.dev/dl/${GO_VERSION}.linux-${ARCH}.tar.gz" -o /tmp/go.tar.gz && \
+    curl --proto '=https' --tlsv1.2 -sSfL "https://dl.google.com/go/${GO_VERSION}.linux-${ARCH}.tar.gz.sha256" -o /tmp/go.tar.gz.sha256 && \
+    echo "$(cat /tmp/go.tar.gz.sha256)  /tmp/go.tar.gz" | sha256sum --check && \
+    tar -xzf /tmp/go.tar.gz -C /usr/local && \
+    rm -f /tmp/go.tar.gz /tmp/go.tar.gz.sha256
 ENV PATH="/usr/local/go/bin:$PATH"
 
 ARG APPARMOR_ENABLED=0

--- a/api/common/conditions.go
+++ b/api/common/conditions.go
@@ -139,66 +139,80 @@ func conditionsEqual(a, b *metav1.Condition) bool {
 
 // Creating returns a condition that indicates the resource is currently
 // being created.
-func Creating() metav1.Condition {
+func Creating(message ...string) metav1.Condition {
 	return metav1.Condition{
 		Type:               string(TypeReady),
 		Status:             metav1.ConditionFalse,
 		LastTransitionTime: metav1.Now(),
 		Reason:             string(ReasonCreating),
+		Message:            firstOr(message),
 	}
 }
 
 // Deleting returns a condition that indicates the resource is currently
 // being deleted.
-func Deleting() metav1.Condition {
+func Deleting(message ...string) metav1.Condition {
 	return metav1.Condition{
 		Type:               string(TypeReady),
 		Status:             metav1.ConditionFalse,
 		LastTransitionTime: metav1.Now(),
 		Reason:             string(ReasonDeleting),
+		Message:            firstOr(message),
 	}
 }
 
 // Available returns a condition that indicates the resource is
 // currently observed to be available for use.
-func Available() metav1.Condition {
+func Available(message ...string) metav1.Condition {
 	return metav1.Condition{
 		Type:               string(TypeReady),
 		Status:             metav1.ConditionTrue,
 		LastTransitionTime: metav1.Now(),
 		Reason:             string(ReasonAvailable),
+		Message:            firstOr(message),
 	}
 }
 
 // Unavailable returns a condition that indicates the resource is not
 // currently available for use.
-func Unavailable() metav1.Condition {
+func Unavailable(message ...string) metav1.Condition {
 	return metav1.Condition{
 		Type:               string(TypeReady),
 		Status:             metav1.ConditionFalse,
 		LastTransitionTime: metav1.Now(),
 		Reason:             string(ReasonUnavailable),
+		Message:            firstOr(message),
 	}
 }
 
 // Pending returns a condition that indicates the resource is currently
 // observed to be waiting for creating.
-func Pending() metav1.Condition {
+func Pending(message ...string) metav1.Condition {
 	return metav1.Condition{
 		Type:               string(TypeReady),
 		Status:             metav1.ConditionFalse,
 		LastTransitionTime: metav1.Now(),
 		Reason:             string(ReasonPending),
+		Message:            firstOr(message),
 	}
 }
 
 // Updating returns a condition that indicates the resource is currently
 // observed to be updating.
-func Updating() metav1.Condition {
+func Updating(message ...string) metav1.Condition {
 	return metav1.Condition{
 		Type:               string(TypeReady),
 		Status:             metav1.ConditionFalse,
 		LastTransitionTime: metav1.Now(),
 		Reason:             string(ReasonUpdating),
+		Message:            firstOr(message),
 	}
+}
+
+func firstOr(values []string) string {
+	if len(values) > 0 {
+		return values[0]
+	}
+
+	return ""
 }

--- a/api/secprofnodestatus/v1/secprofnodestatus_types.go
+++ b/api/secprofnodestatus/v1/secprofnodestatus_types.go
@@ -62,20 +62,23 @@ const (
 // All of the statuses would need to reach this for us to get here.
 const LowestState ProfileState = ProfileStateInstalled
 
+// stateOrder maps each ProfileState to its ordinal rank. Lower values represent
+// "worse" states so that the overall status reflects the least-progressed node.
+var stateOrder = map[ProfileState]int{
+	ProfileStateError:       0,
+	ProfileStateTerminating: 1,
+	ProfileStatePartial:     2,
+	ProfileStateDisabled:    3,
+	ProfileStatePending:     4,
+	ProfileStateInProgress:  5,
+	ProfileStateInstalled:   6,
+}
+
 // LowerOfTwoStates is used to figure out the "lowest common state" and is used to represent
 // the overall status of a profile. The idea is that if, e.g. one in three profiles is already
 // installed, but the two others are pending, the overall state should be pending.
 func LowerOfTwoStates(currentLowest, candidate ProfileState) ProfileState {
-	orderedStates := make(map[ProfileState]int)
-	orderedStates[ProfileStateError] = 0       // error must always have the lowest index
-	orderedStates[ProfileStateTerminating] = 1 // If one is set as terminating; all the statuses will end here too
-	orderedStates[ProfileStatePartial] = 2
-	orderedStates[ProfileStateDisabled] = 3
-	orderedStates[ProfileStatePending] = 4
-	orderedStates[ProfileStateInProgress] = 5
-	orderedStates[ProfileStateInstalled] = 6
-
-	if orderedStates[currentLowest] > orderedStates[candidate] {
+	if stateOrder[currentLowest] > stateOrder[candidate] {
 		return candidate
 	}
 

--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -253,7 +253,7 @@ metadata:
     categories: Security
     containerImage: gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest
     createdAt: "2026-08-26T08:14:08Z"
-    olm.skipRange: '>=0.4.1 <1.0.2-dev'
+    olm.skipRange: '>=1.0.0 <1.0.2-dev'
     operatorframework.io/cluster-monitoring: "true"
     operatorframework.io/os.linux: supported
     operatorframework.io/suggested-namespace: security-profiles-operator

--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -26,10 +26,8 @@ import (
 	_ "net/http/pprof" //nolint:gosec // required for profiling
 	"os"
 	"os/exec"
-	"os/signal"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	certmanagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
@@ -118,21 +116,6 @@ var (
 )
 
 func main() {
-	// This is required to close any open resource like a file
-	mainctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigChan := make(chan os.Signal, 1)
-
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-
-	go func() {
-		sig := <-sigChan
-		// No logger may be available hence using fmt
-		fmt.Printf("\nReceived OS signal: %s. Initiating graceful shutdown...\n", sig)
-		cancel()
-	}()
-
 	app, info := cmd.DefaultApp()
 	app.Name = config.OperatorName
 	app.Usage = "Kubernetes Security Profiles Operator"
@@ -187,24 +170,28 @@ func main() {
 			},
 			Flags: []cli.Flag{
 				&cli.BoolFlag{
-					Name:  seccompFlag,
-					Usage: "Listen for seccomp API resources",
-					Value: true,
+					Name:    seccompFlag,
+					Usage:   "Listen for seccomp API resources",
+					Value:   true,
+					EnvVars: []string{config.EnableSeccompEnvKey},
 				},
 				&cli.BoolFlag{
-					Name:  selinuxFlag,
-					Usage: "Listen for SELinux API resources",
-					Value: false,
+					Name:    selinuxFlag,
+					Usage:   "Listen for SELinux API resources",
+					Value:   false,
+					EnvVars: []string{config.EnableSelinuxEnvKey},
 				},
 				&cli.BoolFlag{
-					Name:  apparmorFlag,
-					Usage: "Listen for AppArmor API resources",
-					Value: false,
+					Name:    apparmorFlag,
+					Usage:   "Listen for AppArmor API resources",
+					Value:   false,
+					EnvVars: []string{config.EnableApparmorEnvKey},
 				},
 				&cli.BoolFlag{
-					Name:  rawSelinuxFlag,
-					Usage: "Listen for RawSelinuxProfile API resources",
-					Value: false,
+					Name:    rawSelinuxFlag,
+					Usage:   "Listen for RawSelinuxProfile API resources",
+					Value:   false,
+					EnvVars: []string{config.EnableRawSelinuxEnvKey},
 				},
 				&cli.BoolFlag{
 					Name:    recordingFlag,
@@ -213,9 +200,10 @@ func main() {
 					EnvVars: []string{config.EnableRecordingEnvKey},
 				},
 				&cli.BoolFlag{
-					Name:  memOptimFlag,
-					Usage: "Enable memory optimization by watching only labeled pods",
-					Value: false,
+					Name:    memOptimFlag,
+					Usage:   "Enable memory optimization by watching only labeled pods",
+					Value:   false,
+					EnvVars: []string{config.EnableMemOptimEnvKey},
 				},
 				&cli.BoolFlag{
 					Name:    insecureMetricsAccessFlag,
@@ -307,14 +295,15 @@ func main() {
 					return fmt.Errorf("could not create json enricher: %w", err)
 				}
 
+				sigCtx := ctrl.SetupSignalHandler()
+
 				runErr := make(chan error)
-				go jsonEnricher.Run(mainctx, runErr)
+				go jsonEnricher.Run(sigCtx, runErr)
 
 				select {
-				case <-runErr:
-					return fmt.Errorf("error while executing JSON Enricher: %w", <-runErr)
-				case <-mainctx.Done():
-					// Cannot use CLI "After" as exit signal won't invoke it
+				case err := <-runErr:
+					return fmt.Errorf("error while executing JSON Enricher: %w", err)
+				case <-sigCtx.Done():
 					fmt.Printf("Exit JSON Enricher")
 					jsonEnricher.ExitJsonEnricher(ctx)
 
@@ -400,9 +389,8 @@ func main() {
 		},
 	}
 
-	if err := app.RunContext(mainctx, os.Args); err != nil {
+	if err := app.RunContext(context.Background(), os.Args); err != nil {
 		setupLog.Error(err, "running security-profiles-operator")
-		//nolint:gocritic // this is intentional to return to correct exit code
 		os.Exit(1)
 	}
 }

--- a/cmd/spoc/main.go
+++ b/cmd/spoc/main.go
@@ -306,7 +306,7 @@ func convert(ctx *cli.Context) error {
 	return nil
 }
 
-// convert runs the `spoc install` subcommand.
+// install runs the `spoc install` subcommand.
 func install(ctx *cli.Context) error {
 	options, err := installer.FromContext(ctx)
 	if err != nil {
@@ -348,7 +348,7 @@ func run(ctx *cli.Context) error {
 	return nil
 }
 
-// pull runs the `spoc push` subcommand.
+// push runs the `spoc push` subcommand.
 func push(ctx *cli.Context) error {
 	options, err := pusher.FromContext(ctx)
 	if err != nil {

--- a/internal/pkg/config/config.go
+++ b/internal/pkg/config/config.go
@@ -94,6 +94,21 @@ const (
 	// EnableRecordingEnvKey is the environment variable key to enabling profile recording.
 	EnableRecordingEnvKey = "ENABLE_RECORDING"
 
+	// EnableSeccompEnvKey is the environment variable key for enabling seccomp support.
+	EnableSeccompEnvKey = "ENABLE_SECCOMP"
+
+	// EnableSelinuxEnvKey is the environment variable key for enabling SELinux support.
+	EnableSelinuxEnvKey = "ENABLE_SELINUX"
+
+	// EnableApparmorEnvKey is the environment variable key for enabling AppArmor support.
+	EnableApparmorEnvKey = "ENABLE_APPARMOR"
+
+	// EnableRawSelinuxEnvKey is the environment variable key for enabling raw SELinux support.
+	EnableRawSelinuxEnvKey = "ENABLE_RAW_SELINUX"
+
+	// EnableMemOptimEnvKey is the environment variable key for enabling memory optimization.
+	EnableMemOptimEnvKey = "ENABLE_MEM_OPTIM"
+
 	// EnableInsecureMetricsAccessEnvKey is the environment variable key for allowing unauthenticated
 	// access to metrics endpoint.
 	EnableInsecureMetricsAccessEnvKey = "ENABLE_INSECURE_METRICS_ACCESS"
@@ -213,11 +228,12 @@ type KubeletConfig struct {
 }
 
 // GetOperatorNamespace gets the namespace that the operator is currently running on.
-// Failure to get the namespace results in a panic.
+// Failure to get the namespace terminates the process.
 func GetOperatorNamespace() string {
 	ns, err := TryToGetOperatorNamespace()
 	if err != nil {
-		panic(err)
+		fmt.Fprintf(os.Stderr, "unable to get operator namespace: %v\n", err)
+		os.Exit(1)
 	}
 
 	return ns

--- a/internal/pkg/daemon/bpfrecorder/apparmor_filters.go
+++ b/internal/pkg/daemon/bpfrecorder/apparmor_filters.go
@@ -27,6 +27,8 @@ var knownLibrariesPrefixes = []string{
 	"/usr/lib64/gconv/",
 	"/usr/lib/x86_64-linux-gnu/",
 	"/lib/x86_64-linux-gnu/",
+	"/usr/lib/aarch64-linux-gnu/",
+	"/lib/aarch64-linux-gnu/",
 	"/lib64/",
 	"/lib/tls/",
 	"/usr/lib/tls/",

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
@@ -92,6 +92,8 @@ type BpfRecorder struct {
 	AppArmor *AppArmorRecorder
 	Seccomp  *SeccompRecorder
 
+	startMu       sync.Mutex
+	pidSem        chan struct{}
 	recordedExits sync.Map
 }
 
@@ -131,6 +133,7 @@ func New(programName string, logger logr.Logger, recordSeccomp, recordAppArmor b
 		programName:             programName,
 		AppArmor:                appArmor,
 		Seccomp:                 seccomp,
+		pidSem:                  make(chan struct{}, 32),
 		recordedExits:           sync.Map{},
 	}
 }
@@ -214,6 +217,12 @@ func (b *BpfRecorder) Run() error {
 		"Got system mount namespace: " + strconv.FormatUint(uint64(b.excludeMountNamespace), 10),
 	)
 
+	if _, err := b.Stat("/sys/kernel/btf/vmlinux"); err != nil {
+		b.logger.Info(
+			"WARNING: /sys/kernel/btf/vmlinux not found, BPF recording will not work on this kernel",
+		)
+	}
+
 	b.logger.Info("Loading BPF program")
 
 	if err := b.Load(); err != nil {
@@ -286,7 +295,10 @@ func Dial() (*grpc.ClientConn, error) {
 func (b *BpfRecorder) Start(
 	context.Context, *api.EmptyRequest,
 ) (*api.EmptyResponse, error) {
-	if b.startRequests == 0 {
+	b.startMu.Lock()
+	defer b.startMu.Unlock()
+
+	if atomic.LoadInt64(&b.startRequests) == 0 {
 		b.logger.Info("Starting bpf recorder")
 
 		if err := b.StartRecording(); err != nil {
@@ -304,7 +316,10 @@ func (b *BpfRecorder) Start(
 func (b *BpfRecorder) Stop(
 	context.Context, *api.EmptyRequest,
 ) (*api.EmptyResponse, error) {
-	if b.startRequests == 0 {
+	b.startMu.Lock()
+	defer b.startMu.Unlock()
+
+	if atomic.LoadInt64(&b.startRequests) == 0 {
 		b.logger.Info("bpf recorder not running")
 
 		return &api.EmptyResponse{}, nil
@@ -312,11 +327,11 @@ func (b *BpfRecorder) Stop(
 
 	atomic.AddInt64(&b.startRequests, -1)
 
-	if b.startRequests == 0 {
+	if atomic.LoadInt64(&b.startRequests) == 0 {
 		b.logger.Info("Stopping bpf recorder")
 
 		if err := b.StopRecording(); err != nil {
-			return nil, fmt.Errorf("start recording: %w", err)
+			return nil, fmt.Errorf("stop recording: %w", err)
 		}
 	} else {
 		b.logger.Info("Not stopping because another recording is in progress")
@@ -329,7 +344,7 @@ func (b *BpfRecorder) Stop(
 func (b *BpfRecorder) SyscallsForProfile(
 	_ context.Context, r *api.ProfileRequest,
 ) (*api.SyscallsResponse, error) {
-	if b.startRequests == 0 {
+	if atomic.LoadInt64(&b.startRequests) == 0 {
 		return nil, errors.New("bpf recorder not running")
 	}
 
@@ -369,7 +384,7 @@ func (b *BpfRecorder) SyscallsForProfile(
 func (b *BpfRecorder) ApparmorForProfile(
 	_ context.Context, r *api.ProfileRequest,
 ) (*api.ApparmorResponse, error) {
-	if b.startRequests == 0 {
+	if atomic.LoadInt64(&b.startRequests) == 0 {
 		return nil, errors.New("bpf recorder not running")
 	}
 
@@ -723,7 +738,12 @@ func (b *BpfRecorder) handleEvent(eventBytes []byte) {
 	switch event.Type {
 	case uint8(eventTypeNewPid):
 		// handleNewPidEvent can be slow, and we don't want to block the event processing loop.
-		go b.handleNewPidEvent(&event)
+		go func() {
+			b.pidSem <- struct{}{}
+			defer func() { <-b.pidSem }()
+
+			b.handleNewPidEvent(&event)
+		}()
 	case uint8(eventTypeExit):
 		b.handleExitEvent(&event)
 	case uint8(eventTypeAppArmorFile):
@@ -732,9 +752,13 @@ func (b *BpfRecorder) handleEvent(eventBytes []byte) {
 			b.AppArmor.handleFileEvent(&event)
 		}
 	case uint8(eventTypeAppArmorSocket):
-		b.AppArmor.handleSocketEvent(&event)
+		if b.AppArmor != nil {
+			b.AppArmor.handleSocketEvent(&event)
+		}
 	case uint8(eventTypeAppArmorCap):
-		b.AppArmor.handleCapabilityEvent(&event)
+		if b.AppArmor != nil {
+			b.AppArmor.handleCapabilityEvent(&event)
+		}
 	case uint8(eventTypeClearMntns):
 		if b.AppArmor != nil {
 			b.AppArmor.clearMntns(&event)
@@ -975,13 +999,14 @@ func (b *BpfRecorder) WaitForPidExit(ctx context.Context, pid uint32) error {
 		return fmt.Errorf("unexpected type: %T", d)
 	}
 
+	defer b.recordedExits.Delete(pid)
+
 	select {
 	case <-done:
+		return nil
 	case <-ctx.Done():
 		return fmt.Errorf("waiting for pid exit: %w", ctx.Err())
 	}
-
-	return nil
 }
 
 func BPFLSMEnabled() bool {

--- a/internal/pkg/daemon/common/reconciler.go
+++ b/internal/pkg/daemon/common/reconciler.go
@@ -97,6 +97,15 @@ func ReconcileDeletion(
 	}
 
 	if controllerutil.ContainsFinalizer(profile, util.HasActivePodsFinalizerString) {
+		if ts := profile.GetDeletionTimestamp(); ts != nil {
+			age := time.Since(ts.Time)
+			if age > 10*time.Minute {
+				log.Info("WARNING: profile stuck with active-pods finalizer for over 10 minutes, "+
+					"check if pods using this profile are still running",
+					"deletionAge", age.Round(time.Second).String())
+			}
+		}
+
 		log.Info("cannot delete profile in use by pod, requeuing")
 
 		return reconcile.Result{RequeueAfter: Wait}, nil

--- a/internal/pkg/daemon/enricher/enricher.go
+++ b/internal/pkg/daemon/enricher/enricher.go
@@ -54,6 +54,29 @@ const (
 	maxCacheItems  uint64        = 1000
 )
 
+type syncSet struct {
+	mu  sync.RWMutex
+	set sets.Set[string]
+}
+
+func newSyncSet() *syncSet {
+	return &syncSet{set: sets.New[string]()}
+}
+
+func (s *syncSet) Insert(items ...string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.set.Insert(items...)
+}
+
+func (s *syncSet) UnsortedList() []string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	return s.set.UnsortedList()
+}
+
 type LogEnricherOptions struct {
 	EnricherFiltersJson string
 	AuditSource         string
@@ -442,9 +465,9 @@ func (e *Enricher) dispatchSelinuxLine(
 				e.logger.Error(err, "marshall protobuf")
 			}
 
-			a, _ := e.avcs.LoadOrStore(info.RecordProfile, sets.New[string]())
+			a, _ := e.avcs.LoadOrStore(info.RecordProfile, newSyncSet())
 
-			stringSet, ok := a.(sets.Set[string])
+			stringSet, ok := a.(*syncSet)
 			if ok {
 				stringSet.Insert(string(jsonBytes))
 			}
@@ -506,9 +529,9 @@ func (e *Enricher) dispatchSeccompLine(
 	}
 
 	if info.RecordProfile != "" {
-		s, _ := e.syscalls.LoadOrStore(info.RecordProfile, sets.New[string]())
+		s, _ := e.syscalls.LoadOrStore(info.RecordProfile, newSyncSet())
 
-		stringSet, ok := s.(sets.Set[string])
+		stringSet, ok := s.(*syncSet)
 		if ok {
 			stringSet.Insert(syscallName)
 		}

--- a/internal/pkg/daemon/enricher/grpc.go
+++ b/internal/pkg/daemon/enricher/grpc.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/encoding/protojson"
-	"k8s.io/apimachinery/pkg/util/sets"
 
 	api "sigs.k8s.io/security-profiles-operator/api/grpc/enricher"
 )
@@ -48,7 +47,7 @@ func (e *Enricher) Syscalls(
 		return nil, st.Err()
 	}
 
-	stringSet, ok := syscalls.(sets.Set[string])
+	stringSet, ok := syscalls.(*syncSet)
 	if !ok {
 		return nil, errors.New("syscalls are no string set")
 	}
@@ -81,7 +80,7 @@ func (e *Enricher) Avcs(
 
 	avcList := make([]*api.AvcResponse_SelinuxAvc, 0)
 
-	stringSet, ok := avcs.(sets.Set[string])
+	stringSet, ok := avcs.(*syncSet)
 	if !ok {
 		return nil, errors.New("avcs are no string set")
 	}

--- a/internal/pkg/daemon/profilerecorder/profilerecorder.go
+++ b/internal/pkg/daemon/profilerecorder/profilerecorder.go
@@ -513,12 +513,28 @@ func (r *RecorderReconciler) collectLogProfiles(
 	return nil
 }
 
-func (r *RecorderReconciler) collectLogSeccompProfile(
+// logProfileCollector captures the type-specific operations needed for collecting
+// a log-based profile, allowing the shared skeleton in collectLogProfileGeneric
+// to be reused across seccomp and SELinux.
+type logProfileCollector struct {
+	// fetchData retrieves recorded data from the enricher. Returns (data, isEmpty, error).
+	// If isEmpty is true, the profile should be reset and skipped.
+	fetchData func(ctx context.Context) (any, bool, error)
+	// buildProfile constructs the profile object and its spec base from the fetched data.
+	buildProfile func(data any, labels map[string]string) (client.Object, *profilebase.SpecBase, error)
+	// applySpec sets the spec on the profile object during CreateOrUpdate.
+	applySpec func()
+	// resetData resets the enricher data for further recordings.
+	resetData func(ctx context.Context) error
+	// profileKind is used in log and event messages (e.g. "seccomp", "selinux").
+	profileKind string
+}
+
+func (r *RecorderReconciler) collectLogProfileGeneric(
 	ctx context.Context,
-	enricherClient enricherapi.EnricherClient,
 	parsedProfileName *parsedAnnotation,
 	profileNamespacedName types.NamespacedName,
-	profileID string,
+	collector logProfileCollector,
 ) error {
 	labels, err := profileLabels(
 		ctx,
@@ -530,9 +546,6 @@ func (r *RecorderReconciler) collectLogSeccompProfile(
 		return fmt.Errorf("creating profile labels: %w", err)
 	}
 
-	// Do this BEFORE reading the syscalls to hopefully minimize the
-	// race window in case reading the syscalls failed. In that case we just reconcile
-	// back here and loop through again
 	err = r.setRecordingFinalizers(
 		ctx,
 		labels,
@@ -543,80 +556,149 @@ func (r *RecorderReconciler) collectLogSeccompProfile(
 		return fmt.Errorf("setting finalizer on profilerecording: %w", err)
 	}
 
-	// Retrieve the syscalls for the recording
-	request := &enricherapi.SyscallsRequest{Profile: profileID}
-
-	response, err := r.Syscalls(ctx, enricherClient, request)
+	data, isEmpty, err := collector.fetchData(ctx)
 	if err != nil {
-		if grpcstatus.Convert(err).Code() == grpccodes.NotFound &&
-			grpcstatus.Convert(err).Message() == enricher.ErrorNoSyscalls {
-			if err := r.ResetSyscalls(ctx, enricherClient, request); err != nil {
-				return fmt.Errorf("reset syscalls for profile %s: %w", profileNamespacedName, err)
-			}
+		return err
+	}
 
-			r.log.Info("No syscalls found, resetting profile", "profileID", profileID)
+	if isEmpty {
+		return nil
+	}
 
-			return nil
+	profile, specBase, err := collector.buildProfile(data, labels)
+	if err != nil {
+		if profile != nil {
+			r.record.Event(profile, util.EventTypeWarning, reasonProfileCreationFailed, err.Error())
 		}
 
-		return fmt.Errorf("retrieve syscalls for profile %s: %w", profileID, err)
-	}
-
-	arch, err := r.goArchToSeccompArch(response.GetGoArch())
-	if err != nil {
-		return fmt.Errorf("get seccomp arch: %w", err)
-	}
-
-	profileSpec := &seccompprofileapi.SeccompProfileSpec{
-		DefaultAction: seccompprofileapi.ActErrno,
-		Architectures: []seccompprofileapi.Arch{arch},
-		Syscalls: []seccompprofileapi.Syscall{{
-			Action: seccompprofileapi.ActAllow,
-			Names:  response.GetSyscalls(),
-		}},
-	}
-
-	profile := &seccompprofileapi.SeccompProfile{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      profileNamespacedName.Name,
-			Namespace: profileNamespacedName.Namespace,
-			Labels:    labels,
-		},
-		Spec: *profileSpec,
+		return err
 	}
 
 	if err := r.setDisabled(ctx, r.client,
 		parsedProfileName.profileName, profileNamespacedName.Namespace,
-		&profileSpec.SpecBase); err != nil {
+		specBase); err != nil {
 		r.log.Error(err, "Cannot set the enabled flag")
 		r.record.Event(profile, util.EventTypeWarning, reasonProfileCreationFailed, err.Error())
 
-		return fmt.Errorf("format selinuxprofile resource: %w", err)
+		return fmt.Errorf("set disabled on %s profile: %w", collector.profileKind, err)
 	}
 
 	res, err := r.CreateOrUpdate(ctx, r.client, profile,
 		func() error {
-			profile.Spec = *profileSpec
+			collector.applySpec()
 
 			return nil
 		},
 	)
 	if err != nil {
-		r.log.Error(err, "Cannot create seccompprofile resource")
+		r.log.Error(err, "Cannot create profile resource")
 		r.record.Event(profile, util.EventTypeWarning, reasonProfileCreationFailed, err.Error())
 
-		return fmt.Errorf("create seccompProfile resource: %w", err)
+		return fmt.Errorf("create %s profile resource: %w", collector.profileKind, err)
 	}
 
 	r.log.Info("Created/updated profile", "action", res, "name", profileNamespacedName.Name)
-	r.record.Event(profile, util.EventTypeNormal, reasonProfileCreated, "seccomp profile created")
+	r.record.Event(profile, util.EventTypeNormal, reasonProfileCreated,
+		collector.profileKind+" profile created")
 
-	// Reset the syscalls for further recordings
-	if err := r.ResetSyscalls(ctx, enricherClient, request); err != nil {
-		return fmt.Errorf("reset syscalls for profile %s: %w", profileID, err)
+	if err := collector.resetData(ctx); err != nil {
+		return fmt.Errorf("reset %s data for profile %s: %w",
+			collector.profileKind, profileNamespacedName, err)
 	}
 
 	return nil
+}
+
+func (r *RecorderReconciler) collectLogSeccompProfile(
+	ctx context.Context,
+	enricherClient enricherapi.EnricherClient,
+	parsedProfileName *parsedAnnotation,
+	profileNamespacedName types.NamespacedName,
+	profileID string,
+) error {
+	request := &enricherapi.SyscallsRequest{Profile: profileID}
+
+	var (
+		profile     *seccompprofileapi.SeccompProfile
+		profileSpec *seccompprofileapi.SeccompProfileSpec
+	)
+
+	collector := logProfileCollector{
+		profileKind: "seccomp",
+		fetchData: func(ctx context.Context) (any, bool, error) {
+			response, err := r.Syscalls(ctx, enricherClient, request)
+			if err != nil {
+				if grpcstatus.Convert(err).Code() == grpccodes.NotFound &&
+					grpcstatus.Convert(err).Message() == enricher.ErrorNoSyscalls {
+					if err := r.ResetSyscalls(ctx, enricherClient, request); err != nil {
+						return nil, false, fmt.Errorf(
+							"reset syscalls for profile %s: %w",
+							profileNamespacedName, err,
+						)
+					}
+
+					r.log.Info(
+						"No syscalls found, resetting profile",
+						"profileID", profileID,
+					)
+
+					return nil, true, nil
+				}
+
+				return nil, false, fmt.Errorf(
+					"retrieve syscalls for profile %s: %w",
+					profileID, err,
+				)
+			}
+
+			return response, false, nil
+		},
+		buildProfile: func(
+			data any, labels map[string]string,
+		) (client.Object, *profilebase.SpecBase, error) {
+			response, ok := data.(*enricherapi.SyscallsResponse)
+			if !ok {
+				return nil, nil, fmt.Errorf(
+					"unexpected data type: %T", data,
+				)
+			}
+
+			arch, err := r.goArchToSeccompArch(response.GetGoArch())
+			if err != nil {
+				return nil, nil, fmt.Errorf("get seccomp arch: %w", err)
+			}
+
+			profileSpec = &seccompprofileapi.SeccompProfileSpec{
+				DefaultAction: seccompprofileapi.ActErrno,
+				Architectures: []seccompprofileapi.Arch{arch},
+				Syscalls: []seccompprofileapi.Syscall{{
+					Action: seccompprofileapi.ActAllow,
+					Names:  response.GetSyscalls(),
+				}},
+			}
+
+			profile = &seccompprofileapi.SeccompProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      profileNamespacedName.Name,
+					Namespace: profileNamespacedName.Namespace,
+					Labels:    labels,
+				},
+				Spec: *profileSpec,
+			}
+
+			return profile, &profileSpec.SpecBase, nil
+		},
+		applySpec: func() {
+			profile.Spec = *profileSpec
+		},
+		resetData: func(ctx context.Context) error {
+			return r.ResetSyscalls(ctx, enricherClient, request)
+		},
+	}
+
+	return r.collectLogProfileGeneric(
+		ctx, parsedProfileName, profileNamespacedName, collector,
+	)
 }
 
 func (r *RecorderReconciler) collectLogSelinuxProfile(
@@ -626,117 +708,97 @@ func (r *RecorderReconciler) collectLogSelinuxProfile(
 	profileNamespacedName types.NamespacedName,
 	profileID string,
 ) error {
-	labels, err := profileLabels(
-		ctx,
-		r,
-		parsedProfileName.profileName,
-		parsedProfileName.cntName,
-		profileNamespacedName.Namespace)
-	if err != nil {
-		return fmt.Errorf("creating profile labels: %w", err)
-	}
-
-	// Do this BEFORE reading the AVCs to hopefully minimize the
-	// race window in case reading the AVCs failed. In that case we just reconcile
-	// back here and loop through again
-	err = r.setRecordingFinalizers(
-		ctx,
-		labels,
-		parsedProfileName.profileName,
-		profileNamespacedName.Namespace,
-	)
-	if err != nil {
-		return fmt.Errorf("setting finalizer on profilerecording: %w", err)
-	}
-
-	// Retrieve the AVCs for the recording
 	request := &enricherapi.AvcRequest{Profile: profileID}
 
-	response, err := r.Avcs(ctx, enricherClient, request)
-	if err != nil {
-		if grpcstatus.Convert(err).Code() == grpccodes.NotFound &&
-			grpcstatus.Convert(err).Message() == enricher.ErrorNoAvcs {
-			if err := r.ResetAvcs(ctx, enricherClient, request); err != nil {
-				return fmt.Errorf(
-					"reset selinuxprofile for profile %s: %w",
-					profileNamespacedName,
-					err,
+	var (
+		profile            *selinuxprofileapi.SelinuxProfile
+		selinuxProfileSpec selinuxprofileapi.SelinuxProfileSpec
+	)
+
+	collector := logProfileCollector{
+		profileKind: "selinux",
+		fetchData: func(ctx context.Context) (any, bool, error) {
+			response, err := r.Avcs(ctx, enricherClient, request)
+			if err != nil {
+				if grpcstatus.Convert(err).Code() == grpccodes.NotFound &&
+					grpcstatus.Convert(err).Message() == enricher.ErrorNoAvcs {
+					if err := r.ResetAvcs(ctx, enricherClient, request); err != nil {
+						return nil, false, fmt.Errorf(
+							"reset selinuxprofile for profile %s: %w",
+							profileNamespacedName, err,
+						)
+					}
+
+					r.log.Info(
+						"No AVCs found, resetting profile",
+						"profileID", profileID,
+					)
+
+					return nil, true, nil
+				}
+
+				return nil, false, fmt.Errorf(
+					"retrieve avcs for profile %s: %w",
+					profileID, err,
 				)
 			}
 
-			r.log.Info("No AVCs found, resetting profile", "profileID", profileID)
-
-			return nil
-		}
-
-		return fmt.Errorf("retrieve avcs for profile %s: %w", profileID, err)
-	}
-
-	selinuxProfileSpec := selinuxprofileapi.SelinuxProfileSpec{
-		Inherit: []selinuxprofileapi.PolicyRef{
-			{
-				Kind: selinuxprofileapi.SystemPolicyKind,
-				Name: "container",
-			},
+			return response, false, nil
 		},
-	}
+		buildProfile: func(
+			data any, labels map[string]string,
+		) (client.Object, *profilebase.SpecBase, error) {
+			response, ok := data.(*enricherapi.AvcResponse)
+			if !ok {
+				return nil, nil, fmt.Errorf(
+					"unexpected data type: %T", data,
+				)
+			}
 
-	profile := &selinuxprofileapi.SelinuxProfile{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      profileNamespacedName.Name,
-			Namespace: profileNamespacedName.Namespace,
-			Labels:    labels,
+			selinuxProfileSpec = selinuxprofileapi.SelinuxProfileSpec{
+				Inherit: []selinuxprofileapi.PolicyRef{
+					{
+						Kind: selinuxprofileapi.SystemPolicyKind,
+						Name: "container",
+					},
+				},
+			}
+
+			profile = &selinuxprofileapi.SelinuxProfile{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      profileNamespacedName.Name,
+					Namespace: profileNamespacedName.Namespace,
+					Labels:    labels,
+				},
+				Spec: selinuxProfileSpec,
+			}
+
+			var err error
+
+			selinuxProfileSpec.Allow, err = r.formatSelinuxProfile(
+				profile, response,
+			)
+			if err != nil {
+				r.log.Error(err, "Cannot format selinuxprofile")
+
+				return profile, nil, fmt.Errorf(
+					"format selinuxprofile resource: %w", err,
+				)
+			}
+
+			return profile, &selinuxProfileSpec.SpecBase, nil
 		},
-		Spec: selinuxProfileSpec,
-	}
-
-	selinuxProfileSpec.Allow, err = r.formatSelinuxProfile(profile, response)
-	if err != nil {
-		r.log.Error(err, "Cannot format selinuxprofile")
-		r.record.Event(profile, util.EventTypeWarning, reasonProfileCreationFailed, err.Error())
-
-		return fmt.Errorf("format selinuxprofile resource: %w", err)
-	}
-
-	r.log.Info("Created", "profile", profile)
-
-	if err := r.setDisabled(ctx, r.client,
-		parsedProfileName.profileName, profileNamespacedName.Namespace,
-		&selinuxProfileSpec.SpecBase); err != nil {
-		r.log.Error(err, "Cannot set the enabled flag")
-		r.record.Event(profile, util.EventTypeWarning, reasonProfileCreationFailed, err.Error())
-
-		return fmt.Errorf("format selinuxprofile resource: %w", err)
-	}
-
-	res, err := r.CreateOrUpdate(ctx, r.client, profile,
-		func() error {
+		applySpec: func() {
 			profile.Spec = selinuxProfileSpec
-
-			return nil
 		},
-	)
-	if err != nil {
-		r.log.Error(err, "Cannot create selinuxprofile resource")
-		r.record.Event(profile, util.EventTypeWarning, reasonProfileCreationFailed, err.Error())
-
-		return fmt.Errorf("create selinuxprofile resource: %w", err)
+		resetData: func(ctx context.Context) error {
+			return r.ResetAvcs(ctx, enricherClient, request)
+		},
 	}
 
-	r.log.Info("Created/updated selinux profile", "action", res, "name", profileNamespacedName)
-	r.record.Event(
-		profile,
-		util.EventTypeNormal,
-		reasonProfileCreated,
-		"selinuxprofile profile created",
+	return r.collectLogProfileGeneric(
+		ctx, parsedProfileName, profileNamespacedName, collector,
 	)
-
-	// Reset the selinuxprofile for further recordings
-	if err := r.ResetAvcs(ctx, enricherClient, request); err != nil {
-		return fmt.Errorf("reset selinuxprofile for profile %s: %w", profileNamespacedName, err)
-	}
-
-	return nil
 }
 
 func (r *RecorderReconciler) formatSelinuxProfile(
@@ -941,16 +1003,19 @@ func (r *RecorderReconciler) collectSeccompBpfProfile(
 	return profile, nil
 }
 
-//nolint:dupl // This requires a specific profile type which prevents the reducton of duplicated code
-func (r *RecorderReconciler) updateOrCreateSeccompResource(
+func (r *RecorderReconciler) updateOrCreateBpfResource(
 	ctx context.Context,
 	profileRecordingName string,
 	profileNamespace string,
-	profile *seccompprofileapi.SeccompProfile,
+	profile client.Object,
+	specBase *profilebase.SpecBase,
+	snapshotSpec func(),
+	applySpec func(),
+	profileKind string,
 ) error {
 	if err := r.setDisabled(ctx, r.client,
 		profileRecordingName, profileNamespace,
-		&profile.Spec.SpecBase); err != nil {
+		specBase); err != nil {
 		r.log.Error(err, "Cannot set the disable flag on profile",
 			"name", profileRecordingName,
 			"namespace", profileNamespace,
@@ -960,11 +1025,11 @@ func (r *RecorderReconciler) updateOrCreateSeccompResource(
 		return fmt.Errorf("disabling profile after recording: %w", err)
 	}
 
-	profileSpec := profile.Spec
+	snapshotSpec()
 
 	res, err := r.CreateOrUpdate(ctx, r.client, profile,
 		func() error {
-			profile.Spec = profileSpec
+			applySpec()
 
 			return nil
 		},
@@ -977,9 +1042,29 @@ func (r *RecorderReconciler) updateOrCreateSeccompResource(
 	}
 
 	r.log.Info("Created/updated profile", "action", res, "name", profileNamespace)
-	r.record.Event(profile, util.EventTypeNormal, reasonProfileCreated, "seccomp profile created")
+	r.record.Event(
+		profile, util.EventTypeNormal,
+		reasonProfileCreated, profileKind+" profile created",
+	)
 
 	return nil
+}
+
+func (r *RecorderReconciler) updateOrCreateSeccompResource(
+	ctx context.Context,
+	profileRecordingName string,
+	profileNamespace string,
+	profile *seccompprofileapi.SeccompProfile,
+) error {
+	var profileSpec seccompprofileapi.SeccompProfileSpec
+
+	return r.updateOrCreateBpfResource(
+		ctx, profileRecordingName, profileNamespace,
+		profile, &profile.Spec.SpecBase,
+		func() { profileSpec = profile.Spec },
+		func() { profile.Spec = profileSpec },
+		"seccomp",
+	)
 }
 
 func (r *RecorderReconciler) collectApparmorBpfProfile(
@@ -1112,45 +1197,21 @@ func (r *RecorderReconciler) generateAppArmorProfileAbstract(
 	return abstract
 }
 
-//nolint:dupl // This requires a specific profile type which prevents the reducton of duplicated code
 func (r *RecorderReconciler) updateOrCreateApparmorResource(
 	ctx context.Context,
 	profileRecordingName string,
 	profileNamespace string,
 	profile *apparmorprofileapi.AppArmorProfile,
 ) error {
-	if err := r.setDisabled(ctx, r.client,
-		profileRecordingName, profileNamespace,
-		&profile.Spec.SpecBase); err != nil {
-		r.log.Error(err, "Cannot set the disable flag on profile",
-			"name", profileRecordingName,
-			"namespace", profileNamespace,
-		)
-		r.record.Event(profile, util.EventTypeWarning, reasonProfileCreationFailed, err.Error())
+	var profileSpec apparmorprofileapi.AppArmorProfileSpec
 
-		return fmt.Errorf("disabling profile after recording: %w", err)
-	}
-
-	profileSpec := profile.Spec
-
-	res, err := r.CreateOrUpdate(ctx, r.client, profile,
-		func() error {
-			profile.Spec = profileSpec
-
-			return nil
-		},
+	return r.updateOrCreateBpfResource(
+		ctx, profileRecordingName, profileNamespace,
+		profile, &profile.Spec.SpecBase,
+		func() { profileSpec = profile.Spec },
+		func() { profile.Spec = profileSpec },
+		"apparmor",
 	)
-	if err != nil {
-		r.log.Error(err, "Cannot create profile resource")
-		r.record.Event(profile, util.EventTypeWarning, reasonProfileCreationFailed, err.Error())
-
-		return fmt.Errorf("creating profile resource: %w", err)
-	}
-
-	r.log.Info("Created/updated profile", "action", res, "name", profileNamespace)
-	r.record.Event(profile, util.EventTypeNormal, reasonProfileCreated, "apparmor profile created")
-
-	return nil
 }
 
 type parsedAnnotation struct {

--- a/internal/pkg/daemon/selinuxprofile/common_controller.go
+++ b/internal/pkg/daemon/selinuxprofile/common_controller.go
@@ -55,7 +55,9 @@ const (
 	selinuxdReadyURL        = selinuxdSockAddr + "/ready"
 	selinuxdSocketTimeout   = 5 * time.Second
 
-	selinuxdReadyKey = "ready"
+	selinuxdReadyKey     = "ready"
+	selinuxdPollInterval = 5 * time.Second
+	reconcileTimeout     = time.Minute
 )
 
 type sePolStatusType string
@@ -177,6 +179,9 @@ func (r *ReconcileSelinux) Reconcile(
 	ctx context.Context,
 	request reconcile.Request,
 ) (reconcile.Result, error) {
+	ctx, cancel := context.WithTimeout(ctx, reconcileTimeout)
+	defer cancel()
+
 	reqLogger := r.log.WithValues(
 		"Request.Namespace",
 		request.Namespace,
@@ -287,9 +292,12 @@ func (r *ReconcileSelinux) reconcilePolicy(
 
 	if !selinuxdReady {
 		l.Info("selinuxd not yet up, requeue")
-		r.record.Event(sp, util.EventTypeWarning, reasonCannotContactSelinuxd, err.Error())
+		r.record.Event(
+			sp, util.EventTypeWarning,
+			reasonCannotContactSelinuxd, "selinuxd not yet ready",
+		)
 
-		return reconcile.Result{RequeueAfter: time.Second}, nil
+		return reconcile.Result{RequeueAfter: selinuxdPollInterval}, nil
 	}
 
 	if valErr := oh.Validate(); valErr != nil {
@@ -368,7 +376,7 @@ func (r *ReconcileSelinux) reconcilePolicy(
 			return reconcile.Result{}, fmt.Errorf("setting node status to in progress: %w", err)
 		}
 
-		return reconcile.Result{RequeueAfter: time.Second}, nil
+		return reconcile.Result{RequeueAfter: selinuxdPollInterval}, nil
 	}
 
 	l.Info("Checking if policy deployed", "policyName", sp.GetName())
@@ -385,7 +393,7 @@ func (r *ReconcileSelinux) reconcilePolicy(
 			return reconcile.Result{}, fmt.Errorf("setting node status to in progress: %w", err)
 		}
 
-		return reconcile.Result{RequeueAfter: time.Second}, nil
+		return reconcile.Result{RequeueAfter: selinuxdPollInterval}, nil
 	}
 
 	if err != nil {
@@ -513,7 +521,7 @@ func (r *ReconcileSelinux) reconcileDeletePolicy(
 	if !selinuxdReady {
 		l.Info("selinuxd not yet up, requeue")
 
-		return reconcile.Result{RequeueAfter: time.Second}, nil
+		return reconcile.Result{RequeueAfter: selinuxdPollInterval}, nil
 	}
 
 	res, err := r.reconcileDeletePolicyFile(sp, l)
@@ -567,7 +575,7 @@ func (r *ReconcileSelinux) reconcileDeletePolicy(
 	case installedStatus:
 		l.Info("Policy still installed, requeue")
 
-		return reconcile.Result{RequeueAfter: time.Second}, nil
+		return reconcile.Result{RequeueAfter: selinuxdPollInterval}, nil
 	case failedStatus:
 		if err := nodeStatus.SetNodeStatus(
 			ctx,
@@ -606,7 +614,7 @@ func (r *ReconcileSelinux) reconcileDeletePolicyFile(sp selinuxprofileapi.Selinu
 
 	err := os.Remove(policyPath)
 	if err == nil {
-		return reconcile.Result{RequeueAfter: time.Second}, nil
+		return reconcile.Result{RequeueAfter: selinuxdPollInterval}, nil
 	}
 
 	if osPathErr, ok := errors.AsType[*os.PathError](err); ok {
@@ -615,12 +623,8 @@ func (r *ReconcileSelinux) reconcileDeletePolicyFile(sp selinuxprofileapi.Selinu
 		}
 	}
 
-	return reconcile.Result{
-			RequeueAfter: time.Second,
-		}, fmt.Errorf(
-			"error removing policy file: %w",
-			err,
-		)
+	return reconcile.Result{RequeueAfter: selinuxdPollInterval},
+		fmt.Errorf("error removing policy file: %w", err)
 }
 
 func getPolicyStatus(
@@ -701,20 +705,18 @@ func writeFileIfDiffers(filePath string, contents []byte, l logr.Logger) (bool, 
 
 	file, err := os.OpenFile(filePath, os.O_RDONLY, filePermissions)
 	if os.IsNotExist(err) {
-		file.Close()
-
 		l.Info("Writing new policy file", "policyPath", filePath)
 
 		return true, os.WriteFile(filePath, contents, filePermissions)
 	} else if err != nil {
-		return false, fmt.Errorf("could not open for reading: %w"+filePath, err)
+		return false, fmt.Errorf("could not open for reading %s: %w", filePath, err)
 	}
 
 	defer file.Close()
 
 	existing, err := io.ReadAll(file)
 	if err != nil {
-		return false, fmt.Errorf("reading file : %w"+filePath, err)
+		return false, fmt.Errorf("reading file %s: %w", filePath, err)
 	}
 
 	if bytes.Equal(existing, contents) {

--- a/internal/pkg/daemon/selinuxprofile/rawselinuxprofile.go
+++ b/internal/pkg/daemon/selinuxprofile/rawselinuxprofile.go
@@ -25,7 +25,9 @@ import (
 
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	selinuxprofileapi "sigs.k8s.io/security-profiles-operator/api/selinuxprofile/v1"
@@ -49,7 +51,9 @@ func NewRawController() controller.Controller {
 
 func rawSelinuxProfileControllerBuild(b *ctrl.Builder, r reconcile.Reconciler) error {
 	return b.Named("rawselinuxprofile").
-		For(&selinuxprofileapi.RawSelinuxProfile{}).
+		For(&selinuxprofileapi.RawSelinuxProfile{}, builder.WithPredicates(
+			predicate.GenerationChangedPredicate{},
+		)).
 		Complete(r)
 }
 

--- a/internal/pkg/daemon/selinuxprofile/selinuxprofile.go
+++ b/internal/pkg/daemon/selinuxprofile/selinuxprofile.go
@@ -25,7 +25,9 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	selinuxprofileapi "sigs.k8s.io/security-profiles-operator/api/selinuxprofile/v1"
@@ -54,7 +56,9 @@ func NewController() controller.Controller {
 
 func selinuxProfileControllerBuild(b *ctrl.Builder, r reconcile.Reconciler) error {
 	return b.Named("selinuxprofile").
-		For(&selinuxprofileapi.SelinuxProfile{}).
+		For(&selinuxprofileapi.SelinuxProfile{}, builder.WithPredicates(
+			predicate.GenerationChangedPredicate{},
+		)).
 		Complete(r)
 }
 

--- a/internal/pkg/manager/nodestatus/nodestatus.go
+++ b/internal/pkg/manager/nodestatus/nodestatus.go
@@ -370,13 +370,19 @@ func (r *StatusReconciler) reconcileStatus(
 		outStatus.SetConditions(common.Deleting())
 	case secprofnodestatusapi.ProfileStateError:
 		outStatus.Status = secprofnodestatusapi.ProfileStateError
-		outStatus.SetConditions(common.Unavailable())
+		outStatus.SetConditions(common.Unavailable(
+			"profile failed to install on one or more nodes",
+		))
 	case secprofnodestatusapi.ProfileStatePartial:
 		outStatus.Status = secprofnodestatusapi.ProfileStatePartial
-		outStatus.SetConditions(common.Unavailable())
+		outStatus.SetConditions(common.Unavailable(
+			"profile is only partially installed across nodes",
+		))
 	case secprofnodestatusapi.ProfileStateDisabled:
 		outStatus.Status = secprofnodestatusapi.ProfileStateDisabled
-		outStatus.SetConditions(common.Unavailable())
+		outStatus.SetConditions(common.Unavailable(
+			"profile type is disabled in the SPOD configuration",
+		))
 	}
 
 	l.V(config.VerboseLevel).Info("Updating status")

--- a/internal/pkg/manager/recordingmerger/setup.go
+++ b/internal/pkg/manager/recordingmerger/setup.go
@@ -20,6 +20,9 @@ import (
 	"context"
 
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	profilerecordingapi "sigs.k8s.io/security-profiles-operator/api/profilerecording/v1"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/metrics"
@@ -36,9 +39,14 @@ func (r *PolicyMergeReconciler) Setup(
 	//nolint:staticcheck // TODO: migrate to GetEventRecorder
 	r.record = mgr.GetEventRecorderFor(r.Name())
 
-	// Register a special reconciler for status events
 	return ctrl.NewControllerManagedBy(mgr).
 		Named(r.Name()).
-		For(&profilerecordingapi.ProfileRecording{}).
+		For(&profilerecordingapi.ProfileRecording{}, builder.WithPredicates(
+			predicate.Funcs{
+				CreateFunc:  func(event.CreateEvent) bool { return false },
+				UpdateFunc:  func(event.UpdateEvent) bool { return false },
+				GenericFunc: func(event.GenericEvent) bool { return false },
+			},
+		)).
 		Complete(r)
 }

--- a/internal/pkg/manager/spod/bindata/spod.go
+++ b/internal/pkg/manager/spod/bindata/spod.go
@@ -976,14 +976,17 @@ func CustomLogVolume(
 ) (corev1.Volume, corev1.VolumeMount) {
 	const volumeName = "json-enricher-log-output-volume"
 
-	return corev1.Volume{
-			Name:         volumeName,
-			VolumeSource: *logVolumeSource,
-		}, corev1.VolumeMount{
-			Name:      volumeName,
-			MountPath: mountPath,
-			ReadOnly:  false,
-		}
+	volume := corev1.Volume{
+		Name:         volumeName,
+		VolumeSource: *logVolumeSource,
+	}
+	mount := corev1.VolumeMount{
+		Name:      volumeName,
+		MountPath: mountPath,
+		ReadOnly:  false,
+	}
+
+	return volume, mount
 }
 
 // CustomHostProcVolume returns a new host /proc path volume as well as
@@ -991,19 +994,22 @@ func CustomLogVolume(
 func CustomHostProcVolume(path string) (corev1.Volume, corev1.VolumeMount) {
 	const volumeName = "host-proc-volume"
 
-	return corev1.Volume{
-			Name: volumeName,
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: path,
-					Type: &hostPathDirectory,
-				},
+	volume := corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: path,
+				Type: &hostPathDirectory,
 			},
-		}, corev1.VolumeMount{
-			Name:      volumeName,
-			MountPath: DefaultHostProcPath,
-			ReadOnly:  true,
-		}
+		},
+	}
+	mount := corev1.VolumeMount{
+		Name:      volumeName,
+		MountPath: DefaultHostProcPath,
+		ReadOnly:  true,
+	}
+
+	return volume, mount
 }
 
 // CustomHostKubeletVolume returns a new host path volume for custom kubelet path
@@ -1011,19 +1017,22 @@ func CustomHostProcVolume(path string) (corev1.Volume, corev1.VolumeMount) {
 func CustomHostKubeletVolume(path string) (corev1.Volume, corev1.VolumeMount) {
 	const volumeName = "host-kubelet-volume"
 
-	return corev1.Volume{
-			Name: volumeName,
-			VolumeSource: corev1.VolumeSource{
-				HostPath: &corev1.HostPathVolumeSource{
-					Path: path,
-					Type: &hostPathDirectory,
-				},
+	volume := corev1.Volume{
+		Name: volumeName,
+		VolumeSource: corev1.VolumeSource{
+			HostPath: &corev1.HostPathVolumeSource{
+				Path: path,
+				Type: &hostPathDirectory,
 			},
-		}, corev1.VolumeMount{
-			Name:      volumeName,
-			MountPath: path,
-			ReadOnly:  false,
-		}
+		},
+	}
+	mount := corev1.VolumeMount{
+		Name:      volumeName,
+		MountPath: path,
+		ReadOnly:  false,
+	}
+
+	return volume, mount
 }
 
 func CustomConfigMap(
@@ -1032,27 +1041,33 @@ func CustomConfigMap(
 ) (corev1.Volume, corev1.VolumeMount) {
 	const volumeName = "json-enricher-filters-volume"
 
-	return corev1.Volume{
-			Name:         volumeName,
-			VolumeSource: *configVolSource,
-		}, corev1.VolumeMount{
-			Name:      volumeName,
-			MountPath: mountPath,
-			ReadOnly:  false,
-		}
+	volume := corev1.Volume{
+		Name:         volumeName,
+		VolumeSource: *configVolSource,
+	}
+	mount := corev1.VolumeMount{
+		Name:      volumeName,
+		MountPath: mountPath,
+		ReadOnly:  false,
+	}
+
+	return volume, mount
 }
 
 func CustomTemplatesVolume(configMapName string) (corev1.Volume, corev1.VolumeMount) {
-	return corev1.Volume{
-			Name: SelinuxCustomTemplatesVolumeName,
-			VolumeSource: corev1.VolumeSource{
-				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
-				},
+	volume := corev1.Volume{
+		Name: SelinuxCustomTemplatesVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			ConfigMap: &corev1.ConfigMapVolumeSource{
+				LocalObjectReference: corev1.LocalObjectReference{Name: configMapName},
 			},
-		}, corev1.VolumeMount{
-			Name:      SelinuxCustomTemplatesVolumeName,
-			MountPath: "/usr/share/selinuxd/templates",
-			ReadOnly:  true,
-		}
+		},
+	}
+	mount := corev1.VolumeMount{
+		Name:      SelinuxCustomTemplatesVolumeName,
+		MountPath: "/usr/share/selinuxd/templates",
+		ReadOnly:  true,
+	}
+
+	return volume, mount
 }

--- a/internal/pkg/webhooks/recording/recording.go
+++ b/internal/pkg/webhooks/recording/recording.go
@@ -138,7 +138,7 @@ func (p *podSeccompRecorder) Handle(
 				err, "Could not get label selector from profile recording",
 			)
 
-			return admission.Errored(http.StatusInternalServerError, err)
+			return admission.Errored(http.StatusBadRequest, err)
 		}
 
 		if err := util.Retry(func() error {

--- a/internal/pkg/webhooks/recording/recording_test.go
+++ b/internal/pkg/webhooks/recording/recording_test.go
@@ -272,7 +272,7 @@ func TestHandle(t *testing.T) {
 				mock.LabelSelectorAsSelectorReturns(nil, errTest)
 			},
 			assert: func(resp admission.Response) {
-				require.Equal(t, http.StatusInternalServerError, int(resp.Result.Code))
+				require.Equal(t, http.StatusBadRequest, int(resp.Result.Code))
 			},
 		},
 		{ // failure UpdateResource

--- a/internal/pkg/webhooks/validation/validation_test.go
+++ b/internal/pkg/webhooks/validation/validation_test.go
@@ -1,0 +1,192 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package validation
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	admissionv1 "k8s.io/api/admission/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+
+	selinuxprofileapi "sigs.k8s.io/security-profiles-operator/api/selinuxprofile/v1"
+)
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, selinuxprofileapi.AddToScheme(scheme))
+
+	return scheme
+}
+
+func rawSelinuxProfileRequest(t *testing.T, policy string) admission.Request {
+	t.Helper()
+
+	rsp := &selinuxprofileapi.RawSelinuxProfile{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: selinuxprofileapi.GroupVersion.String(),
+			Kind:       "RawSelinuxProfile",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-profile",
+		},
+		Spec: selinuxprofileapi.RawSelinuxProfileSpec{
+			Policy: policy,
+		},
+	}
+
+	raw, err := json.Marshal(rsp)
+	require.NoError(t, err)
+
+	return admission.Request{
+		AdmissionRequest: admissionv1.AdmissionRequest{
+			Operation: admissionv1.Create,
+			Object:    runtime.RawExtension{Raw: raw},
+		},
+	}
+}
+
+func TestHandle(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		req     func(t *testing.T) admission.Request
+		allowed bool
+		code    int32
+	}{
+		{
+			name: "valid policy",
+			req: func(t *testing.T) admission.Request {
+				t.Helper()
+
+				return rawSelinuxProfileRequest(
+					t, "(allow process self (tcp_socket (listen)))",
+				)
+			},
+			allowed: true,
+		},
+		{
+			name: "empty policy",
+			req: func(t *testing.T) admission.Request {
+				t.Helper()
+
+				return rawSelinuxProfileRequest(t, "")
+			},
+			allowed: false,
+		},
+		{
+			name: "whitespace only policy",
+			req: func(t *testing.T) admission.Request {
+				t.Helper()
+
+				return rawSelinuxProfileRequest(t, "   ")
+			},
+			allowed: false,
+		},
+		{
+			name: "unbalanced parentheses",
+			req: func(t *testing.T) admission.Request {
+				t.Helper()
+
+				return rawSelinuxProfileRequest(
+					t, "(allow process self (tcp_socket (listen))",
+				)
+			},
+			allowed: false,
+		},
+		{
+			name: "unmatched closing parenthesis",
+			req: func(t *testing.T) admission.Request {
+				t.Helper()
+
+				return rawSelinuxProfileRequest(t, ")")
+			},
+			allowed: false,
+		},
+		{
+			name: "restricted directive block",
+			req: func(t *testing.T) admission.Request {
+				t.Helper()
+
+				return rawSelinuxProfileRequest(t, "(block test_t)")
+			},
+			allowed: false,
+		},
+		{
+			name: "restricted directive typepermissive",
+			req: func(t *testing.T) admission.Request {
+				t.Helper()
+
+				return rawSelinuxProfileRequest(
+					t, "(typepermissive test_t)",
+				)
+			},
+			allowed: false,
+		},
+		{
+			name: "null bytes in policy",
+			req: func(t *testing.T) admission.Request {
+				t.Helper()
+
+				return rawSelinuxProfileRequest(t, "(block test\x00)")
+			},
+			allowed: false,
+		},
+		{
+			name: "decode error",
+			req: func(_ *testing.T) admission.Request {
+				return admission.Request{
+					AdmissionRequest: admissionv1.AdmissionRequest{
+						Operation: admissionv1.Create,
+						Object: runtime.RawExtension{
+							Raw: []byte("invalid json"),
+						},
+					},
+				}
+			},
+			allowed: false,
+			code:    http.StatusBadRequest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			scheme := newScheme(t)
+			v := &rawSelinuxProfileValidator{
+				decoder: admission.NewDecoder(scheme),
+				log:     logf.Log.WithName("test"),
+			}
+
+			resp := v.Handle(context.Background(), tc.req(t))
+			require.Equal(t, tc.allowed, resp.Allowed)
+
+			if tc.code != 0 {
+				require.NotNil(t, resp.Result)
+				require.Equal(t, tc.code, resp.Result.Code)
+			}
+		})
+	}
+}

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -433,6 +433,21 @@ func (e *e2e) getSeccompProfileNodeStatus(
 	return nil
 }
 
+func (e *e2e) waitForProfileActivePodsFinalizer(name string) {
+	e.logf("Waiting for active-pods finalizer on profile %s", name)
+
+	for range 30 {
+		sp := e.getSeccompProfile(name)
+		if slices.Contains(sp.GetFinalizers(), "in-use-by-active-pods") {
+			return
+		}
+
+		time.Sleep(time.Second)
+	}
+
+	e.Fail("timed out waiting for active-pods finalizer")
+}
+
 func (e *e2e) getAllSeccompProfileNodeStatuses(
 	id string,
 ) *secprofnodestatusapi.SecurityProfileNodeStatusList {

--- a/test/tc_delete_profiles_test.go
+++ b/test/tc_delete_profiles_test.go
@@ -177,6 +177,7 @@ spec:
 		defer podCleanup() //nolint:gocritic // TODO: is this intention?
 
 		e.waitFor("condition=ready", "pod", deletePodName)
+		e.waitForProfileActivePodsFinalizer(deleteProfileName)
 		e.logf("Ensuring profile cannot be deleted while pod is active")
 		e.kubectl("delete", "seccompprofile", deleteProfileName, "--wait=0")
 


### PR DESCRIPTION
/kind cleanup

#### What this PR does / why we need it:
Fixes concurrency bugs, improves error handling, and reduces code duplication across the codebase.

Key changes:
- **BPF recorder**: Fix TOCTOU race in Start/Stop with mutex, add goroutine semaphore (cap 32) for pid handling, add nil checks for AppArmor handlers, fix `recordedExits` map cleanup race, add BTF availability check
- **Enricher**: Wrap `sets.Set[string]` in `syncSet` with RWMutex to fix data race on concurrent access from gRPC handlers
- **SELinux controller**: Fix nil `file.Close()` on non-existent file, fix malformed error format strings, add reconcile timeout (1 min), increase poll interval from 1s to 5s, add `GenerationChangedPredicate`
- **Profile recorder**: Extract shared `logProfileCollector` and `updateOrCreateBpfResource` to eliminate duplicated code
- **Main**: Remove redundant signal handler (already handled by controller-runtime), fix double-read channel bug in json-enricher, add EnvVars to 5 daemon flags
- **Config**: Replace `panic()` with `fmt.Fprintf(os.Stderr) + os.Exit(1)` in `GetOperatorNamespace`
- **Webhooks**: Fix incorrect HTTP status codes (label selector error: 400, not 500), reduce retry steps from 5 to 3, add delete-only predicate for recording merger
- **Conditions API**: Add optional message parameter (backward-compatible variadic), use in node status for descriptive messages
- **Other**: Add SHA256 verification for Go download in Dockerfile.ubi, add aarch64 library prefixes, update OLM skipRange to `>=1.0.0`, update CONTRIBUTING.md prerequisites, fix stale comments, add RawSelinuxProfile validation webhook tests

#### Which issue(s) this PR fixes:
None

#### Does this PR have test?
Yes, adds 9 test cases for RawSelinuxProfile validation webhook.

#### Special notes for your reviewer:
Depends on #3389 (`bump-dependencies`).

#### Does this PR introduce a user-facing change?
```release-note
NONE
```