### PR TITLE
Fix bugs, resource leaks, and logging across daemon packages

### DIFF
--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -660,6 +660,7 @@ func runDaemon(ctx *cli.Context, info *version.Info) error {
 	if err := met.ServeGRPC(); err != nil {
 		return fmt.Errorf("start metrics grpc server: %w", err)
 	}
+	defer met.GracefulStop()
 
 	disableHTTP2 := func(c *tls.Config) {
 		c.NextProtos = []string{"http/1.1"}

--- a/internal/pkg/artifact/artifact.go
+++ b/internal/pkg/artifact/artifact.go
@@ -22,7 +22,6 @@ import (
 	"fmt"
 	"maps"
 	"path/filepath"
-	"strconv"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -85,6 +84,21 @@ type Artifact struct {
 	logger logr.Logger
 }
 
+func (a *Artifact) setRepoCredentials(repo *remote.Repository, username, password string) {
+	if username != "" && password != "" {
+		a.logger.Info("Using username and password")
+
+		repo.Client = &auth.Client{
+			Client: retry.DefaultClient,
+			Cache:  auth.DefaultCache,
+			Credential: auth.StaticCredential(
+				repo.Reference.Registry,
+				auth.Credential{Username: username, Password: password},
+			),
+		}
+	}
+}
+
 // PullSignatureOptions options for verifying the OCI image signature during pulling.
 type PullSignatureOptions struct {
 	// DisableSignatureVerification disables signature verification during pulling.
@@ -118,11 +132,11 @@ func (a *Artifact) Push(
 
 	defer func() {
 		if err := a.RemoveAll(dir); err != nil {
-			a.logger.Info("Unable to remove temp dir: " + err.Error())
+			a.logger.Info("Unable to remove temp dir", "error", err)
 		}
 	}()
 
-	a.logger.Info("Creating file store in: " + dir)
+	a.logger.Info("Creating file store", "dir", dir)
 
 	store, err := a.FileNew(dir)
 	if err != nil {
@@ -131,7 +145,7 @@ func (a *Artifact) Push(
 
 	defer func() {
 		if err := a.FileClose(store); err != nil {
-			a.logger.Info("Unable to close file store: " + err.Error())
+			a.logger.Info("Unable to close file store", "error", err)
 		}
 	}()
 
@@ -140,14 +154,12 @@ func (a *Artifact) Push(
 
 	fileDescriptors := []v1.Descriptor{}
 
-	a.logger.Info("Adding " + strconv.Itoa(len(files)) + " profiles")
+	a.logger.Info("Adding profiles", "count", len(files))
 
 	for platform, file := range files {
-		a.logger.Info(
-			"Adding profile " + file +
-				" for platform " +
-				platformToString(platform) +
-				" to store",
+		a.logger.Info("Adding profile to store",
+			"file", file,
+			"platform", platformToString(platform),
 		)
 
 		absPath, err := a.FilepathAbs(file)
@@ -183,7 +195,7 @@ func (a *Artifact) Push(
 		return fmt.Errorf("pack files: %w", err)
 	}
 
-	a.logger.Info("Verifying reference: " + to)
+	a.logger.Info("Verifying reference", "ref", to)
 
 	parsedRef, err := a.ParseReference(to)
 	if err != nil {
@@ -192,32 +204,21 @@ func (a *Artifact) Push(
 
 	tag := parsedRef.Identifier()
 
-	a.logger.Info("Using tag: " + tag)
+	a.logger.Info("Using tag", "tag", tag)
 
 	if err = a.StoreTag(ctx, store, manifestDescriptor, tag); err != nil {
 		return fmt.Errorf("creating tag: %w", err)
 	}
 
 	ref := parsedRef.Context().Name()
-	a.logger.Info("Creating repository for " + ref)
+	a.logger.Info("Creating repository", "ref", ref)
 
 	repo, err := a.NewRepository(ref)
 	if err != nil {
 		return fmt.Errorf("create repository: %w", err)
 	}
 
-	if username != "" && password != "" {
-		a.logger.Info("Using username and password")
-
-		repo.Client = &auth.Client{
-			Client: retry.DefaultClient,
-			Cache:  auth.DefaultCache,
-			Credential: auth.StaticCredential(
-				repo.Reference.Registry,
-				auth.Credential{Username: username, Password: password},
-			),
-		}
-	}
+	a.setRepoCredentials(repo, username, password)
 
 	a.logger.Info("Copying profile to repository")
 
@@ -287,7 +288,7 @@ func (a *Artifact) Pull(
 
 	originalImage := from
 
-	a.logger.Info("Resolving digest of image: " + originalImage)
+	a.logger.Info("Resolving digest of image", "image", originalImage)
 
 	// Retrieve the immutable image digest before doing any verification to
 	// prevent a TOCTOU attack on the mutable tag of the base image, which
@@ -326,11 +327,11 @@ func (a *Artifact) Pull(
 
 	defer func() {
 		if err := a.RemoveAll(dir); err != nil {
-			a.logger.Info("Unable to remove temp dir: " + err.Error())
+			a.logger.Info("Unable to remove temp dir", "error", err)
 		}
 	}()
 
-	a.logger.Info("Creating file store in: " + dir)
+	a.logger.Info("Creating file store", "dir", dir)
 
 	store, err := a.FileNew(dir)
 	if err != nil {
@@ -339,7 +340,7 @@ func (a *Artifact) Pull(
 
 	defer func() {
 		if err := a.FileClose(store); err != nil {
-			a.logger.Info("Unable to close file store: " + err.Error())
+			a.logger.Info("Unable to close file store", "error", err)
 		}
 	}()
 
@@ -358,7 +359,7 @@ func (a *Artifact) Pull(
 	content := []byte{}
 
 	for _, name := range []string{profileName(platform), defaultProfileYAML} {
-		a.logger.Info("Trying to read profile: " + name)
+		a.logger.Info("Trying to read profile", "name", name)
 
 		content, err = a.ReadFile(filepath.Join(dir, name))
 		if err == nil {
@@ -416,18 +417,7 @@ func (a *Artifact) imageWithDigest(ctx context.Context, image, username, passwor
 			ref.Name(), err)
 	}
 
-	if username != "" && password != "" {
-		a.logger.Info("Using username and password")
-
-		repo.Client = &auth.Client{
-			Client: retry.DefaultClient,
-			Cache:  auth.DefaultCache,
-			Credential: auth.StaticCredential(
-				repo.Reference.Registry,
-				auth.Credential{Username: username, Password: password},
-			),
-		}
-	}
+	a.setRepoCredentials(repo, username, password)
 
 	desc, err := a.ResolveRepository(ctx, repo, ref.Identifier())
 	if err != nil {

--- a/internal/pkg/artifact/profile_reader.go
+++ b/internal/pkg/artifact/profile_reader.go
@@ -36,8 +36,6 @@ func ReadProfile(content []byte) (client.Object, error) {
 
 	err := yaml.Unmarshal(content, &genericCRD)
 	if err != nil {
-		fmt.Println(err)
-
 		return nil, fmt.Errorf("cannot parse yaml: %w", err)
 	}
 

--- a/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmor_supported.go
@@ -171,7 +171,7 @@ func loadProfile(logger logr.Logger, name, content string) (bool, error) {
 		return nil
 	})
 
-	return err != nil, err
+	return err == nil, err
 }
 
 func removeProfile(logger logr.Logger, profileName string) error {

--- a/internal/pkg/daemon/apparmorprofile/apparmorprofile.go
+++ b/internal/pkg/daemon/apparmorprofile/apparmorprofile.go
@@ -257,7 +257,7 @@ func (r *Reconciler) handleDeletion(sp *apparmorprofileapi.AppArmorProfile) erro
 		return fmt.Errorf("unloading profile from host: %w", err)
 	}
 
-	r.log.Info("removed profile " + sp.GetProfileName())
+	r.log.Info("removed profile", "profile", sp.GetProfileName())
 	r.metrics.IncAppArmorProfileDelete()
 
 	return nil
@@ -274,10 +274,10 @@ func (r *Reconciler) logNodeInfo() {
 
 	err := mount.Do(func() error {
 		enabled, err := a.Enabled()
-		r.log.Info("apparmor enabled: " + ok(enabled, err))
+		r.log.Info("apparmor enabled", "status", ok(enabled, err))
 
 		enforceable, err := a.Enforceable()
-		r.log.Info("apparmor enforceable: " + ok(enforceable, err))
+		r.log.Info("apparmor enforceable", "status", ok(enforceable, err))
 
 		return nil
 	})

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
@@ -148,11 +148,8 @@ func (b *BpfRecorder) Syscalls() *bpf.BPFMap {
 func (b *BpfRecorder) Run() error {
 	b.logger.Info("Setting up caches", "expiry", defaultCacheTimeout)
 
-	for _, cache := range []*ttlcache.Cache[string, string]{
-		b.pidToContainerIDCache,
-	} {
-		go cache.Start()
-	}
+	go b.pidToContainerIDCache.Start()
+	defer b.pidToContainerIDCache.Stop()
 
 	b.nodeName = b.Getenv(config.NodeNameEnvKey)
 	if b.nodeName == "" {
@@ -162,7 +159,7 @@ func (b *BpfRecorder) Run() error {
 		return err
 	}
 
-	b.logger.Info("Starting ebpf recorder on node: " + b.nodeName)
+	b.logger.Info("Starting ebpf recorder on node", "node", b.nodeName)
 
 	clusterConfig, err := b.InClusterConfig()
 	if err != nil {
@@ -352,7 +349,7 @@ func (b *BpfRecorder) SyscallsForProfile(
 		return nil, errors.New("not seccomp profiles recording running")
 	}
 
-	b.logger.Info("Getting syscalls for profile " + r.GetName())
+	b.logger.Info("Getting syscalls for profile", "profile", r.GetName())
 
 	mntns, err := b.getMntnsForProfileWithRetry(r.GetName())
 	if err != nil {
@@ -392,7 +389,7 @@ func (b *BpfRecorder) ApparmorForProfile(
 		return nil, errors.New("no apparmor profiles recording running")
 	}
 
-	b.logger.Info("Getting apparmor profile for profile " + r.GetName())
+	b.logger.Info("Getting apparmor profile", "profile", r.GetName())
 
 	mntns, err := b.getMntnsForProfileWithRetry(r.GetName())
 	if err != nil {
@@ -676,7 +673,7 @@ func (b *BpfRecorder) StopRecording() error {
 
 	b.logger.Info("Stop BPF recording: Detaching all programs...")
 
-	if err := b.UpdateValue(b.isRecordingBpfMap, 0, []byte{1}); err != nil {
+	if err := b.UpdateValue(b.isRecordingBpfMap, 0, []byte{0}); err != nil {
 		return fmt.Errorf("failed to update `is_recording`: %w", err)
 	}
 
@@ -1009,11 +1006,13 @@ func (b *BpfRecorder) WaitForPidExit(ctx context.Context, pid uint32) error {
 	}
 }
 
+var bpfLSMRegex = regexp.MustCompile(`(^|,)bpf(,|$)`)
+
 func BPFLSMEnabled() bool {
 	contents, err := os.ReadFile("/sys/kernel/security/lsm")
 	if err != nil {
 		return false
 	}
 
-	return regexp.MustCompile(`(^|,)bpf(,|$)`).Match(contents)
+	return bpfLSMRegex.Match(contents)
 }

--- a/internal/pkg/daemon/enricher/auditsource/audit.go
+++ b/internal/pkg/daemon/enricher/auditsource/audit.go
@@ -65,7 +65,7 @@ func (a *AuditdSource) StartTail() (log chan *types.AuditLine, err error) {
 	go func() {
 		for l := range a.file.Lines {
 			line := l.Text
-			a.logger.V(config.VerboseLevel).Info("Got line: " + line)
+			a.logger.V(config.VerboseLevel).Info("Got line", "line", line)
 
 			if !IsAuditLine(line) {
 				a.logger.V(config.VerboseLevel).Info("Not an audit line")

--- a/internal/pkg/daemon/enricher/enricher.go
+++ b/internal/pkg/daemon/enricher/enricher.go
@@ -100,6 +100,7 @@ type Enricher struct {
 	auditLineCache   *ttlcache.Cache[string, []*types.AuditLine]
 	clientset        kubernetes.Interface
 	enricherFilters  []types.EnricherFilterOptions
+	grpcServer       *grpc.Server
 }
 
 // New returns a new Enricher instance.
@@ -172,11 +173,16 @@ func (e *Enricher) Run() error {
 		return fmt.Errorf("load in-cluster config: %w", err)
 	}
 
-	e.logger.Info(fmt.Sprintf("Setting up caches with expiry of %v", defaultCacheTimeout))
+	e.logger.Info("Setting up caches", "expiry", defaultCacheTimeout)
 
 	go e.containerIDCache.Start()
+	defer e.containerIDCache.Stop()
+
 	go e.infoCache.Start()
+	defer e.infoCache.Stop()
+
 	go e.auditLineCache.Start()
+	defer e.auditLineCache.Stop()
 
 	nodeName := e.Getenv(config.NodeNameEnvKey)
 	if nodeName == "" {
@@ -186,7 +192,7 @@ func (e *Enricher) Run() error {
 		return err
 	}
 
-	e.logger.Info("Starting log-enricher on node: " + nodeName)
+	e.logger.Info("Starting log-enricher on node", "node", nodeName)
 
 	e.logger.Info("Connecting to local GRPC server")
 
@@ -220,6 +226,7 @@ func (e *Enricher) Run() error {
 	if err := e.startGrpcServer(); err != nil {
 		return fmt.Errorf("start GRPC server: %w", err)
 	}
+	defer e.grpcServer.GracefulStop()
 
 	log, err := e.StartTail(e.source)
 	if err != nil {
@@ -228,7 +235,7 @@ func (e *Enricher) Run() error {
 
 	for auditLine := range log {
 		e.logger.V(config.VerboseLevel).
-			Info(fmt.Sprintf("Get container ID for PID: %d", auditLine.ProcessID))
+			Info("Get container ID for PID", "pid", auditLine.ProcessID)
 
 		cID, err := e.ContainerIDForPID(e.containerIDCache, auditLine.ProcessID)
 		if errors.Is(err, os.ErrNotExist) {
@@ -253,7 +260,7 @@ func (e *Enricher) Run() error {
 			continue
 		}
 
-		e.logger.V(config.VerboseLevel).Info("Get container info for: " + cID)
+		e.logger.V(config.VerboseLevel).Info("Get container info", "containerID", cID)
 
 		info, err := getContainerInfo(context.Background(),
 			nodeName, cID, e.clientset, e.impl, e.infoCache, e.logger)
@@ -308,14 +315,14 @@ func (e *Enricher) startGrpcServer() error {
 		return fmt.Errorf("change GRPC socket owner to rootless: %w", err)
 	}
 
-	grpcServer := grpc.NewServer(
+	e.grpcServer = grpc.NewServer(
 		grpc.MaxSendMsgSize(maxMsgSize),
 		grpc.MaxRecvMsgSize(maxMsgSize),
 	)
-	apienricher.RegisterEnricherServer(grpcServer, e)
+	apienricher.RegisterEnricherServer(e.grpcServer, e)
 
 	go func() {
-		if err := e.Serve(grpcServer, listener); err != nil {
+		if err := e.Serve(e.grpcServer, listener); err != nil {
 			e.logger.Error(err, "unable to run GRPC server")
 		}
 	}()

--- a/internal/pkg/daemon/enricher/jsonenricher.go
+++ b/internal/pkg/daemon/enricher/jsonenricher.go
@@ -66,7 +66,7 @@ type JsonEnricherOptions struct {
 }
 
 var JsonEnricherDefaultOptions = JsonEnricherOptions{
-	AuditFreq:           time.Duration(60) * time.Second,
+	AuditFreq:           time.Minute,
 	AuditLogPath:        "",
 	AuditLogMaxSize:     0,
 	AuditLogMaxAge:      0,
@@ -196,7 +196,7 @@ func (e *JsonEnricher) Run(ctx context.Context, runErr chan<- error) {
 		return
 	}
 
-	e.logger.Info("Starting audit JSON logging on node " + nodeName)
+	e.logger.Info("Starting audit JSON logging on node", "node", nodeName)
 
 	e.logLinesCache.OnEviction(
 		func(ctx context.Context, reason ttlcache.EvictionReason, logItem *ttlcache.Item[int, *types.LogBucket]) {
@@ -208,7 +208,7 @@ func (e *JsonEnricher) Run(ctx context.Context, runErr chan<- error) {
 		},
 	)
 
-	e.logger.Info(fmt.Sprintf("Setting up caches with expiry of %v", defaultCacheTimeout))
+	e.logger.Info("Setting up caches", "expiry", defaultCacheTimeout)
 
 	clusterConfig, err := e.InClusterConfig()
 	if err != nil {
@@ -225,9 +225,16 @@ func (e *JsonEnricher) Run(ctx context.Context, runErr chan<- error) {
 	}
 
 	go e.containerIDCache.Start()
+	defer e.containerIDCache.Stop()
+
 	go e.infoCache.Start()
+	defer e.infoCache.Stop()
+
 	go e.logLinesCache.Start()
+	defer e.logLinesCache.Stop()
+
 	go e.processCache.Start()
+	defer e.processCache.Stop()
 
 	// Use auditd logs as main source or syslog as fallback.
 	filePath := common.LogFilePath()
@@ -250,7 +257,7 @@ func (e *JsonEnricher) Run(ctx context.Context, runErr chan<- error) {
 		return
 	}
 
-	e.logger.Info("Reading from file " + filePath)
+	e.logger.Info("Reading from file", "path", filePath)
 
 	timePrev := time.Now()
 
@@ -279,7 +286,7 @@ func (e *JsonEnricher) Run(ctx context.Context, runErr chan<- error) {
 		}
 
 		line := l.Text
-		e.logger.V(config.VerboseLevel).Info("Got line: " + line)
+		e.logger.V(config.VerboseLevel).Info("Got line", "line", line)
 
 		if !auditsource.IsAuditLine(line) {
 			e.logger.V(config.VerboseLevel).Info("Not an audit line")
@@ -287,7 +294,7 @@ func (e *JsonEnricher) Run(ctx context.Context, runErr chan<- error) {
 			continue
 		}
 
-		e.logger.V(config.VerboseLevel).Info("AuditLine Parsed: " + line)
+		e.logger.V(config.VerboseLevel).Info("AuditLine parsed", "line", line)
 
 		auditLine, err := auditsource.ExtractAuditLine(line)
 		if err != nil {
@@ -389,8 +396,8 @@ func (e *JsonEnricher) fetchContainerInfo(
 	nodeName string,
 ) *types.ContainerInfo {
 	cID, errContainer := e.ContainerIDForPID(e.containerIDCache, processId)
-	e.logger.V(config.VerboseLevel).Info(
-		fmt.Sprintf("Container ID for Pid: %v with len %d", cID, len(cID)))
+	e.logger.V(config.VerboseLevel).Info("Container ID for PID",
+		"containerID", cID, "len", len(cID))
 
 	var containerInfo *types.ContainerInfo
 
@@ -404,8 +411,8 @@ func (e *JsonEnricher) fetchContainerInfo(
 		e.logger.V(config.VerboseLevel).Info("unable to get container Id", "err", errContainer)
 	}
 
-	e.logger.V(config.VerboseLevel).Info(
-		fmt.Sprintf("Container Info: %v", containerInfo))
+	e.logger.V(config.VerboseLevel).Info("Container info",
+		"containerInfo", containerInfo)
 
 	return containerInfo
 }
@@ -417,8 +424,8 @@ func (e *JsonEnricher) fetchProcessInfo(
 	uid, gid uint32,
 ) *types.ProcessInfo {
 	processInfo, err := GetProcessInfo(processId, executable, uid, gid, e.processCache, e.impl)
-	e.logger.V(config.VerboseLevel).Info(
-		fmt.Sprintf("Process Info: %v", processInfo))
+	e.logger.V(config.VerboseLevel).Info("Process info",
+		"processInfo", processInfo)
 
 	if err != nil {
 		e.logger.V(config.VerboseLevel).Info("get process info", "err", err)

--- a/internal/pkg/daemon/metrics/grpc.go
+++ b/internal/pkg/daemon/metrics/grpc.go
@@ -49,21 +49,28 @@ func (m *Metrics) ServeGRPC() error {
 		return fmt.Errorf("create listener: %w", err)
 	}
 
-	grpcServer := grpc.NewServer(
+	m.grpcServer = grpc.NewServer(
 		grpc.MaxSendMsgSize(maxMsgSize),
 		grpc.MaxRecvMsgSize(maxMsgSize),
 	)
-	api.RegisterMetricsServer(grpcServer, m)
+	api.RegisterMetricsServer(m.grpcServer, m)
 
 	go func() {
 		m.log.Info("Starting GRPC server API")
 
-		if err := grpcServer.Serve(listener); err != nil {
+		if err := m.grpcServer.Serve(listener); err != nil {
 			m.log.Error(err, "unable to run GRPC server")
 		}
 	}()
 
 	return nil
+}
+
+// GracefulStop gracefully stops the GRPC server.
+func (m *Metrics) GracefulStop() {
+	if m.grpcServer != nil {
+		m.grpcServer.GracefulStop()
+	}
 }
 
 // Dial can be used to connect to the default GRPC server by creating a new

--- a/internal/pkg/daemon/metrics/metrics.go
+++ b/internal/pkg/daemon/metrics/metrics.go
@@ -24,6 +24,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"google.golang.org/grpc"
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	api "sigs.k8s.io/security-profiles-operator/api/grpc/metrics"
@@ -80,6 +81,7 @@ type Metrics struct {
 	api.UnimplementedMetricsServer
 	impl                        impl
 	log                         logr.Logger
+	grpcServer                  *grpc.Server
 	metricSeccompProfile        *prometheus.CounterVec
 	metricSeccompProfileAudit   *prometheus.CounterVec
 	metricSeccompProfileBpf     *prometheus.CounterVec
@@ -235,7 +237,7 @@ func (m *Metrics) Register() error {
 		metricNameAppArmorProfileError:  m.metricAppArmorProfileError,
 		metricNameAppArmorProfileDenial: m.metricAppArmorProfileDenial,
 	} {
-		m.log.Info("Registering metric: " + name)
+		m.log.Info("Registering metric", "name", name)
 
 		if err := m.impl.Register(collector); err != nil {
 			return fmt.Errorf("register collector for %s metric: %w", name, err)

--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -435,7 +435,7 @@ func (r *Reconciler) resolveSyscallsForProfile(
 				OS:           runtime.GOOS,
 			}, signOpts)
 			if err != nil {
-				l.Error(err, "cannot pull base profile "+baseProfileName)
+				l.Error(err, "cannot pull base profile", "profile", baseProfileName)
 				r.IncSeccompProfileError(r.metrics, reasonCannotPullProfile)
 				r.RecordEvent(
 					r.record,
@@ -467,7 +467,7 @@ func (r *Reconciler) resolveSyscallsForProfile(
 			ctx, r.client, util.NamespacedName(baseProfileName, sp.GetNamespace()),
 		)
 		if err != nil {
-			l.Error(err, "cannot retrieve base profile "+baseProfileName)
+			l.Error(err, "cannot retrieve base profile", "profile", baseProfileName)
 			r.IncSeccompProfileError(r.metrics, reasonInvalidSeccompProfile)
 			r.RecordEvent(
 				r.record,
@@ -538,7 +538,7 @@ func (r *Reconciler) reconcileSeccompProfile(
 
 	profileContent, err := json.Marshal(outputProfile.Spec)
 	if err != nil {
-		l.Error(err, "cannot validate profile "+profileName)
+		l.Error(err, "cannot validate profile", "profile", profileName)
 		r.metrics.IncSeccompProfileError(reasonInvalidSeccompProfile)
 		r.record.Event(sp, util.EventTypeWarning, reasonInvalidSeccompProfile, err.Error())
 
@@ -656,7 +656,7 @@ func (r *Reconciler) handleDeletion(sp *seccompprofileapi.SeccompProfile) error 
 		return fmt.Errorf("removing profile from host: %w", err)
 	}
 
-	r.log.Info("removed profile " + profilePath)
+	r.log.Info("removed profile", "path", profilePath)
 	r.metrics.IncSeccompProfileDelete()
 
 	return nil

--- a/internal/pkg/daemon/selinuxprofile/common_controller.go
+++ b/internal/pkg/daemon/selinuxprofile/common_controller.go
@@ -148,8 +148,8 @@ func (r *ReconcileSelinux) SchemeBuilder() runtime.SchemeBuilder {
 }
 
 // Healthz is the liveness probe endpoint of the controller.
-func (r *ReconcileSelinux) Healthz(*http.Request) error {
-	ready, err := isSelinuxdReady(context.TODO(), r.httpc)
+func (r *ReconcileSelinux) Healthz(req *http.Request) error {
+	ready, err := isSelinuxdReady(req.Context(), r.httpc)
 	if err != nil {
 		return fmt.Errorf("getting health status: %w", err)
 	}
@@ -188,7 +188,7 @@ func (r *ReconcileSelinux) Reconcile(
 		"Request.Name",
 		request.Name,
 	)
-	reqLogger.Info("Reconciling object in " + r.controllerName)
+	reqLogger.Info("Reconciling object", "controller", r.controllerName)
 
 	// Fetch the object instance
 	oh, err := r.objectHandlerInit(ctx, r.client, request.NamespacedName)

--- a/internal/pkg/daemon/selinuxprofile/selinuxprofile.go
+++ b/internal/pkg/daemon/selinuxprofile/selinuxprofile.go
@@ -43,6 +43,9 @@ var (
 	ErrInvalidPermission       = errors.New("invalid permission")
 	ErrSystemInheritNotAllowed = errors.New("system profile not allowed")
 	ErrUnknownKindForEntry     = errors.New("unknown inherit kind for entry")
+
+	labelRegex        = regexp.MustCompile(`^([a-zA-Z0-9.\-_]+|@self)$`)
+	objClassPermRegex = regexp.MustCompile(`^[a-zA-Z0-9.\-_]+$`)
 )
 
 // NewController returns a new empty controller instance.
@@ -65,13 +68,11 @@ func selinuxProfileControllerBuild(b *ctrl.Builder, r reconcile.Reconciler) erro
 var _ SelinuxObjectHandler = &selinuxProfileHandler{}
 
 type selinuxProfileHandler struct {
-	sp                *selinuxprofileapi.SelinuxProfile
-	cli               client.Client
-	systemInherits    []string
-	objInherits       []selinuxprofileapi.SelinuxProfileObject
-	labelRegex        *regexp.Regexp
-	objClassPermRegex *regexp.Regexp
-	translatorOpts    *translator.Options
+	sp             *selinuxprofileapi.SelinuxProfile
+	cli            client.Client
+	systemInherits []string
+	objInherits    []selinuxprofileapi.SelinuxProfileObject
+	translatorOpts *translator.Options
 }
 
 func (sph *selinuxProfileHandler) Init(
@@ -87,18 +88,6 @@ func (sph *selinuxProfileHandler) Init(
 	if err := sph.cli.Get(ctx, key, sph.sp); err != nil {
 		return fmt.Errorf("getting selinux profile: %w", err)
 	}
-
-	// Matches alpha numerical names in upper and lower-case, as well as
-	// dashes and underscores. @self is also allowed explicitly.
-	// Must be at least one character.
-	// The characters must match from beginning to end of the string
-	sph.labelRegex = regexp.MustCompile(`^([a-zA-Z0-9.\-_]+|@self)$`)
-
-	// Matches alpha numerical names in upper and lower-case, as well as
-	// dashes and underscores.
-	// Must be at least one character.
-	// The characters must match from beginning to end of the string
-	sph.objClassPermRegex = regexp.MustCompile(`^[a-zA-Z0-9.\-_]+$`)
 
 	return nil
 }
@@ -162,7 +151,7 @@ func (sph *selinuxProfileHandler) validateAndTrackInherit(
 func (sph *selinuxProfileHandler) validateLabelKey(
 	key selinuxprofileapi.LabelKey,
 ) error {
-	if !sph.labelRegex.MatchString(string(key)) {
+	if !labelRegex.MatchString(string(key)) {
 		return fmt.Errorf("'%s' didn't match expected characters: %w", key, ErrInvalidLabelKey)
 	}
 
@@ -172,7 +161,7 @@ func (sph *selinuxProfileHandler) validateLabelKey(
 func (sph *selinuxProfileHandler) validateObjClass(
 	key selinuxprofileapi.ObjectClassKey,
 ) error {
-	if !sph.objClassPermRegex.MatchString(string(key)) {
+	if !objClassPermRegex.MatchString(string(key)) {
 		return fmt.Errorf("'%s' didn't match expected characters: %w", key, ErrInvalidObjClass)
 	}
 
@@ -182,7 +171,7 @@ func (sph *selinuxProfileHandler) validateObjClass(
 func (sph *selinuxProfileHandler) validatePermission(
 	perm string,
 ) error {
-	if !sph.objClassPermRegex.MatchString(perm) {
+	if !objClassPermRegex.MatchString(perm) {
 		return fmt.Errorf("'%s' didn't match expected characters: %w", perm, ErrInvalidPermission)
 	}
 

--- a/internal/pkg/nonrootenabler/nonrootenabler.go
+++ b/internal/pkg/nonrootenabler/nonrootenabler.go
@@ -54,10 +54,10 @@ func (n *NonRootEnabler) Run(logger logr.Logger, runtime, kubeletDir string, app
 
 	const filePermissions os.FileMode = 0o644
 
-	logger.Info("Container runtime:" + runtime)
+	logger.Info("Container runtime", "runtime", runtime)
 
 	kubeleteSeccompDir := path.Join(config.HostRoot, kubeletDir, config.SeccompProfilesFolder)
-	logger.Info("Ensuring seccomp root path: " + kubeleteSeccompDir)
+	logger.Info("Ensuring seccomp root path", "path", kubeleteSeccompDir)
 
 	if err := n.MkdirAll(
 		kubeleteSeccompDir, dirPermissions,
@@ -68,7 +68,7 @@ func (n *NonRootEnabler) Run(logger logr.Logger, runtime, kubeletDir string, app
 		)
 	}
 
-	logger.Info("Ensuring operator root path: " + config.OperatorRoot)
+	logger.Info("Ensuring operator root path", "path", config.OperatorRoot)
 
 	if err := n.MkdirAll(
 		config.OperatorRoot, dirPermissions,
@@ -128,7 +128,7 @@ func (n *NonRootEnabler) Run(logger logr.Logger, runtime, kubeletDir string, app
 		return fmt.Errorf("change operator root permissions: %w", err)
 	}
 
-	logger.Info("Copying profiles into root path: " + kubeleteSeccompDir)
+	logger.Info("Copying profiles into root path", "path", kubeleteSeccompDir)
 
 	if err := n.CopyDirContentsLocal(
 		config.DefaultSpoProfilePath, kubeleteSeccompDir,
@@ -140,7 +140,7 @@ func (n *NonRootEnabler) Run(logger logr.Logger, runtime, kubeletDir string, app
 	if apparmor && aaManager.Enabled() {
 		for _, p := range []string{config.SpoApparmorProfile, config.BpfRecorderApparmorProfile} {
 			profile := path.Join(config.DefaultSpoProfilePath, p)
-			logger.Info("Installing apparmor profile: " + profile)
+			logger.Info("Installing apparmor profile", "profile", profile)
 
 			if err := n.InstallApparmor(aaManager, profile); err != nil {
 				return fmt.Errorf("installing apparmor profile: %w", err)

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -507,10 +507,6 @@ func (e *e2e) getSELinuxPolicyUsage(kind, policy string) string {
 	return e.kubectl("get", kind, "-n", ns, policy, "-o", "jsonpath={.status.usage}")
 }
 
-func (e *e2e) sliceContainsString(slice []string, s string) bool {
-	return slices.Contains(slice, s)
-}
-
 func (e *e2e) waitForSpod() {
 	for i := range 50 {
 		output, err := command.New(

--- a/test/tc_selinux_base_usage_test.go
+++ b/test/tc_selinux_base_usage_test.go
@@ -18,6 +18,7 @@ package e2e_test
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"time"
 )
@@ -381,7 +382,7 @@ func (e *e2e) assertSelinuxPolicyIsInstalled(
 
 		for _, node := range nodes {
 			policiesRaw := e.execNode(node, "semodule", "-l")
-			if !e.sliceContainsString(strings.Split(policiesRaw, "\n"), policy) {
+			if !slices.Contains(strings.Split(policiesRaw, "\n"), policy) {
 				missingPolName = node
 
 				break
@@ -413,7 +414,7 @@ func (e *e2e) assertSelinuxPolicyIsRemoved(
 
 		for _, node := range nodes {
 			policiesRaw := e.execNode(node, "semodule", "-l")
-			if e.sliceContainsString(strings.Split(policiesRaw, "\n"), policy) {
+			if slices.Contains(strings.Split(policiesRaw, "\n"), policy) {
 				missingPolName = node
 
 				break


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Fixes two bugs, multiple resource leaks, and improves logging consistency across daemon packages:

**Bug fixes:**
- AppArmor `loadProfile` returned `err != nil` instead of `err == nil`, inverting the boolean. This prevented success events (`IncAppArmorProfileUpdate`) and Kubernetes events from ever firing on successful profile loads.
- BPF `StopRecording` wrote `[]byte{1}` (the "on" value) to `is_recording` instead of `[]byte{0}`, so recording never actually stopped.

**Resource leak fixes:**
- GRPC servers in enricher and metrics packages now get `GracefulStop()` on shutdown.
- All `ttlcache` goroutines (`cache.Start()`) now have matching `defer cache.Stop()` calls across enricher, jsonenricher, and bpfrecorder.

**Refactoring (no behavior change):**
- Convert string concatenation and `fmt.Sprintf` in structured logging to key-value pairs across all daemon packages.
- Move regex compilation to package-level vars in bpfrecorder and selinuxprofile to avoid per-call recompilation.
- Use `req.Context()` instead of `context.TODO()` in SELinux Healthz probe.
- Extract `setRepoCredentials` helper to deduplicate OCI auth client setup in artifact package.
- Remove stray `fmt.Println` in profile_reader that bypassed structured logging.
- Replace test helper `sliceContainsString` with stdlib `slices.Contains`.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

N/A (bug fixes verified by code inspection, build validation, and existing unit tests)

#### Special notes for your reviewer:

The AppArmor and BPF bug fixes are the most impactful changes. The rest is cleanup that improves resource management and logging consistency.

#### Does this PR introduce a user-facing change?

```release-note
Fix AppArmor profile load success events and metrics never firing due to inverted return value.
Fix BPF recorder not actually stopping recording when StopRecording was called.
```