### PR TITLE
helm: Add restrictToNamespace value

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -32,6 +32,7 @@ please refer to [Installation Guide](https://github.com/kubernetes-sigs/security
 | nodeSelector                                | object | `{}` | `specify on which node to deploy the workload` |
 | podSecurityContext                          | object | `` | `pod security contexts`                        |
 | replicaCount                                | int | `3` | `the number of replicas of the pods`           |
+| restrictToNamespace                         | string | `""` | `restrict the operator to a single namespace`  |
 | resources.limits.memory                     | string | `"128Mi"` | `memory limits for the pod`                    |
 | resources.requests.cpu                      | string | `"250m"` | `cpu requests for the pod`                     |
 | resources.requests.memory                   | string | `"50Mi"` | `memory requests for pod`                      |

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -36,6 +36,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        {{- if .Values.restrictToNamespace }}
+        - name: RESTRICT_TO_NAMESPACE
+          value: {{ .Values.restrictToNamespace | quote }}
+        {{- end }}
         image: {{ .Values.spoImage.registry }}/{{ .Values.spoImage.repository }}:{{ .Values.spoImage.tag }}
         imagePullPolicy: Always
         name: {{ .Chart.Name }}

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -46,6 +46,7 @@ enableAppArmor: false
 enableBpfRecorder: false
 enableProfiling: false
 verbosity: 0
+restrictToNamespace: ""
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
/kind feature

#### What this PR does / why we need it:
Adds a `restrictToNamespace` Helm value that sets the `RESTRICT_TO_NAMESPACE` environment variable on the manager deployment. This allows Helm users to restrict the operator to watch profiles in a single namespace, which was previously only possible via the upstream manifests or OLM.

#### Which issue(s) this PR fixes:
Fixes #3395

#### Does this PR have test?
N/A (Helm template change, verified with `helm template`)

#### Special notes for your reviewer:
The operator already supports `RESTRICT_TO_NAMESPACE` and propagates it from the manager deployment to the SPOd DaemonSet automatically (`setup.go:231-236`), so only the Helm chart needs to be updated.

#### Does this PR introduce a user-facing change?
```release-note
Add `restrictToNamespace` Helm chart value to restrict the operator to a single namespace.
```