### PR TITLE
Fix API consistency, error handling, security, observability, and performance issues

### DIFF
--- a/api/selinuxprofile/v1/common.go
+++ b/api/selinuxprofile/v1/common.go
@@ -23,9 +23,18 @@ import (
 	profilebasev1 "sigs.k8s.io/security-profiles-operator/api/profilebase/v1"
 )
 
+// PolicyRefKind describes the kind of policy that a SELinux profile inherits from.
+// +kubebuilder:validation:Enum=System;SelinuxProfile;
+type PolicyRefKind string
+
 const (
-	SystemPolicyKind = "System"
+	SystemPolicyKind         PolicyRefKind = "System"
+	SelinuxProfilePolicyKind PolicyRefKind = "SelinuxProfile"
 )
+
+func selinuxPolicyUsage(name string) string {
+	return name + ".process"
+}
 
 // +k8s:deepcopy-gen=false
 type SelinuxProfileObject interface {

--- a/api/selinuxprofile/v1/rawselinuxprofile_types.go
+++ b/api/selinuxprofile/v1/rawselinuxprofile_types.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strings"
 	"unicode"
 	"unicode/utf8"
@@ -123,15 +124,16 @@ func (sp *RawSelinuxProfile) SetImplementationStatus() {
 }
 
 // GetPolicyName gets the policy module name in the format that
-// we're expecting for parsing.
+// we're expecting for parsing. filepath.Base is defense-in-depth
+// against path traversal; Kubernetes names cannot contain slashes.
 func (sp *RawSelinuxProfile) GetPolicyName() string {
-	return sp.GetName()
+	return filepath.Base(sp.GetName())
 }
 
 // GetPolicyUsage is the representation of how a pod will call this
 // SELinux module.
 func (sp *RawSelinuxProfile) GetPolicyUsage() string {
-	return sp.GetPolicyName() + ".process"
+	return selinuxPolicyUsage(sp.GetPolicyName())
 }
 
 func (sp *RawSelinuxProfile) ListProfilesByRecording(

--- a/api/selinuxprofile/v1/selinuxprofile_types.go
+++ b/api/selinuxprofile/v1/selinuxprofile_types.go
@@ -18,6 +18,7 @@ package v1
 
 import (
 	"context"
+	"path/filepath"
 	"sort"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -48,8 +49,7 @@ type PolicyRef struct {
 	// SecurityProfilesOperatorDaemon instance.
 	// +optional
 	// +default="System"
-	// +kubebuilder:validation:Enum=System;SelinuxProfile;
-	Kind string `json:"kind,omitempty"`
+	Kind PolicyRefKind `json:"kind,omitempty"`
 	// name is the name of the policy that this inherits from.
 	// +required
 	// +kubebuilder:validation:MinLength=1
@@ -172,15 +172,16 @@ func (sp *SelinuxProfile) SetImplementationStatus() {
 }
 
 // GetPolicyName gets the policy module name in the format that
-// we're expecting for parsing.
+// we're expecting for parsing. filepath.Base is defense-in-depth
+// against path traversal; Kubernetes names cannot contain slashes.
 func (sp *SelinuxProfile) GetPolicyName() string {
-	return sp.GetName()
+	return filepath.Base(sp.GetName())
 }
 
 // GetPolicyUsage is the representation of how a pod will call this
 // SELinux module.
 func (sp *SelinuxProfile) GetPolicyUsage() string {
-	return sp.GetPolicyName() + ".process"
+	return selinuxPolicyUsage(sp.GetPolicyName())
 }
 
 func (sp *SelinuxProfile) ListProfilesByRecording(

--- a/internal/pkg/cli/platform.go
+++ b/internal/pkg/cli/platform.go
@@ -17,11 +17,18 @@ limitations under the License.
 package cli
 
 import (
+	"errors"
 	"fmt"
 	"runtime"
 	"strings"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+var (
+	ErrParsePlatform     = errors.New("unable to parse platform")
+	ErrParseOS           = errors.New("unable to parse OS")
+	ErrParseArchitecture = errors.New("unable to parse architecture")
 )
 
 // ParsePlatform parses an OCI image spec platform from the provided string.
@@ -49,16 +56,16 @@ func ParsePlatform(input string) (*v1.Platform, error) {
 	case 1:
 		res.Architecture = runtime.GOARCH
 	default:
-		return nil, fmt.Errorf("unable to parse platform from %s", input)
+		return nil, fmt.Errorf("%w from %s", ErrParsePlatform, input)
 	}
 
 	res.OS = parts[0]
 	if res.OS == "" {
-		return nil, fmt.Errorf("unable to parse OS from %s", input)
+		return nil, fmt.Errorf("%w from %s", ErrParseOS, input)
 	}
 
 	if res.Architecture == "" {
-		return nil, fmt.Errorf("unable to parse architecture from %s", input)
+		return nil, fmt.Errorf("%w from %s", ErrParseArchitecture, input)
 	}
 
 	return res, nil

--- a/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
@@ -198,11 +198,14 @@ func removeProfile(logger logr.Logger, profileName string) error {
 		}
 
 		if err := a.DeletePolicy(profileName); err != nil {
-			return err
+			return fmt.Errorf("deleting apparmor policy %s: %w", profileName, err)
 		}
 
 		return os.Remove(filepath.Join(targetProfileDir, profileFilename(profileName)))
 	})
+	if err != nil {
+		return fmt.Errorf("removing apparmor profile: %w", err)
+	}
 
-	return err
+	return nil
 }

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
@@ -146,7 +146,7 @@ func (b *BpfRecorder) Syscalls() *bpf.BPFMap {
 
 // Run the BpfRecorder.
 func (b *BpfRecorder) Run() error {
-	b.logger.Info(fmt.Sprintf("Setting up caches with expiry of %v", defaultCacheTimeout))
+	b.logger.Info("Setting up caches", "expiry", defaultCacheTimeout)
 
 	for _, cache := range []*ttlcache.Cache[string, string]{
 		b.pidToContainerIDCache,
@@ -530,9 +530,9 @@ func (b *BpfRecorder) Load() (err error) {
 		programName := []byte(filepath.Base(b.programName))
 		if len(programName) >= maxCommLen {
 			programName = programName[:maxCommLen-1]
-			b.logger.Info(fmt.Sprintf("Set truncated program name filter: '%s'", programName))
+			b.logger.Info("Set truncated program name filter", "programName", string(programName))
 		} else {
-			b.logger.Info(fmt.Sprintf("Set program name filter: '%s'", programName))
+			b.logger.Info("Set program name filter", "programName", string(programName))
 		}
 
 		programName = append(programName, 0)
@@ -583,7 +583,7 @@ func (b *BpfRecorder) Load() (err error) {
 
 	if b.Seccomp != nil {
 		if err := b.Seccomp.Load(b); err != nil {
-			return err
+			return fmt.Errorf("loading seccomp bpf hooks: %w", err)
 		}
 	}
 
@@ -661,7 +661,7 @@ func (b *BpfRecorder) StartRecording() (err error) {
 
 	if b.Seccomp != nil {
 		if err := b.Seccomp.StartRecording(b); err != nil {
-			return err
+			return fmt.Errorf("starting seccomp recording: %w", err)
 		}
 	}
 
@@ -684,13 +684,13 @@ func (b *BpfRecorder) StopRecording() error {
 
 	if b.Seccomp != nil {
 		if err := b.Seccomp.StopRecording(b); err != nil {
-			return err
+			return fmt.Errorf("stopping seccomp recording: %w", err)
 		}
 	}
 
 	if b.AppArmor != nil {
 		if err := b.AppArmor.StopRecording(b); err != nil {
-			return err
+			return fmt.Errorf("stopping apparmor recording: %w", err)
 		}
 	}
 
@@ -767,7 +767,7 @@ func (b *BpfRecorder) handleEvent(eventBytes []byte) {
 }
 
 func (b *BpfRecorder) handleNewPidEvent(e *bpfEvent) {
-	b.logger.Info(fmt.Sprintf("Received new pid: %d with mntns=%d", e.Pid, e.Mntns))
+	b.logger.Info("Received new pid", "pid", e.Pid, "mntns", e.Mntns)
 
 	pid := e.Pid
 	mntns := e.Mntns
@@ -812,7 +812,7 @@ func (b *BpfRecorder) handleNewPidEvent(e *bpfEvent) {
 }
 
 func (b *BpfRecorder) handleExitEvent(exitEvent *bpfEvent) {
-	b.logger.Info(fmt.Sprintf("record pid exit: %d.", exitEvent.Pid))
+	b.logger.Info("Record pid exit", "pid", exitEvent.Pid)
 	d, _ := b.recordedExits.LoadOrStore(exitEvent.Pid, make(chan bool))
 
 	done, ok := d.(chan bool)

--- a/internal/pkg/daemon/metrics/metrics.go
+++ b/internal/pkg/daemon/metrics/metrics.go
@@ -54,7 +54,7 @@ const (
 	metricLabelValueProfileDelete = "delete"
 
 	// Metrics labels.
-	metricLabelOperation       = "operation"
+	metricsLabelOperation      = "operation"
 	metricsLabelContainer      = "container"
 	metricsLabelExecutable     = "executable"
 	metricsLabelNamespace      = "namespace"
@@ -104,7 +104,7 @@ func New() *Metrics {
 				Namespace: metricNamespace,
 				Help:      "Counter about seccomp profile operations.",
 			},
-			[]string{metricLabelOperation},
+			[]string{metricsLabelOperation},
 		),
 		metricSeccompProfileAudit: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -146,7 +146,7 @@ func New() *Metrics {
 				Namespace: metricNamespace,
 				Help:      "Counter about selinux profile operations.",
 			},
-			[]string{metricLabelOperation},
+			[]string{metricsLabelOperation},
 		),
 		metricSelinuxProfileAudit: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -177,7 +177,7 @@ func New() *Metrics {
 				Namespace: metricNamespace,
 				Help:      "Counter about apparmor profile operations.",
 			},
-			[]string{metricLabelOperation},
+			[]string{metricsLabelOperation},
 		),
 		metricAppArmorProfileAudit: prometheus.NewCounterVec(
 			prometheus.CounterOpts{
@@ -191,7 +191,7 @@ func New() *Metrics {
 				metricsLabelPod,
 				metricsLabelContainer,
 				metricsLabelProfile,
-				metricLabelOperation,
+				metricsLabelOperation,
 				metricsLabelApparmor,
 			},
 		),
@@ -214,7 +214,7 @@ func New() *Metrics {
 			},
 			[]string{
 				metricsLabelProfile,
-				metricLabelOperation,
+				metricsLabelOperation,
 			},
 		),
 	}

--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -212,7 +212,7 @@ func (r *Reconciler) handleAllowedSyscallsChanged(
 	defer cancel()
 
 	seccompProfileList := &seccompprofileapi.SeccompProfileList{}
-	if err := r.client.List(ctx, seccompProfileList, &client.ListOptions{}); err != nil {
+	if err := r.client.List(ctx, seccompProfileList); err != nil {
 		r.log.Error(err, "cannot list seccomp profiles in the cluster")
 
 		return []reconcile.Request{}
@@ -227,10 +227,10 @@ func (r *Reconciler) handleAllowedSyscallsChanged(
 			spod.Spec.Security.AllowedSyscalls,
 			spod.Spec.Security.AllowedSeccompActions,
 		); err != nil {
-			r.log.Info(fmt.Sprintf("deleting not allowed seccomp profile %s/%s",
-				sp.GetNamespace(), sp.GetName()))
+			r.log.Info("deleting not allowed seccomp profile",
+				"namespace", sp.GetNamespace(), "name", sp.GetName())
 
-			if err := r.client.Delete(ctx, sp, &client.DeleteOptions{}); err != nil {
+			if err := r.client.Delete(ctx, sp); err != nil {
 				r.log.Error(err, "cannot delete not allowed seccomp profile")
 
 				continue

--- a/internal/pkg/daemon/selinuxprofile/rawselinuxprofile.go
+++ b/internal/pkg/daemon/selinuxprofile/rawselinuxprofile.go
@@ -69,9 +69,11 @@ func (sph *rawSelinuxProfileHandler) Init(
 	cli client.Client,
 	key types.NamespacedName,
 ) error {
-	err := cli.Get(ctx, key, sph.rsp)
+	if err := cli.Get(ctx, key, sph.rsp); err != nil {
+		return fmt.Errorf("getting raw selinux profile: %w", err)
+	}
 
-	return err
+	return nil
 }
 
 func (sph *rawSelinuxProfileHandler) GetProfileObject() selinuxprofileapi.SelinuxProfileObject {

--- a/internal/pkg/daemon/selinuxprofile/selinuxprofile.go
+++ b/internal/pkg/daemon/selinuxprofile/selinuxprofile.go
@@ -85,7 +85,7 @@ func (sph *selinuxProfileHandler) Init(
 	}
 	// initiate the SelinuxProfile object
 	if err := sph.cli.Get(ctx, key, sph.sp); err != nil {
-		return err
+		return fmt.Errorf("getting selinux profile: %w", err)
 	}
 
 	// Matches alpha numerical names in upper and lower-case, as well as
@@ -118,23 +118,23 @@ func (sph *selinuxProfileHandler) Validate() error {
 	for _, inherit := range sph.sp.Spec.Inherit {
 		err := sph.validateAndTrackInherit(spod, inherit, sph.sp.GetNamespace())
 		if err != nil {
-			return err
+			return fmt.Errorf("validating inherit: %w", err)
 		}
 	}
 
 	for key, classperms := range sph.sp.Spec.Allow {
 		if err := sph.validateLabelKey(key); err != nil {
-			return err
+			return fmt.Errorf("validating label key: %w", err)
 		}
 
 		for objclass, perms := range classperms {
 			if err := sph.validateObjClass(objclass); err != nil {
-				return err
+				return fmt.Errorf("validating object class: %w", err)
 			}
 
 			for _, perm := range perms {
 				if err := sph.validatePermission(perm); err != nil {
-					return err
+					return fmt.Errorf("validating permission: %w", err)
 				}
 			}
 		}
@@ -150,9 +150,9 @@ func (sph *selinuxProfileHandler) validateAndTrackInherit(
 ) error {
 	switch ancestorRef.Kind {
 	// We default to System if Kind is left empty
-	case selinuxprofileapi.SystemPolicyKind, "":
+	case selinuxprofileapi.SystemPolicyKind, selinuxprofileapi.PolicyRefKind(""):
 		return sph.handleInheritSystemPolicy(spod, ancestorRef)
-	case "SelinuxProfile":
+	case selinuxprofileapi.SelinuxProfilePolicyKind:
 		return sph.handleInheritSPOPolicy(ancestorRef, namespace)
 	}
 

--- a/internal/pkg/daemon/selinuxprofile/selinuxprofile_test.go
+++ b/internal/pkg/daemon/selinuxprofile/selinuxprofile_test.go
@@ -124,7 +124,7 @@ func Test_selinuxProfileHandler(t *testing.T) {
 				Spec: selinuxprofileapi.SelinuxProfileSpec{
 					Inherit: []selinuxprofileapi.PolicyRef{
 						{
-							Kind: "SelinuxProfile",
+							Kind: selinuxprofileapi.SelinuxProfilePolicyKind,
 							Name: "foo",
 						},
 					},
@@ -188,7 +188,7 @@ func Test_selinuxProfileHandler(t *testing.T) {
 				Spec: selinuxprofileapi.SelinuxProfileSpec{
 					Inherit: []selinuxprofileapi.PolicyRef{
 						{
-							Kind: "SelinuxProfile",
+							Kind: selinuxprofileapi.SelinuxProfilePolicyKind,
 							Name: "unexistent-ref",
 						},
 					},
@@ -250,7 +250,7 @@ func Test_selinuxProfileHandler(t *testing.T) {
 				Spec: selinuxprofileapi.SelinuxProfileSpec{
 					Inherit: []selinuxprofileapi.PolicyRef{
 						{
-							Kind: "SelinuxProfile",
+							Kind: selinuxprofileapi.SelinuxProfilePolicyKind,
 							Name: "foo",
 						},
 					},

--- a/internal/pkg/manager/recordingmerger/merge_utils_test.go
+++ b/internal/pkg/manager/recordingmerger/merge_utils_test.go
@@ -155,7 +155,7 @@ func TestMergeProfiles(t *testing.T) {
 						Spec: selinuxprofileapi.SelinuxProfileSpec{
 							Inherit: []selinuxprofileapi.PolicyRef{
 								{
-									Kind: "System",
+									Kind: selinuxprofileapi.SystemPolicyKind,
 									Name: "container",
 								},
 							},
@@ -171,7 +171,7 @@ func TestMergeProfiles(t *testing.T) {
 						Spec: selinuxprofileapi.SelinuxProfileSpec{
 							Inherit: []selinuxprofileapi.PolicyRef{
 								{
-									Kind: "System",
+									Kind: selinuxprofileapi.SystemPolicyKind,
 									Name: "container",
 								},
 							},

--- a/internal/pkg/manager/spod/bindata/webhook.go
+++ b/internal/pkg/manager/spod/bindata/webhook.go
@@ -433,7 +433,7 @@ func (w *Webhook) webhookNeedsUpdate(existing *admissionregv1.MutatingWebhook, i
 		return true
 	}
 
-	w.log.V(1).Info("webbhook does not need update")
+	w.log.V(1).Info("webhook does not need update")
 
 	return false
 }

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -230,7 +230,7 @@ func (p *podBinder) updatePod(
 		case profilebindingapi.ProfileBindingKindAppArmorProfile:
 			bindProfile, err = p.getAppArmorProfile(ctx, namespacedName)
 		default:
-			p.log.Info(fmt.Sprintf("profile kind %s not supported", profileKind))
+			p.log.Info("profile kind not supported", "kind", profileKind)
 
 			continue
 		}
@@ -253,7 +253,7 @@ func (p *podBinder) updatePod(
 				continue
 			}
 
-			p.log.Error(err, fmt.Sprintf("failed to get %v %#v", profileKind, namespacedName))
+			p.log.Error(err, "failed to get profile", "kind", profileKind, "name", namespacedName)
 
 			return pod, admission.Errored(http.StatusInternalServerError, err)
 		}

--- a/internal/pkg/webhooks/recording/recording.go
+++ b/internal/pkg/webhooks/recording/recording.go
@@ -115,9 +115,7 @@ func (p *podSeccompRecorder) Handle(
 	for i := range items {
 		item := items[i]
 		if !item.IsKindSupported() {
-			p.log.Info(fmt.Sprintf(
-				"recording kind %s not supported", item.Spec.Kind,
-			))
+			p.log.Info("recording kind not supported", "kind", item.Spec.Kind)
 
 			continue
 		}
@@ -228,10 +226,8 @@ func (p *podSeccompRecorder) updatePod(
 			}
 
 			pod.Annotations[key] = value
-			p.log.Info(fmt.Sprintf(
-				"adding recording annotation %s=%s to pod %s",
-				key, value, pod.Name,
-			))
+			p.log.Info("adding recording annotation to pod",
+				"key", key, "value", value, "pod", pod.Name)
 
 			podChanged = true
 
@@ -245,14 +241,8 @@ func (p *podSeccompRecorder) updatePod(
 			pod.Annotations[key] = value
 			podChanged = true
 
-			p.log.Info(
-				fmt.Sprintf(
-					"workload %s already has annotation %q, overwriting with %q.",
-					podName,
-					existingValue,
-					value,
-				),
-			)
+			p.log.Info("workload already has annotation, overwriting",
+				"workload", podName, "existingValue", existingValue, "newValue", value)
 		}
 	}
 
@@ -277,10 +267,8 @@ func (p *podSeccompRecorder) updateSecurityContext(
 		p.updateApparmorSecurityContext(ctr, pr)
 	}
 
-	p.log.Info(fmt.Sprintf(
-		"set SecurityContext for container %s: %+v",
-		ctr.Name, ctr.SecurityContext,
-	))
+	p.log.Info("set SecurityContext for container",
+		"container", ctr.Name, "securityContext", ctr.SecurityContext)
 }
 
 func (p *podSeccompRecorder) updateSeccompSecurityContext(

--- a/test/spoc/e2e_spoc_test.go
+++ b/test/spoc/e2e_spoc_test.go
@@ -338,7 +338,7 @@ func recordAppArmorTest(t *testing.T) {
 
 			if strings.Contains(
 				spocLogs.Text(),
-				fmt.Sprintf("record pid exit: %d.", cmd2.Process.Pid),
+				fmt.Sprintf("Record pid exit (pid=%d)", cmd2.Process.Pid),
 			) {
 				break
 			}


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup
/kind api-change

#### What this PR does / why we need it:

Addresses multiple code quality findings across the codebase:

**API:**
- Add `PolicyRefKind` typed enum for SELinux `PolicyRef.Kind` field (was raw `string`)
- Move shared `selinuxPolicyUsage()` helper to `common.go` to deduplicate `GetPolicyUsage()` across SelinuxProfile and RawSelinuxProfile
- Sanitize SELinux profile names via `filepath.Base()` in `GetPolicyName()` to prevent path traversal
- Fix metric label naming inconsistency (`metricLabelOperation` -> `metricsLabelOperation`)

**Error handling:**
- Wrap 12 bare `return err` statements with context in bpfrecorder, selinuxprofile, rawselinuxprofile, and apparmor_supported
- Add sentinel errors (`ErrParsePlatform`, `ErrParseOS`, `ErrParseArchitecture`) in CLI platform parsing

**Observability:**
- Convert `fmt.Sprintf` log calls to structured key-value pairs in webhooks, seccomp profile controller, and BPF recorder
- Fix "webbhook" typo

**Performance:**
- Remove unnecessary empty `ListOptions`/`DeleteOptions` allocations in seccomp controller

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Existing tests updated to use typed constants. All tests pass.

#### Special notes for your reviewer:

**Go API breaking change:** `PolicyRef.Kind` field type changes from `string` to `PolicyRefKind`. Existing YAML/JSON values (`"System"`, `"SelinuxProfile"`) are unchanged, but Go callers assigning raw strings will need to use the typed constants (`SystemPolicyKind`, `SelinuxProfilePolicyKind`).

The `"SelinuxProfile"` string literals in `nodestatus.go`, `profile_reader.go`, and `consts.go` were intentionally left as-is because they match against Kubernetes GVK kind strings (type `string`), not `PolicyRefKind` values.

#### Does this PR introduce a user-facing change?

```release-note
Introduce PolicyRefKind typed enum for SELinux PolicyRef.Kind field. Go API consumers assigning raw strings to this field must switch to the new typed constants.
```