### PR TITLE
Use GitHub auto-generated release notes

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -19,7 +19,59 @@ None
 - [ ] Run `./hack/release.sh {VERSION}` and merge version bump PR
 - [ ] Verify [`post-security-profiles-operator-push-image` prow job](https://prow.k8s.io/?job=post-security-profiles-operator-push-image) succeeds
 - [ ] Create and merge image promotion PR in [k8s.io](https://github.com/kubernetes/k8s.io) via `kpromo`
-- [ ] Create GitHub release with release notes
+- [ ] Create GitHub release with auto-generated release notes (use the template below)
 - [ ] Run `./hack/back-to-dev.sh` and create back-to-dev PR
 - [ ] Create OperatorHub community-operators PR
 - [ ] Send release announcement to #security-profiles-operator Slack channel
+
+#### Release notes template
+
+<!-- Replace {VERSION} with the actual version, e.g. 1.0.2 -->
+
+<details>
+<summary>Click to expand</summary>
+
+````markdown
+Welcome to the v{VERSION} release of the **security-profiles-operator**!
+
+<!-- Add a short summary of the release here -->
+
+The general usage and setup can be found [in our documentation][0].
+
+To install the operator, run:
+
+```
+$ kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/security-profiles-operator/v{VERSION}/deploy/operator.yaml
+```
+
+You can also verify the container image signature by using [cosign][1]:
+
+```
+$ cosign verify \
+    --certificate-identity krel-trust@k8s-releng-prod.iam.gserviceaccount.com \
+    --certificate-oidc-issuer https://accounts.google.com \
+    registry.k8s.io/security-profiles-operator/security-profiles-operator:v{VERSION}
+```
+
+Besides the operator image, we now also ship `spoc`, the official Security Profiles Operator Command Line Interface! Binaries for `amd64`, `arm64`, `ppc64le` and `s390x` are attached to this release.
+
+To verify the signature of `spoc`, download all release artifacts and run for `amd64` (works in the same way for `arm64`, `ppc64le` and `s390x`):
+
+```
+$ cosign verify-blob \
+    --certificate-identity sgrunert@redhat.com \
+    --certificate-oidc-issuer https://github.com/login/oauth \
+    --bundle spoc.amd64.bundle \
+    spoc.amd64
+```
+
+We also provide `.sha512` sum files for the binaries.
+
+Feel free to provide us any kind of feedback in the official [Kubernetes Slack #security-profiles-operator channel][2].
+
+[0]: https://github.com/kubernetes-sigs/security-profiles-operator/blob/v{VERSION}/installation-usage.md
+[1]: https://github.com/sigstore/cosign
+[2]: https://app.slack.com/client/T09NY5SBT/C013FQNB0A2
+````
+
+</details>

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,38 @@
+changelog:
+  exclude:
+    labels:
+      - release-note-none
+  categories:
+    - title: API Changes
+      labels:
+        - kind/api-change
+    - title: Feature
+      labels:
+        - kind/feature
+    - title: Bug
+      labels:
+        - kind/bug
+    - title: Cleanup
+      labels:
+        - kind/cleanup
+    - title: Deprecation
+      labels:
+        - kind/deprecation
+    - title: Documentation
+      labels:
+        - kind/documentation
+    - title: Failing Test
+      labels:
+        - kind/failing-test
+    - title: Flake
+      labels:
+        - kind/flake
+    - title: Regression
+      labels:
+        - kind/regression
+    - title: Dependencies
+      labels:
+        - dependencies
+    - title: Other
+      labels:
+        - "*"

--- a/release.md
+++ b/release.md
@@ -64,9 +64,9 @@ To run the tool from `$GOPATH/src/sigs.k8s.io/promo-tools`, just execute:
 This will automatically create a PR in the k/k8s.io repository. If this PR got
 merged, then we're finally ready to [create the
 release](https://github.com/kubernetes-sigs/security-profiles-operator/releases/new)
-directly on GitHub and add the release notes. The release notes can be generated
-by the [official Kubernetes Release Notes
-tool](https://github.com/kubernetes/release/tree/master/cmd/release-notes).
+directly on GitHub and add the release notes. The release notes will be
+auto-generated based on PR labels and the configuration in
+[`.github/release.yml`](.github/release.yml).
 
 Run `make nix-spoc` and attach the results from the `build` directory to the
 GitHub release.


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it:

The release notes tool from k/release does not work anymore for our merge workflow. This switches to GitHub's built-in release notes generation via `.github/release.yml`, which categorizes PRs by `kind/*` labels and excludes `release-note-none` PRs.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A

#### Special notes for your reviewer:

The category mapping in `.github/release.yml` matches the existing release notes format (API Changes, Feature, Bug, Cleanup, etc.). The intro text of each release (install instructions, cosign verification, spoc binaries) is still written manually when creating the release.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```