### PR TITLE
fix(ci): update Kubernetes to 1.37 and fix Flatcar e2e

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,7 @@ permissions: {}
 jobs:
   macos:
     runs-on: macos-latest
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -36,6 +37,7 @@ jobs:
           - ppc64le
     runs-on: ubuntu-24.04
     name: nix / ${{ matrix.arch }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
@@ -62,6 +64,7 @@ jobs:
           - ppc64le
     runs-on: ubuntu-24.04
     name: nix / spoc / ${{ matrix.arch }}
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: cachix/install-nix-action@13d8dd58da0234aa297dedd986986ccb8e7f3e24 # v31.11.1
@@ -85,6 +88,7 @@ jobs:
     if: github.ref == 'refs/heads/main' || contains(github.ref, 'refs/tags')
     name: nix / spoc / push / ${{ matrix.arch }}
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: write  # required for updating the release
       id-token: write  # required for sigstore signing
@@ -117,6 +121,7 @@ jobs:
 
   bpf:
     runs-on: ubuntu-24.04
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -134,6 +139,7 @@ jobs:
 
   build-image:
     runs-on: ubuntu-24.04
+    timeout-minutes: 40
     steps:
       - name: Remove unnecessary files
         run: |
@@ -175,6 +181,7 @@ jobs:
 
   operator-image:
     runs-on: ubuntu-24.04
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Docker Buildx
@@ -209,6 +216,7 @@ jobs:
 
   ubi-image:
     runs-on: ubuntu-24.04
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Set up Docker Buildx

--- a/.github/workflows/helm-chart-lint.yaml
+++ b/.github/workflows/helm-chart-lint.yaml
@@ -14,6 +14,7 @@ permissions: {}
 jobs:
   lint-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/helm-chart-package.yaml
+++ b/.github/workflows/helm-chart-package.yaml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   helm-package:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/olm_tests.yaml
+++ b/.github/workflows/olm_tests.yaml
@@ -5,7 +5,7 @@ on:
       - main
   pull_request:
 env:
-  KIND_IMG_TAG: v1.36.1
+  KIND_IMG_TAG: v1.37.0
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -16,6 +16,7 @@ jobs:
   main:
     name: tests
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
 
     steps:
     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/osff.yml
+++ b/.github/workflows/osff.yml
@@ -17,6 +17,7 @@ jobs:
   analysis:
     name: scorecard
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,7 @@ jobs:
       security-events: write
 
     runs-on: ubuntu-24.04
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
@@ -28,6 +29,7 @@ jobs:
 
   coverage:
     runs-on: ubuntu-24.04
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7.0.0
@@ -44,6 +46,7 @@ jobs:
 
   image:
     runs-on: ubuntu-24.04
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: hack/install-crun
@@ -277,6 +280,7 @@ jobs:
 
   typos:
     runs-on: ubuntu-24.04
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: crate-ci/typos@8a48f81b6c64dcfea44b3633223084c4be58ac5f # v1.49.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,11 +13,6 @@ documentation, submitting pull requests or patches, and other activities._
 
 We have full documentation on how to get started contributing here:
 
-<!---
-If your repo has certain guidelines for contribution, put them here ahead of the
-general k8s resources
--->
-
 - [Contributor License Agreement](https://git.k8s.io/community/CLA.md)
   Kubernetes projects require that you sign a Contributor License Agreement
   (CLA) before we can accept your pull requests
@@ -67,11 +62,6 @@ Following the targets that can be used to test your changes locally.
 - [Mentoring Initiatives](https://git.k8s.io/community/mentoring) - We have a
   diverse set of mentorship programs available that are always looking for
   volunteers!
-
-<!---
-Custom Information - if you're copying this template for the first time you can
-add custom content here.
--->
 
 ## Contact Information
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -58,13 +58,13 @@ dependencies:
       match: cert-manager/cert-manager
 
   - name: kind
-    version: 0.32.0
+    version: 0.33.0
     refPaths:
     - path: test/suite_test.go
       match: 'kindVersion\s+='
 
   - name: kind-image
-    version: 1.36.1
+    version: 1.37.0
     refPaths:
     - path: test/suite_test.go
       match: 'kindImage\s+='
@@ -72,7 +72,7 @@ dependencies:
       match: KIND_IMG_TAG
 
   - name: e2e-kubernetes
-    version: 1.36
+    version: 1.37
     refPaths:
     - path: hack/ci/Vagrantfile-fedora
       match: "KUBERNETES_VERSION="

--- a/hack/ci/Vagrantfile-debian
+++ b/hack/ci/Vagrantfile-debian
@@ -61,7 +61,7 @@ Vagrant.configure("2") do |config|
       chmod +x "$COSIGN_BINARY"
 
       # Install kubernetes related binaries
-      KUBERNETES_VERSION=v1.36
+      KUBERNETES_VERSION=v1.37
       curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
       echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
       curl -fsSL https://download.opensuse.org/repositories/isv:/cri-o:/prerelease:/main/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg

--- a/hack/ci/Vagrantfile-fedora
+++ b/hack/ci/Vagrantfile-fedora
@@ -40,7 +40,7 @@ Vagrant.configure("2") do |config|
       echo 'export GOPATH="$HOME/go"' >> /etc/profile
       echo 'export GOBIN="$GOPATH/bin"' >> /etc/profile
 
-      KUBERNETES_VERSION=v1.36
+      KUBERNETES_VERSION=v1.37
       cat <<EOF | tee /etc/yum.repos.d/kubernetes.repo
 [kubernetes]
 name=Kubernetes

--- a/hack/ci/Vagrantfile-flatcar
+++ b/hack/ci/Vagrantfile-flatcar
@@ -85,8 +85,8 @@ Vagrant.configure("2") do |config|
       sysctl --system
 
       # Install k8s components
-      CNI_VERSION="v1.0.1"
-      RELEASE_VERSION="v0.16.2"
+      CNI_VERSION="v1.9.1"
+      RELEASE_VERSION="v0.21.1"
       DOWNLOAD_DIR=/opt/bin
       RELEASE="$(curl -sSL https://dl.k8s.io/release/stable.txt)"
 

--- a/hack/ci/Vagrantfile-ubuntu
+++ b/hack/ci/Vagrantfile-ubuntu
@@ -35,7 +35,7 @@ Vagrant.configure("2") do |config|
         tar xfz - -C /usr/local
 
       # Kubernetes
-      KUBERNETES_VERSION=v1.36
+      KUBERNETES_VERSION=v1.37
       curl -fsSL https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
       echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/$KUBERNETES_VERSION/deb/ /" | tee /etc/apt/sources.list.d/kubernetes.list
       curl -fsSL https://download.opensuse.org/repositories/isv:/cri-o:/prerelease:/main/deb/Release.key | gpg --dearmor -o /etc/apt/keyrings/cri-o-apt-keyring.gpg

--- a/hack/ci/kubeadm-config-flatcar.yaml
+++ b/hack/ci/kubeadm-config-flatcar.yaml
@@ -1,14 +1,16 @@
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: InitConfiguration
 nodeRegistration:
   kubeletExtraArgs:
-    volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+  - name: volume-plugin-dir
+    value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
   criSocket: "unix:///run/containerd/containerd.sock"
 ---
-apiVersion: kubeadm.k8s.io/v1beta3
+apiVersion: kubeadm.k8s.io/v1beta4
 kind: ClusterConfiguration
 networking:
   podSubnet: 192.168.0.0/16
 controllerManager:
   extraArgs:
-    flex-volume-plugin-dir: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"
+  - name: flex-volume-plugin-dir
+    value: "/opt/libexec/kubernetes/kubelet-plugins/volume/exec/"

--- a/test/suite_test.go
+++ b/test/suite_test.go
@@ -40,10 +40,10 @@ import (
 )
 
 const (
-	kindVersion      = "v0.32.0"
-	kindImage        = "kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5"
-	kindDarwinSHA512 = "d0f2f0a9502f73505be50a22ce6c03f3a266c0230a99774df5f0c0129662ac8d4abc124180a1d42f14849055041636d12d97c5b0c9678afc9f2745f611ba404e" //nolint:lll // full length SHA
-	kindLinuxSHA512  = "f27636cff87ae24ffd06672ea4f1f4814279f139d061a1cf28614f760f623a8167013d10b276b0862c1bc8fd932cab0bd793cd42aa997253902232df62d8966b" //nolint:lll // full length SHA
+	kindVersion      = "v0.33.0"
+	kindImage        = "kindest/node:v1.37.0@sha256:a1ed56cfb0e7b93589bdf97c8cd566405a265939e3620fc4f5de89adff580ae5"
+	kindDarwinSHA512 = "5dccea9fd7fef0d5f5e8212bc4683389b13c4724b55057911da9d34bb6b605641e024affaa34b17b672ed22df4534cdcbc56a505a3078d6f17a10ac81fbd5f10" //nolint:lll // full length SHA
+	kindLinuxSHA512  = "f58a029ef8dee72f7fcf0345a5731795de0745ee6c955efd24801ced8409395cd2a4dc0ca41663c43231a48e94a5375cd01e63bc37b4557bf708e9ce6703fffa" //nolint:lll // full length SHA
 )
 
 var (


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Kubernetes v1.37 dropped support for the `kubeadm.k8s.io/v1beta3` API,
breaking the Flatcar e2e CI which pulls the latest stable K8s release.

This PR:
- Migrates kubeadm config to `v1beta4` (list-style `kubeletExtraArgs`/`extraArgs`)
- Bumps Kubernetes to v1.37 across all Vagrantfiles
- Bumps KIND to v0.33.0 with `kindest/node:v1.37.0`
- Bumps Flatcar box/developer container to 4593.2.5
- Bumps CNI plugins from v1.0.1 to v1.9.1
- Bumps Calico from v3.24.5 to v3.32.1
- Bumps kubernetes/release templates from v0.16.2 to v0.21.1
- Fixes jq download URL (`stedolan/jq` -> `jqlang/jq` v1.8.2)
- Adds DNS nameserver override to Flatcar Vagrantfile
- Adds `timeout-minutes` to all CI workflow jobs missing it
- Updates CONTRIBUTING.md prerequisites

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A (CI infrastructure changes, validated by CI itself)

#### Special notes for your reviewer:

The K8s Go library bump (`k8s.io/*` v0.36 -> v0.37) is not included
because `controller-runtime` v0.25.0 has not been released yet. That
will be a follow-up once the compatible release is available.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```