### PR TITLE
Publish runtime-spec seccomp profiles as KEP-6061 artifacts

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -6,6 +6,7 @@
   - [Run commands with seccomp profiles](#run-commands-with-seccomp-profiles)
   - [Pull security profiles from OCI registries](#pull-security-profiles-from-oci-registries)
   - [Push security profiles to OCI registries](#push-security-profiles-to-oci-registries)
+  - [Pushing profiles for container runtimes](#pushing-profiles-for-container-runtimes)
   - [Using multiple platforms](#using-multiple-platforms)
 <!-- /toc -->
 
@@ -224,6 +225,80 @@ Please also note that signing is always required for push and pull. It is
 possible to add custom annotations to the security profile by using the
 `--annotations` / `-a` flag multiple times in `KEY:VALUE` format.
 
+### Pushing profiles for container runtimes
+
+Container runtimes consume seccomp profiles from OCI artifacts in the format
+defined by [KEP-6061](https://github.com/kubernetes/enhancements/issues/6061):
+exactly one layer containing the profile as OCI runtime-spec JSON, identified
+by the media type `application/vnd.cncf.seccomp-profile.config.v1+json`. This
+differs from the profile CRD artifacts above, which keep the generic
+`application/vnd.unknown.config.v1+json` artifact type together with the empty
+OCI config descriptor, and are used by the operator for `oci://` base
+profiles.
+
+`spoc push` produces the runtime format automatically when the input file is a
+raw runtime-spec seccomp profile in JSON, for example the output of
+`spoc convert`, which writes the profile spec without the fields that are
+specific to the operator (`state`, `baseProfileName` and the listener fields):
+
+```
+> spoc push -f ./profile.json ghcr.io/security-profiles/runc:v1.5.1
+```
+
+The media type is set on the manifest config as well as on `artifactType`, and
+the single layer is not platform qualified:
+
+```
+> skopeo inspect --raw docker://ghcr.io/security-profiles/runc:v1.5.1 | jq .
+{
+  "schemaVersion": 2,
+  "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": "application/vnd.cncf.seccomp-profile.config.v1+json",
+  "config": {
+    "mediaType": "application/vnd.cncf.seccomp-profile.config.v1+json",
+    "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
+    "size": 2
+  },
+  "layers": [
+    {
+      "mediaType": "application/json",
+      "digest": "sha256:d6ad0c0d1f2eb0e0b0a2d16a44a8bb5a1e11e8fbc0a90e4e1a36ba4b7d1e3f9c",
+      "size": 1031,
+      "annotations": {
+        "org.opencontainers.image.title": "profile.json"
+      }
+    }
+  ],
+  "annotations": {
+    "org.opencontainers.image.created": "2026-09-09T07:32:11Z"
+  }
+}
+```
+
+The input has to decode strictly as a runtime-spec seccomp profile: unknown
+fields and trailing data are rejected and `defaultAction` is required. Such
+artifacts contain exactly one profile, so pushing several platforms into one
+artifact is rejected for this format; per-platform variants have to be pushed
+as separate artifacts.
+
+Profiles which are neither a profile CRD nor a runtime-spec profile are
+rejected, so that no artifact gets published which no consumer understands.
+Content container runtimes reject is reported as a warning: the listener
+fields, `SCMP_ACT_NOTIFY`, profiles above 1 MiB and syscalls with more than
+128 rule entries. The last two are runtime defaults rather than part of the
+format, so they do not fail the push.
+
+`spoc pull` and `oci://` base profile references accept both formats. Runtime
+format artifacts are recognized by their media type and read from their single
+layer, so layer names and annotations do not matter. For other artifacts, the
+layer names above are used, with a fallback to the single layer if there is
+exactly one and it is not bound to another platform. A runtime format artifact
+is exposed as a `SeccompProfile` named after the last path element of the
+reference (`runc` for the example above), whose spec drops fields the CRD
+cannot express, such as `defaultErrnoRet`. `spoc pull` writes the artifact
+content unchanged, so a runtime format artifact is saved as runtime-spec JSON
+and the default output file switches to a `.json` extension.
+
 ### Using multiple platforms
 
 `spoc push` supports specifying the target platforms for the profiles to be
@@ -249,8 +324,9 @@ The pushed artifact now contains both profiles, separated by their platform:
 {
   "schemaVersion": 2,
   "mediaType": "application/vnd.oci.image.manifest.v1+json",
+  "artifactType": "application/vnd.unknown.config.v1+json",
   "config": {
-    "mediaType": "application/vnd.unknown.config.v1+json",
+    "mediaType": "application/vnd.oci.empty.v1+json",
     "digest": "sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a",
     "size": 2
   },

--- a/cmd/spoc/main.go
+++ b/cmd/spoc/main.go
@@ -175,16 +175,21 @@ func main() {
 			},
 		},
 		&cli.Command{
-			Name:      "push",
-			Aliases:   []string{"p"},
-			Usage:     "push a profile to a container registry",
+			Name:    "push",
+			Aliases: []string{"p"},
+			Usage:   "push a profile to a container registry",
+			Description: "Profile CRDs are pushed as YAML artifacts for oci:// base profiles. " +
+				"A raw OCI runtime-spec seccomp profile in JSON is pushed in the KEP-6061 " +
+				"runtime format for container runtimes (single JSON layer, media type " +
+				"application/vnd.cncf.seccomp-profile.config.v1+json); exactly one profile " +
+				"is allowed in that format.",
 			Action:    push,
 			ArgsUsage: "FILE",
 			Flags: []cli.Flag{
 				&cli.StringSliceFlag{
 					Name:        pusher.FlagProfiles,
 					Aliases:     []string{"f"},
-					Usage:       "the profiles to be used",
+					Usage:       "the profiles to be used (profile CRD YAML or raw runtime-spec seccomp JSON)",
 					DefaultText: pusher.DefaultInputFile,
 					TakesFile:   true,
 				},
@@ -210,9 +215,13 @@ func main() {
 			},
 		},
 		&cli.Command{
-			Name:      "pull",
-			Aliases:   []string{"l"},
-			Usage:     "pull a profile from a container registry",
+			Name:    "pull",
+			Aliases: []string{"l"},
+			Usage:   "pull a profile from a container registry",
+			Description: "Profile CRD artifacts and KEP-6061 runtime format artifacts are " +
+				"supported; the artifact content is written unchanged, so runtime format " +
+				"artifacts are saved as runtime-spec JSON and the default output file " +
+				"switches to a .json extension.",
 			Action:    pull,
 			ArgsUsage: "IMAGE",
 			Flags: []cli.Flag{

--- a/internal/pkg/artifact/artifact.go
+++ b/internal/pkg/artifact/artifact.go
@@ -17,9 +17,12 @@ limitations under the License.
 package artifact
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"maps"
 	"path/filepath"
 	"strings"
@@ -27,10 +30,13 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/generate"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/options"
 	"github.com/sigstore/cosign/v2/cmd/cosign/cli/verify"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote"
 	"oras.land/oras-go/v2/registry/remote/auth"
 	"oras.land/oras-go/v2/registry/remote/retry"
@@ -50,7 +56,14 @@ type PullResult struct {
 	selinuxProfile  *selinuxprofileapi.SelinuxProfile
 	apparmorProfile *apparmorprofileapi.AppArmorProfile
 
-	content []byte
+	content       []byte
+	runtimeFormat bool
+}
+
+// IsRuntimeFormat returns whether the artifact used the KEP-6061 runtime
+// format, which means that the content is raw runtime-spec JSON.
+func (p *PullResult) IsRuntimeFormat() bool {
+	return p.runtimeFormat
 }
 
 // Type returns the PullResultType of the PullResult.
@@ -152,23 +165,31 @@ func (a *Artifact) Push(
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
+	a.logger.Info("Reading profiles", "count", len(files))
+
+	entries, runtimeSpecProfiles, err := a.profileEntries(files)
+	if err != nil {
+		return err
+	}
+
+	if runtimeSpecProfiles > 0 && runtimeSpecProfiles != len(files) {
+		return ErrMixedProfileFormats
+	}
+
+	if runtimeSpecProfiles > 1 {
+		return ErrMultipleRuntimeSpecProfiles
+	}
+
 	fileDescriptors := []v1.Descriptor{}
 
-	a.logger.Info("Adding profiles", "count", len(files))
-
-	for platform, file := range files {
+	for _, entry := range entries {
 		a.logger.Info("Adding profile to store",
-			"file", file,
-			"platform", platformToString(platform),
+			"file", entry.absPath,
+			"platform", platformToString(entry.platform),
 		)
 
-		absPath, err := a.FilepathAbs(file)
-		if err != nil {
-			return fmt.Errorf("get absolute file path: %w", err)
-		}
-
 		fileDescriptor, err := a.StoreAdd(
-			ctx, store, profileName(platform), "", absPath,
+			ctx, store, entry.name, entry.layerMediaType, entry.absPath,
 		)
 		if err != nil {
 			return fmt.Errorf("add profile to store: %w", err)
@@ -176,20 +197,32 @@ func (a *Artifact) Push(
 
 		maps.Copy(fileDescriptor.Annotations, annotations)
 
-		fileDescriptor.Platform = platform
+		fileDescriptor.Platform = entry.platform
 		fileDescriptors = append(fileDescriptors, fileDescriptor)
 	}
 
-	a.logger.Info("Packing files")
+	mediaType := oras.MediaTypeUnknownConfig
+	packOptions := oras.PackManifestOptions{Layers: fileDescriptors}
+
+	if runtimeSpecProfiles > 0 {
+		mediaType = MediaTypeSeccompProfile
+
+		configDescriptor, err := a.pushConfig(ctx, store, mediaType)
+		if err != nil {
+			return fmt.Errorf("push config: %w", err)
+		}
+
+		packOptions.ConfigDescriptor = &configDescriptor
+	}
+
+	a.logger.Info("Packing files", "mediaType", mediaType)
 
 	manifestDescriptor, err := a.PackManifest(
 		ctx,
 		store,
 		oras.PackManifestVersion1_1,
-		oras.MediaTypeUnknownConfig,
-		oras.PackManifestOptions{
-			Layers: fileDescriptors,
-		},
+		mediaType,
+		packOptions,
 	)
 	if err != nil {
 		return fmt.Errorf("pack files: %w", err)
@@ -347,33 +380,43 @@ func (a *Artifact) Pull(
 	a.logger.Info("Copying profile from repository")
 	a.logger.Info("Source image", "image", from)
 
-	if _, err := a.Copy(
+	manifestDescriptor, err := a.Copy(
 		ctx, repo, sha.String(), store, sha.String(), oras.DefaultCopyOptions,
-	); err != nil {
+	)
+	if err != nil {
 		return nil, fmt.Errorf("copy from repository: %w", err)
 	}
 
 	a.logger.Info("Checking profile contents")
 
-	// Allow a fallback to defaultProfileYAML if no platform is available.
-	content := []byte{}
-
-	for _, name := range []string{profileName(platform), defaultProfileYAML} {
-		a.logger.Info("Trying to read profile", "name", name)
-
-		content, err = a.ReadFile(filepath.Join(dir, name))
-		if err == nil {
-			break
-		}
-	}
-
+	content, runtimeFormat, err := a.profileContent(
+		ctx, store, dir, &manifestDescriptor, platform,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("read profile: %w", err)
 	}
 
+	if runtimeFormat {
+		spec, err := runtimeSpecSeccompProfileSpec(content)
+		if err != nil {
+			return nil, fmt.Errorf("decode %s artifact: %w", MediaTypeSeccompProfile, err)
+		}
+
+		return seccompPullResult(originalImage, spec, content, true), nil
+	}
+
 	profile, err := a.ReadProfile(content)
 	if err != nil {
-		return nil, errors.Join(ErrDecodeYAML, err)
+		// Artifacts without the KEP-6061 media type may still hold a raw
+		// runtime-spec seccomp profile.
+		spec, specErr := runtimeSpecSeccompProfileSpec(content)
+		if specErr != nil {
+			return nil, errors.Join(ErrDecodeYAML, err, specErr)
+		}
+
+		a.logger.Info("Profile is an OCI runtime-spec seccomp profile")
+
+		return seccompPullResult(originalImage, spec, content, true), nil
 	}
 
 	switch obj := profile.(type) {
@@ -429,7 +472,416 @@ func (a *Artifact) imageWithDigest(ctx context.Context, image, username, passwor
 		desc.Digest.String()), repo, desc.Digest, nil
 }
 
-// profileName returns the name for the profile based on the platform.
+// profileEntry is a profile to be added to the artifact store on push.
+type profileEntry struct {
+	platform       *v1.Platform
+	absPath        string
+	name           string
+	layerMediaType string
+	runtimeSpec    bool
+}
+
+// profileEntries reads the provided files and derives the layer name and
+// media type for each of them. It also returns how many of them are raw OCI
+// runtime-spec seccomp profiles.
+func (a *Artifact) profileEntries(
+	files map[*v1.Platform]string,
+) ([]profileEntry, int, error) {
+	entries := make([]profileEntry, 0, len(files))
+	runtimeSpecProfiles := 0
+
+	for platform, file := range files {
+		absPath, err := a.FilepathAbs(file)
+		if err != nil {
+			return nil, 0, fmt.Errorf("get absolute file path: %w", err)
+		}
+
+		content, err := a.ReadFile(absPath)
+		if err != nil {
+			return nil, 0, fmt.Errorf("read profile: %w", err)
+		}
+
+		entry := profileEntry{
+			platform: platform,
+			absPath:  absPath,
+			name:     profileName(platform),
+		}
+
+		runtimeSpec, isRuntimeSpec, err := a.runtimeSpecSeccompProfile(content)
+		if err != nil {
+			return nil, 0, fmt.Errorf("profile %s: %w", file, err)
+		}
+
+		if isRuntimeSpec {
+			a.logger.Info("Profile is an OCI runtime-spec seccomp profile", "file", file)
+			a.warnRuntimeRestrictions(runtimeSpec, content, file)
+
+			// KEP-6061 artifacts hold exactly one platform independent
+			// profile, so the layer is neither named nor tagged per platform.
+			if platform != nil {
+				a.logger.Info(
+					"Ignoring platform, runtime format artifacts are platform independent",
+					"file", file,
+					"platform", platformToString(platform),
+				)
+			}
+
+			runtimeSpecProfiles++
+			entry.runtimeSpec = true
+			entry.platform = nil
+			entry.name = defaultProfileJSON
+			entry.layerMediaType = layerMediaTypeJSON
+		}
+
+		entries = append(entries, entry)
+	}
+
+	return entries, runtimeSpecProfiles, nil
+}
+
+// pushConfig pushes the manifest config blob of a runtime format artifact to
+// the store and returns its descriptor. ORAS defaults to the empty OCI config
+// descriptor, which would leave the media type identifying the artifact in
+// the manifest artifactType field only.
+func (a *Artifact) pushConfig(
+	ctx context.Context, store *file.Store, mediaType string,
+) (v1.Descriptor, error) {
+	descriptor := v1.Descriptor{
+		MediaType: mediaType,
+		Digest:    digest.FromBytes(emptyConfig),
+		Size:      int64(len(emptyConfig)),
+	}
+
+	if err := a.StorePush(ctx, store, descriptor, bytes.NewReader(emptyConfig)); err != nil {
+		return v1.Descriptor{}, fmt.Errorf("store config blob: %w", err)
+	}
+
+	return descriptor, nil
+}
+
+// profileContent returns the profile content of a pulled artifact, together
+// with whether the artifact uses the KEP-6061 runtime format. It prefers the
+// layer names used by push, but falls back to the single layer of the
+// artifact because KEP-6061 mandates no particular layer name.
+func (a *Artifact) profileContent(
+	ctx context.Context,
+	store *file.Store,
+	dir string,
+	manifestDescriptor *v1.Descriptor,
+	platform *v1.Platform,
+) (content []byte, runtimeFormat bool, err error) {
+	manifest, err := a.manifest(ctx, store, manifestDescriptor)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// KEP-6061 identifies the artifact by the config media type, with the
+	// artifact type as fallback for the empty OCI config descriptor.
+	if manifest.Config.MediaType == MediaTypeSeccompProfile ||
+		manifest.ArtifactType == MediaTypeSeccompProfile {
+		a.logger.Info("Artifact is in the runtime format", "mediaType", MediaTypeSeccompProfile)
+
+		if len(manifest.Layers) != 1 {
+			return nil, false, fmt.Errorf("%w: got %d", ErrNoSingleLayer, len(manifest.Layers))
+		}
+
+		content, err := a.blobContent(ctx, store, &manifest.Layers[0])
+
+		return content, true, err
+	}
+
+	// profileName falls back to defaultProfileYAML if no platform is
+	// available, so only look for it separately if there is one.
+	names := []string{profileName(platform)}
+	if platform != nil {
+		names = append(names, defaultProfileYAML)
+	}
+
+	names = append(names, defaultProfileJSON)
+
+	for _, name := range names {
+		a.logger.Info("Trying to read profile", "name", name)
+
+		if content, err := a.ReadFile(filepath.Join(dir, name)); err == nil {
+			return content, false, nil
+		}
+	}
+
+	content, err = a.singleLayerContent(ctx, store, manifest, platform)
+
+	return content, false, err
+}
+
+// singleLayerContent returns the content of the only layer of an artifact,
+// which is the fallback for artifacts not using a layer name push produces.
+// It reads the layer through its descriptor, because KEP-6061 requires
+// neither a layer name nor the annotation the ORAS file store needs to
+// materialize a layer on disk. A layer bound to another platform is not
+// eligible, it would have been found by name for a matching one.
+func (a *Artifact) singleLayerContent(
+	ctx context.Context, store *file.Store, manifest *v1.Manifest, platform *v1.Platform,
+) ([]byte, error) {
+	if len(manifest.Layers) != 1 {
+		return nil, fmt.Errorf("%w: got %d", ErrNoSingleLayer, len(manifest.Layers))
+	}
+
+	layer := &manifest.Layers[0]
+	title := layer.Annotations[v1.AnnotationTitle]
+
+	if !layerMatchesPlatform(layer, platform) {
+		return nil, fmt.Errorf("%w: %s", ErrPlatformMismatch, title)
+	}
+
+	a.logger.Info("Falling back to single artifact layer", "title", title)
+
+	return a.blobContent(ctx, store, layer)
+}
+
+// layerMatchesPlatform reports whether the layer can be used for the
+// requested platform. Layers without a platform are only eligible if they are
+// not named for one either.
+func layerMatchesPlatform(layer *v1.Descriptor, platform *v1.Platform) bool {
+	if layer.Platform == nil {
+		return !platformQualifiedName.MatchString(layer.Annotations[v1.AnnotationTitle])
+	}
+
+	return platform != nil &&
+		layer.Platform.OS == platform.OS &&
+		layer.Platform.Architecture == platform.Architecture &&
+		layer.Platform.Variant == platform.Variant &&
+		layer.Platform.OSVersion == platform.OSVersion
+}
+
+// manifest returns the parsed manifest of a pulled artifact.
+func (a *Artifact) manifest(
+	ctx context.Context, store *file.Store, descriptor *v1.Descriptor,
+) (*v1.Manifest, error) {
+	content, err := a.blobContent(ctx, store, descriptor)
+	if err != nil {
+		return nil, fmt.Errorf("read manifest: %w", err)
+	}
+
+	manifest := &v1.Manifest{}
+	if err := json.Unmarshal(content, manifest); err != nil {
+		return nil, fmt.Errorf("unmarshal manifest: %w", err)
+	}
+
+	return manifest, nil
+}
+
+// blobContent returns the content of a blob from the store.
+func (a *Artifact) blobContent(
+	ctx context.Context, store *file.Store, descriptor *v1.Descriptor,
+) ([]byte, error) {
+	reader, err := a.StoreFetch(ctx, store, *descriptor)
+	if err != nil {
+		return nil, fmt.Errorf("fetch blob: %w", err)
+	}
+
+	defer func() {
+		if err := reader.Close(); err != nil {
+			a.logger.Info("Unable to close blob reader", "error", err)
+		}
+	}()
+
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("read blob: %w", err)
+	}
+
+	return content, nil
+}
+
+// seccompPullResult builds the PullResult for a raw OCI runtime-spec seccomp
+// profile, which carries no metadata of its own.
+func seccompPullResult(
+	image string,
+	spec *seccompprofileapi.SeccompProfileSpec,
+	content []byte,
+	runtimeFormat bool,
+) *PullResult {
+	return &PullResult{
+		typ: PullResultTypeSeccompProfile,
+		seccompProfile: &seccompprofileapi.SeccompProfile{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "SeccompProfile",
+				APIVersion: seccompprofileapi.GroupVersion.String(),
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: nameFromReference(image),
+			},
+			Spec: *spec,
+		},
+		content:       content,
+		runtimeFormat: runtimeFormat,
+	}
+}
+
+// runtimeSpecSeccompProfile reports whether content is a raw OCI runtime-spec
+// seccomp profile and returns it if so. A profile CRD is not one, but content
+// which is neither is an error, publishing it would create an artifact no
+// consumer understands.
+func (a *Artifact) runtimeSpecSeccompProfile(
+	content []byte,
+) (*specs.LinuxSeccomp, bool, error) {
+	_, profileErr := a.ReadProfile(content)
+	if profileErr == nil {
+		return nil, false, nil
+	}
+
+	runtimeSpec, err := decodeRuntimeSpecSeccompProfile(content)
+	if err != nil {
+		return nil, false, errors.Join(ErrDecodeYAML, profileErr, err)
+	}
+
+	return runtimeSpec, true, nil
+}
+
+// warnRuntimeRestrictions logs the parts of a profile which container
+// runtimes reject when they validate a KEP-6061 artifact.
+func (a *Artifact) warnRuntimeRestrictions(
+	runtimeSpec *specs.LinuxSeccomp, content []byte, path string,
+) {
+	if runtimeSpec.ListenerPath != "" || runtimeSpec.ListenerMetadata != "" {
+		a.logger.Info(
+			"Profile sets listener fields, which container runtimes reject",
+			"file", path,
+		)
+	}
+
+	if usesNotify(runtimeSpec) {
+		a.logger.Info(
+			"Profile uses "+string(specs.ActNotify)+", which container runtimes reject",
+			"file", path,
+		)
+	}
+
+	if len(content) > maxProfileSize {
+		a.logger.Info(
+			"Profile is larger than container runtimes accept by default",
+			"file", path,
+			"size", len(content),
+			"limit", maxProfileSize,
+		)
+	}
+
+	if syscall := exceedsSyscallEntries(runtimeSpec); syscall != "" {
+		a.logger.Info(
+			"Profile has more entries for a syscall than container runtimes accept by default",
+			"file", path,
+			"syscall", syscall,
+			"limit", maxSyscallEntries,
+		)
+	}
+}
+
+// exceedsSyscallEntries returns the first syscall which is referenced by more
+// rule entries than container runtimes accept, and an empty string if there
+// is none.
+func exceedsSyscallEntries(runtimeSpec *specs.LinuxSeccomp) string {
+	entries := map[string]int{}
+
+	for i := range runtimeSpec.Syscalls {
+		for _, name := range runtimeSpec.Syscalls[i].Names {
+			entries[name]++
+
+			if entries[name] > maxSyscallEntries {
+				return name
+			}
+		}
+	}
+
+	return ""
+}
+
+// usesNotify reports whether the profile relies on a seccomp notifier.
+func usesNotify(runtimeSpec *specs.LinuxSeccomp) bool {
+	if runtimeSpec.DefaultAction == specs.ActNotify {
+		return true
+	}
+
+	for i := range runtimeSpec.Syscalls {
+		if runtimeSpec.Syscalls[i].Action == specs.ActNotify {
+			return true
+		}
+	}
+
+	return false
+}
+
+// decodeRuntimeSpecSeccompProfile decodes the content of a KEP-6061 artifact,
+// a raw OCI runtime-spec seccomp profile. The content has to decode strictly
+// into the runtime-spec type, so unknown fields and trailing data are
+// rejected and defaultAction is required.
+func decodeRuntimeSpecSeccompProfile(content []byte) (*specs.LinuxSeccomp, error) {
+	decoder := json.NewDecoder(bytes.NewReader(content))
+	decoder.DisallowUnknownFields()
+
+	runtimeSpec := &specs.LinuxSeccomp{}
+	if err := decoder.Decode(runtimeSpec); err != nil {
+		return nil, fmt.Errorf("decode runtime-spec seccomp profile: %w", err)
+	}
+
+	if decoder.More() {
+		return nil, ErrTrailingData
+	}
+
+	if runtimeSpec.DefaultAction == "" {
+		return nil, ErrNoDefaultAction
+	}
+
+	return runtimeSpec, nil
+}
+
+// runtimeSpecSeccompProfileSpec converts the content of a KEP-6061 artifact
+// into a SeccompProfileSpec. Fields the CRD cannot express, such as
+// defaultErrnoRet, are dropped in the conversion. Values which do not fit the
+// CRD, for example syscall argument values beyond the signed 64 bit range,
+// are an error. Detection on push does not use this conversion, so profiles
+// the CRD cannot hold are still published in the right format.
+func runtimeSpecSeccompProfileSpec(
+	content []byte,
+) (*seccompprofileapi.SeccompProfileSpec, error) {
+	if _, err := decodeRuntimeSpecSeccompProfile(content); err != nil {
+		return nil, err
+	}
+
+	spec := &seccompprofileapi.SeccompProfileSpec{}
+	if err := json.Unmarshal(content, spec); err != nil {
+		return nil, fmt.Errorf("convert runtime-spec seccomp profile: %w", err)
+	}
+
+	return spec, nil
+}
+
+// nameFromReference derives a profile name from an image reference by taking
+// the last repository path element, so that pull results from runtime-spec
+// artifacts, which carry no metadata, still have a name.
+func nameFromReference(ref string) string {
+	name := ref
+	if idx := strings.Index(name, "@"); idx >= 0 {
+		name = name[:idx]
+	}
+
+	if idx := strings.LastIndex(name, "/"); idx >= 0 {
+		name = name[idx+1:]
+	}
+
+	if idx := strings.Index(name, ":"); idx >= 0 {
+		name = name[:idx]
+	}
+
+	name = strings.Trim(
+		invalidNameChars.ReplaceAllString(strings.ToLower(name), "-"), "-.",
+	)
+	if name == "" {
+		return defaultProfileName
+	}
+
+	return name
+}
+
+// profileName returns the layer name for the platform.
 func profileName(platform *v1.Platform) string {
 	name := strings.Builder{}
 	name.WriteString("profile")
@@ -448,13 +900,17 @@ func profileName(platform *v1.Platform) string {
 		}
 	}
 
-	name.WriteString(".yaml")
+	name.WriteString(extYAML)
 
 	return name.String()
 }
 
 // platformToString returns a string for the provided platform.
 func platformToString(platform *v1.Platform) string {
+	if platform == nil {
+		return ""
+	}
+
 	name := strings.Builder{}
 
 	for i, part := range []string{

--- a/internal/pkg/artifact/artifact_test.go
+++ b/internal/pkg/artifact/artifact_test.go
@@ -17,15 +17,27 @@ limitations under the License.
 package artifact
 
 import (
+	"bytes"
+	"context"
+	"encoding/json"
 	"errors"
+	"io"
 	"runtime"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/opencontainers/go-digest"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	specs "github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/require"
+	"oras.land/oras-go/v2"
+	"oras.land/oras-go/v2/content/file"
 	"oras.land/oras-go/v2/registry/remote"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	apparmorprofileapi "sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1"
 	seccompprofileapi "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1"
@@ -302,6 +314,26 @@ func TestPull(t *testing.T) {
 			},
 		},
 		{
+			name: "success runtime-spec seccomp profile",
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+				mock.ParseReferenceReturns(testRef, nil)
+				mock.ReadFileReturns([]byte(rawSeccompJSON), nil)
+				mock.ReadProfileReturns(nil, errTest)
+			},
+			assert: func(res *PullResult, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, res)
+				require.Equal(t, PullResultTypeSeccompProfile, res.Type())
+				require.JSONEq(t, rawSeccompJSON, string(res.Content()))
+				require.Equal(t, "SeccompProfile", res.SeccompProfile().Kind)
+				require.NotEmpty(t, res.SeccompProfile().GetName())
+				require.Equal(t, seccompprofileapi.Action("SCMP_ACT_ERRNO"), res.SeccompProfile().Spec.DefaultAction)
+				require.Len(t, res.SeccompProfile().Spec.Syscalls, 1)
+			},
+		},
+		{
 			name: "failure on all YAML decodes",
 			prepare: func(mock *artifactfakes.FakeImpl) {
 				mock.NewRepositoryReturns(&remote.Repository{}, nil)
@@ -317,12 +349,208 @@ func TestPull(t *testing.T) {
 			},
 		},
 		{
-			name: "failure on ReadFile",
+			name: "success on runtime format artifact",
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+				mock.ParseReferenceReturns(testRef, nil)
+				// No layer name, no title annotation and no file on disk.
+				stubManifest(mock, &ocispec.Manifest{
+					Config: ocispec.Descriptor{MediaType: MediaTypeSeccompProfile},
+					Layers: []ocispec.Descriptor{testLayer("")},
+				}, map[digest.Digest]string{testLayer("").Digest: rawSeccompJSON})
+				mock.ReadFileReturns(nil, errTest)
+				mock.ReadProfileReturns(nil, errTest)
+			},
+			assert: func(res *PullResult, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, res)
+				require.Equal(t, PullResultTypeSeccompProfile, res.Type())
+				require.JSONEq(t, rawSeccompJSON, string(res.Content()))
+			},
+		},
+		{
+			name: "success on runtime format artifact identified by artifactType",
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+				mock.ParseReferenceReturns(testRef, nil)
+				stubManifest(mock, &ocispec.Manifest{
+					Config:       ocispec.Descriptor{MediaType: ocispec.MediaTypeEmptyJSON},
+					ArtifactType: MediaTypeSeccompProfile,
+					Layers:       []ocispec.Descriptor{testLayer("")},
+				}, map[digest.Digest]string{testLayer("").Digest: rawSeccompJSON})
+				mock.ReadFileReturns(nil, errTest)
+				mock.ReadProfileReturns(nil, errTest)
+			},
+			assert: func(res *PullResult, err error) {
+				require.NoError(t, err)
+				require.Equal(t, PullResultTypeSeccompProfile, res.Type())
+				require.JSONEq(t, rawSeccompJSON, string(res.Content()))
+			},
+		},
+		{
+			name: "failure on runtime format artifact with multiple layers",
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+				mock.ParseReferenceReturns(testRef, nil)
+				stubManifest(mock, &ocispec.Manifest{
+					Config: ocispec.Descriptor{MediaType: MediaTypeSeccompProfile},
+					Layers: []ocispec.Descriptor{testLayer("a"), testLayer("b")},
+				}, nil)
+			},
+			assert: func(res *PullResult, err error) {
+				require.ErrorIs(t, err, ErrNoSingleLayer)
+				require.Nil(t, res)
+			},
+		},
+		{
+			name: "failure on undecodable runtime format artifact",
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+				mock.ParseReferenceReturns(testRef, nil)
+				stubManifest(mock, &ocispec.Manifest{
+					Config: ocispec.Descriptor{MediaType: MediaTypeSeccompProfile},
+					Layers: []ocispec.Descriptor{testLayer("")},
+				}, map[digest.Digest]string{testLayer("").Digest: `{"syscalls":[]}`})
+			},
+			assert: func(res *PullResult, err error) {
+				require.ErrorIs(t, err, ErrNoDefaultAction)
+				require.ErrorContains(t, err, MediaTypeSeccompProfile)
+				require.Nil(t, res)
+			},
+		},
+		{
+			name: "success on single layer with unknown name",
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+				mock.ParseReferenceReturns(testRef, nil)
+				stubManifest(mock, &ocispec.Manifest{
+					Layers: []ocispec.Descriptor{testLayer("seccomp.json")},
+				}, map[digest.Digest]string{testLayer("seccomp.json").Digest: rawSeccompJSON})
+				mock.ReadFileReturns(nil, errTest)
+				mock.ReadProfileReturns(nil, errTest)
+			},
+			assert: func(res *PullResult, err error) {
+				require.NoError(t, err)
+				require.NotNil(t, res)
+				require.Equal(t, PullResultTypeSeccompProfile, res.Type())
+				require.JSONEq(t, rawSeccompJSON, string(res.Content()))
+			},
+		},
+		{
+			name: "failure on platform qualified single layer",
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+				mock.ParseReferenceReturns(testRef, nil)
+				stubManifest(mock, &ocispec.Manifest{
+					Layers: []ocispec.Descriptor{testLayer("profile-linux-arm64.yaml")},
+				}, nil)
+				mock.ReadFileReturns(nil, errTest)
+			},
+			assert: func(res *PullResult, err error) {
+				require.ErrorIs(t, err, ErrPlatformMismatch)
+				require.Nil(t, res)
+			},
+		},
+		{
+			name: "failure on single layer bound to another platform",
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+				mock.ParseReferenceReturns(testRef, nil)
+
+				layer := testLayer("seccomp.json")
+				layer.Platform = &ocispec.Platform{OS: "linux", Architecture: "arm64"}
+
+				stubManifest(mock, &ocispec.Manifest{
+					Layers: []ocispec.Descriptor{layer},
+				}, nil)
+				mock.ReadFileReturns(nil, errTest)
+			},
+			assert: func(res *PullResult, err error) {
+				require.ErrorIs(t, err, ErrPlatformMismatch)
+				require.Nil(t, res)
+			},
+		},
+		{
+			name: "failure on ReadFile without single layer",
 			prepare: func(mock *artifactfakes.FakeImpl) {
 				mock.NewRepositoryReturns(&remote.Repository{}, nil)
 				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
 				mock.ParseReferenceReturns(testRef, nil)
 				mock.ReadFileReturns(nil, errTest)
+				stubManifest(mock, &ocispec.Manifest{
+					Layers: []ocispec.Descriptor{
+						testLayer("profile-linux-amd64.yaml"),
+						testLayer("profile-linux-arm64.yaml"),
+					},
+				}, nil)
+			},
+			assert: func(res *PullResult, err error) {
+				require.ErrorIs(t, err, ErrNoSingleLayer)
+				require.Nil(t, res)
+			},
+		},
+		{
+			name: "failure on StoreFetch of the manifest",
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+				mock.ParseReferenceReturns(testRef, nil)
+				mock.StoreFetchReturns(nil, errTest)
+			},
+			assert: func(res *PullResult, err error) {
+				require.ErrorIs(t, err, errTest)
+				require.Nil(t, res)
+			},
+		},
+		{
+			name: "failure on unparsable manifest",
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+				mock.ParseReferenceReturns(testRef, nil)
+				mock.StoreFetchStub = func(
+					_ context.Context, _ *file.Store, _ ocispec.Descriptor,
+				) (io.ReadCloser, error) {
+					return io.NopCloser(strings.NewReader("not json")), nil
+				}
+			},
+			assert: func(res *PullResult, err error) {
+				require.ErrorContains(t, err, "unmarshal manifest")
+				require.Nil(t, res)
+			},
+		},
+		{
+			name: "failure on StoreFetch of the single layer",
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.NewRepositoryReturns(&remote.Repository{}, nil)
+				mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+				mock.ParseReferenceReturns(testRef, nil)
+				mock.ReadFileReturns(nil, errTest)
+
+				manifest, err := json.Marshal(ocispec.Manifest{
+					Layers: []ocispec.Descriptor{testLayer("seccomp.json")},
+				})
+				require.NoError(t, err)
+
+				first := true
+				mock.StoreFetchStub = func(
+					_ context.Context, _ *file.Store, _ ocispec.Descriptor,
+				) (io.ReadCloser, error) {
+					if first {
+						first = false
+
+						return io.NopCloser(bytes.NewReader(manifest)), nil
+					}
+
+					return nil, errTest
+				}
 			},
 			assert: func(res *PullResult, err error) {
 				require.ErrorIs(t, err, errTest)
@@ -422,6 +650,7 @@ func TestPull(t *testing.T) {
 			t.Parallel()
 
 			mock := &artifactfakes.FakeImpl{}
+			stubManifest(mock, &ocispec.Manifest{}, nil)
 			prepare(mock)
 
 			sut := New(logr.Discard())
@@ -431,4 +660,571 @@ func TestPull(t *testing.T) {
 			assert(res, err)
 		})
 	}
+}
+
+const rawSeccompJSON = `{"defaultAction":"SCMP_ACT_ERRNO","architectures":["SCMP_ARCH_X86_64"],` +
+	`"syscalls":[{"names":["read","write"],"action":"SCMP_ACT_ALLOW"}]}`
+
+// rawSeccompArgJSON uses an unsigned 64 bit argument value, which is valid in
+// the runtime-spec but does not fit the CRD.
+const rawSeccompArgJSON = `{"defaultAction":"SCMP_ACT_ERRNO","syscalls":[{"names":["clone"],` +
+	`"action":"SCMP_ACT_ALLOW","args":[{"index":0,"value":18446744073709551615,` +
+	`"op":"SCMP_CMP_MASKED_EQ"}]}]}`
+
+const profileCRDYAML = "apiVersion: security-profiles-operator.x-k8s.io/v1\nkind: SeccompProfile\n"
+
+func TestPushMediaTypes(t *testing.T) {
+	t.Parallel()
+
+	testRef, err := name.ParseReference("docker.io/foo/bar:v1")
+	require.NoError(t, err)
+
+	platform := &ocispec.Platform{OS: "linux", Architecture: "amd64"}
+
+	for _, tc := range []struct {
+		name               string
+		content            []byte
+		readProfileErr     error
+		wantLayerName      string
+		wantLayerMediaType string
+		wantLayerPlatform  *ocispec.Platform
+		wantMediaType      string
+		wantConfig         bool
+	}{
+		{
+			name:               "runtime-spec seccomp profile",
+			content:            []byte(rawSeccompJSON),
+			readProfileErr:     errTest,
+			wantLayerName:      defaultProfileJSON,
+			wantLayerMediaType: layerMediaTypeJSON,
+			wantLayerPlatform:  nil,
+			wantMediaType:      MediaTypeSeccompProfile,
+			wantConfig:         true,
+		},
+		{
+			name:               "profile CRD",
+			content:            []byte(profileCRDYAML),
+			readProfileErr:     nil,
+			wantLayerName:      "profile-linux-amd64.yaml",
+			wantLayerMediaType: "",
+			wantLayerPlatform:  platform,
+			wantMediaType:      oras.MediaTypeUnknownConfig,
+			wantConfig:         false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &artifactfakes.FakeImpl{}
+			mock.ReadFileReturns(tc.content, nil)
+			mock.ReadProfileReturns(&seccompprofileapi.SeccompProfile{}, tc.readProfileErr)
+			mock.StoreAddReturns(defaultDescriptor(), nil)
+			mock.ParseReferenceReturns(testRef, nil)
+			mock.NewRepositoryReturns(&remote.Repository{}, nil)
+
+			sut := New(logr.Discard())
+			sut.impl = mock
+
+			err := sut.Push(map[*ocispec.Platform]string{platform: "profile"}, "", "", "", nil)
+			require.NoError(t, err)
+
+			require.Equal(t, 1, mock.StoreAddCallCount())
+			_, _, layerName, layerMediaType, _ := mock.StoreAddArgsForCall(0)
+			require.Equal(t, tc.wantLayerName, layerName)
+			require.Equal(t, tc.wantLayerMediaType, layerMediaType)
+
+			require.Equal(t, 1, mock.PackManifestCallCount())
+			_, _, _, mediaType, opts := mock.PackManifestArgsForCall(0)
+			require.Equal(t, tc.wantMediaType, mediaType)
+			require.Len(t, opts.Layers, 1)
+			require.Equal(t, tc.wantLayerPlatform, opts.Layers[0].Platform)
+
+			if !tc.wantConfig {
+				require.Nil(t, opts.ConfigDescriptor)
+				require.Equal(t, 0, mock.StorePushCallCount())
+
+				return
+			}
+
+			// The config media type has to be set explicitly, ORAS would
+			// otherwise default to the empty OCI config descriptor.
+			require.NotNil(t, opts.ConfigDescriptor)
+			require.Equal(t, tc.wantMediaType, opts.ConfigDescriptor.MediaType)
+
+			require.Equal(t, 1, mock.StorePushCallCount())
+			_, _, configDescriptor, _ := mock.StorePushArgsForCall(0)
+			require.Equal(t, *opts.ConfigDescriptor, configDescriptor)
+		})
+	}
+}
+
+// TestPushManifest verifies the manifest ORAS produces for the options built
+// by Push, because the config media type and the artifact type are set from
+// different inputs.
+func TestPushManifest(t *testing.T) {
+	t.Parallel()
+
+	layer := ocispec.Descriptor{
+		MediaType: layerMediaTypeJSON,
+		Digest:    digest.FromString(rawSeccompJSON),
+		Size:      int64(len(rawSeccompJSON)),
+		Annotations: map[string]string{
+			ocispec.AnnotationTitle: defaultProfileJSON,
+		},
+	}
+	config := ocispec.Descriptor{
+		MediaType: MediaTypeSeccompProfile,
+		Digest:    digest.FromBytes(emptyConfig),
+		Size:      int64(len(emptyConfig)),
+	}
+
+	pusher := &testPusher{blobs: map[digest.Digest][]byte{}}
+
+	descriptor, err := oras.PackManifest(
+		t.Context(), pusher, oras.PackManifestVersion1_1, MediaTypeSeccompProfile,
+		oras.PackManifestOptions{
+			Layers:           []ocispec.Descriptor{layer},
+			ConfigDescriptor: &config,
+		},
+	)
+	require.NoError(t, err)
+
+	manifest := ocispec.Manifest{}
+	require.NoError(t, json.Unmarshal(pusher.blobs[descriptor.Digest], &manifest))
+
+	// KEP-6061 identifies seccomp artifacts by the config media type, with
+	// the artifact type as fallback for the empty OCI config descriptor.
+	require.Equal(t, MediaTypeSeccompProfile, manifest.Config.MediaType)
+	require.Equal(t, MediaTypeSeccompProfile, manifest.ArtifactType)
+	require.NotEqual(t, ocispec.MediaTypeEmptyJSON, manifest.Config.MediaType)
+
+	// KEP-6061 artifacts contain exactly one layer holding the raw profile.
+	require.Len(t, manifest.Layers, 1)
+	//nolint:testifylint // this compares a media type, not encoded JSON
+	require.Equal(t, layerMediaTypeJSON, manifest.Layers[0].MediaType)
+	require.Nil(t, manifest.Layers[0].Platform)
+}
+
+// testPusher is a content.Pusher which keeps all pushed blobs in memory.
+type testPusher struct {
+	blobs map[digest.Digest][]byte
+}
+
+//nolint:gocritic // the signature is defined by content.Pusher
+func (t *testPusher) Push(
+	_ context.Context, desc ocispec.Descriptor, content io.Reader,
+) error {
+	blob, err := io.ReadAll(content)
+	if err != nil {
+		return err
+	}
+
+	t.blobs[desc.Digest] = blob
+
+	return nil
+}
+
+func TestPushRuntimeSpecSeccompProfileErrors(t *testing.T) {
+	t.Parallel()
+
+	amd64 := &ocispec.Platform{OS: "linux", Architecture: "amd64"}
+	arm64 := &ocispec.Platform{OS: "linux", Architecture: "arm64"}
+
+	for _, tc := range []struct {
+		name    string
+		files   map[*ocispec.Platform]string
+		prepare func(mock *artifactfakes.FakeImpl)
+		wantErr error
+	}{
+		{
+			name:  "multiple runtime-spec profiles",
+			files: map[*ocispec.Platform]string{amd64: "raw-amd64", arm64: "raw-arm64"},
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.ReadFileReturns([]byte(rawSeccompJSON), nil)
+				mock.ReadProfileReturns(nil, errTest)
+			},
+			wantErr: ErrMultipleRuntimeSpecProfiles,
+		},
+		{
+			name:  "mixed formats",
+			files: map[*ocispec.Platform]string{amd64: "raw", arm64: "crd"},
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.ReadFileStub = func(path string) ([]byte, error) {
+					if strings.HasSuffix(path, "raw") {
+						return []byte(rawSeccompJSON), nil
+					}
+
+					return []byte(profileCRDYAML), nil
+				}
+				mock.ReadProfileStub = func(content []byte) (client.Object, error) {
+					if string(content) == rawSeccompJSON {
+						return nil, errTest
+					}
+
+					return &seccompprofileapi.SeccompProfile{}, nil
+				}
+			},
+			wantErr: ErrMixedProfileFormats,
+		},
+		{
+			name:  "failure on ReadFile",
+			files: map[*ocispec.Platform]string{amd64: "raw"},
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.ReadFileReturns(nil, errTest)
+			},
+			wantErr: errTest,
+		},
+		{
+			name:  "neither a profile CRD nor a runtime-spec profile",
+			files: map[*ocispec.Platform]string{amd64: "moby"},
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				// The moby superset format used by the default profiles of
+				// containers/common and docker.
+				mock.ReadFileReturns([]byte(
+					`{"defaultAction":"SCMP_ACT_ERRNO","archMap":[],"syscalls":[]}`,
+				), nil)
+				mock.ReadProfileReturns(nil, errTest)
+			},
+			wantErr: ErrDecodeYAML,
+		},
+		{
+			name:  "garbage input",
+			files: map[*ocispec.Platform]string{amd64: "garbage"},
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.ReadFileReturns([]byte("not a profile at all"), nil)
+				mock.ReadProfileReturns(nil, errTest)
+			},
+			wantErr: ErrDecodeYAML,
+		},
+		{
+			name:  "failure on StorePush",
+			files: map[*ocispec.Platform]string{amd64: "raw"},
+			prepare: func(mock *artifactfakes.FakeImpl) {
+				mock.ReadFileReturns([]byte(rawSeccompJSON), nil)
+				mock.ReadProfileReturns(nil, errTest)
+				mock.StorePushReturns(errTest)
+			},
+			wantErr: errTest,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &artifactfakes.FakeImpl{}
+			mock.FilepathAbsStub = func(path string) (string, error) { return path, nil }
+			mock.StoreAddReturns(defaultDescriptor(), nil)
+			tc.prepare(mock)
+
+			sut := New(logr.Discard())
+			sut.impl = mock
+
+			err := sut.Push(tc.files, "", "", "", nil)
+			require.ErrorIs(t, err, tc.wantErr)
+		})
+	}
+}
+
+func TestDecodeRuntimeSpecSeccompProfile(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name        string
+		content     string
+		wantErr     error
+		wantErrText string
+	}{
+		{name: "valid", content: rawSeccompJSON},
+		{
+			name: "valid with fields the CRD drops",
+			content: `{"defaultAction":"SCMP_ACT_ERRNO","defaultErrnoRet":1,` +
+				`"flags":["SECCOMP_FILTER_FLAG_LOG"]}`,
+		},
+		{
+			name:    "valid with values the CRD cannot hold",
+			content: rawSeccompArgJSON,
+		},
+		{
+			name:    "missing defaultAction",
+			content: `{"syscalls":[]}`,
+			wantErr: ErrNoDefaultAction,
+		},
+		{
+			name:    "trailing data",
+			content: rawSeccompJSON + `{"defaultAction":"SCMP_ACT_ALLOW"}`,
+			wantErr: ErrTrailingData,
+		},
+		{
+			name:        "unknown field",
+			content:     `{"defaultAction":"SCMP_ACT_ERRNO","bogus":1}`,
+			wantErrText: "unknown field",
+		},
+		{
+			name:        "not JSON",
+			content:     profileCRDYAML,
+			wantErrText: "invalid character",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			runtimeSpec, err := decodeRuntimeSpecSeccompProfile([]byte(tc.content))
+
+			switch {
+			case tc.wantErr != nil:
+				require.ErrorIs(t, err, tc.wantErr)
+				require.Nil(t, runtimeSpec)
+			case tc.wantErrText != "":
+				require.ErrorContains(t, err, tc.wantErrText)
+				require.Nil(t, runtimeSpec)
+			default:
+				require.NoError(t, err)
+				require.Equal(t,
+					specs.LinuxSeccompAction("SCMP_ACT_ERRNO"),
+					runtimeSpec.DefaultAction,
+				)
+			}
+		})
+	}
+}
+
+func TestRuntimeSpecSeccompProfileSpec(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		spec, err := runtimeSpecSeccompProfileSpec([]byte(rawSeccompJSON))
+		require.NoError(t, err)
+		require.Equal(t, seccompprofileapi.Action("SCMP_ACT_ERRNO"), spec.DefaultAction)
+		require.Len(t, spec.Syscalls, 1)
+	})
+
+	t.Run("failure on decode", func(t *testing.T) {
+		t.Parallel()
+
+		spec, err := runtimeSpecSeccompProfileSpec([]byte(`{"syscalls":[]}`))
+		require.ErrorIs(t, err, ErrNoDefaultAction)
+		require.Nil(t, spec)
+	})
+
+	t.Run("failure on values the CRD cannot hold", func(t *testing.T) {
+		t.Parallel()
+
+		// The runtime-spec allows unsigned 64 bit argument values, the CRD
+		// only signed ones. Push does not use this conversion, so such
+		// profiles are still published in the runtime format.
+		sut := New(logr.Discard())
+		sut.impl = &artifactfakes.FakeImpl{ReadProfileStub: func([]byte) (client.Object, error) {
+			return nil, errTest
+		}}
+
+		runtimeSpec, isRuntimeSpec, err := sut.runtimeSpecSeccompProfile(
+			[]byte(rawSeccompArgJSON),
+		)
+		require.NoError(t, err)
+		require.True(t, isRuntimeSpec)
+		require.NotNil(t, runtimeSpec)
+
+		spec, specErr := runtimeSpecSeccompProfileSpec([]byte(rawSeccompArgJSON))
+		require.ErrorContains(t, specErr, "convert runtime-spec seccomp profile")
+		require.Nil(t, spec)
+	})
+}
+
+func TestNameFromReference(t *testing.T) {
+	t.Parallel()
+
+	for ref, want := range map[string]string{
+		"registry.example.com/security/profiles/api-server-seccomp@sha256:abc": "api-server-seccomp",
+		"localhost:5000/my_profile:v1":                                         "my-profile",
+		"ghcr.io/security-profiles/runc:v1.5.1":                                "runc",
+		"registry.example.com/UPPER/-Weird_Name-:tag":                          "weird-name",
+		"registry.example.com/...":                                             "profile",
+		"profile":                                                              "profile",
+		"":                                                                     "profile",
+	} {
+		require.Equal(t, want, nameFromReference(ref), ref)
+	}
+}
+
+// testLayer returns a layer descriptor with the provided title, which the
+// ORAS file store uses as the file name, and no title at all if it is empty.
+func testLayer(title string) ocispec.Descriptor {
+	descriptor := ocispec.Descriptor{
+		MediaType: layerMediaTypeJSON,
+		Digest:    digest.FromString(title),
+	}
+
+	if title != "" {
+		descriptor.Annotations = map[string]string{ocispec.AnnotationTitle: title}
+	}
+
+	return descriptor
+}
+
+// stubManifest makes StoreFetch return the manifest for every descriptor
+// except the ones in blobs, which stand for the layers of the artifact.
+func stubManifest(
+	mock *artifactfakes.FakeImpl, manifest *ocispec.Manifest, blobs map[digest.Digest]string,
+) {
+	raw, err := json.Marshal(manifest)
+	if err != nil {
+		panic(err)
+	}
+
+	mock.StoreFetchStub = func(
+		_ context.Context, _ *file.Store, descriptor ocispec.Descriptor,
+	) (io.ReadCloser, error) {
+		if blob, ok := blobs[descriptor.Digest]; ok {
+			return io.NopCloser(strings.NewReader(blob)), nil
+		}
+
+		return io.NopCloser(bytes.NewReader(raw)), nil
+	}
+}
+
+// TestPushConfigBlob verifies that the config blob of a runtime format
+// artifact ends up in the store, because it is only referenced by the
+// manifest and would otherwise fail the copy to the registry.
+func TestPushConfigBlob(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+
+	store, err := file.New(dir)
+	require.NoError(t, err)
+
+	defer func() { require.NoError(t, store.Close()) }()
+
+	sut := New(logr.Discard())
+
+	config, err := sut.pushConfig(t.Context(), store, MediaTypeSeccompProfile)
+	require.NoError(t, err)
+	require.Equal(t, MediaTypeSeccompProfile, config.MediaType)
+
+	reader, err := store.Fetch(t.Context(), config)
+	require.NoError(t, err)
+
+	defer func() { require.NoError(t, reader.Close()) }()
+
+	blob, err := io.ReadAll(reader)
+	require.NoError(t, err)
+	require.Equal(t, emptyConfig, blob)
+}
+
+func TestWarnRuntimeRestrictions(t *testing.T) {
+	t.Parallel()
+
+	manyNames := make([]string, 0, maxSyscallEntries+1)
+	for i := range maxSyscallEntries + 1 {
+		manyNames = append(manyNames, "syscall"+strconv.Itoa(i))
+	}
+
+	for _, tc := range []struct {
+		name        string
+		runtimeSpec *specs.LinuxSeccomp
+		content     []byte
+		wantLogs    []string
+	}{
+		{
+			name:        "nothing to warn about",
+			runtimeSpec: &specs.LinuxSeccomp{DefaultAction: specs.ActErrno},
+		},
+		{
+			name: "listener fields",
+			runtimeSpec: &specs.LinuxSeccomp{
+				DefaultAction: specs.ActErrno,
+				ListenerPath:  "/var/run/agent.sock",
+			},
+			wantLogs: []string{"listener fields"},
+		},
+		{
+			name: "listener metadata only",
+			runtimeSpec: &specs.LinuxSeccomp{
+				DefaultAction:    specs.ActErrno,
+				ListenerMetadata: "meta",
+			},
+			wantLogs: []string{"listener fields"},
+		},
+		{
+			name: "notify as default action",
+			runtimeSpec: &specs.LinuxSeccomp{
+				DefaultAction: specs.ActNotify,
+			},
+			wantLogs: []string{string(specs.ActNotify)},
+		},
+		{
+			name: "notify as syscall action",
+			runtimeSpec: &specs.LinuxSeccomp{
+				DefaultAction: specs.ActErrno,
+				Syscalls: []specs.LinuxSyscall{
+					{Names: []string{"openat"}, Action: specs.ActNotify},
+				},
+			},
+			wantLogs: []string{string(specs.ActNotify)},
+		},
+		{
+			name:        "oversized profile",
+			runtimeSpec: &specs.LinuxSeccomp{DefaultAction: specs.ActErrno},
+			content:     make([]byte, maxProfileSize+1),
+			wantLogs:    []string{"larger than container runtimes accept"},
+		},
+		{
+			name:        "profile at the size limit",
+			runtimeSpec: &specs.LinuxSeccomp{DefaultAction: specs.ActErrno},
+			content:     make([]byte, maxProfileSize),
+		},
+		{
+			name: "too many entries for one syscall",
+			runtimeSpec: &specs.LinuxSeccomp{
+				DefaultAction: specs.ActErrno,
+				Syscalls:      manyEntriesFor("openat"),
+			},
+			wantLogs: []string{"more entries for a syscall", "openat"},
+		},
+		{
+			name: "many distinct syscalls are fine",
+			runtimeSpec: &specs.LinuxSeccomp{
+				DefaultAction: specs.ActErrno,
+				Syscalls: []specs.LinuxSyscall{
+					{Names: manyNames, Action: specs.ActAllow},
+				},
+			},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			logs := &bytes.Buffer{}
+			sut := New(funcr.New(func(_, args string) {
+				logs.WriteString(args + "\n")
+			}, funcr.Options{}))
+
+			sut.warnRuntimeRestrictions(tc.runtimeSpec, tc.content, "profile.json")
+
+			if len(tc.wantLogs) == 0 {
+				require.Empty(t, logs.String())
+
+				return
+			}
+
+			for _, want := range tc.wantLogs {
+				require.Contains(t, logs.String(), want)
+			}
+		})
+	}
+}
+
+// manyEntriesFor returns more rule entries for the syscall than container
+// runtimes accept.
+func manyEntriesFor(syscall string) []specs.LinuxSyscall {
+	entries := make([]specs.LinuxSyscall, 0, maxSyscallEntries+1)
+	for range maxSyscallEntries + 1 {
+		entries = append(entries, specs.LinuxSyscall{
+			Names:  []string{syscall},
+			Action: specs.ActAllow,
+		})
+	}
+
+	return entries
 }

--- a/internal/pkg/artifact/artifactfakes/fake_impl.go
+++ b/internal/pkg/artifact/artifactfakes/fake_impl.go
@@ -19,6 +19,7 @@ package artifactfakes
 
 import (
 	"context"
+	"io"
 	"sync"
 
 	"github.com/google/go-containerregistry/pkg/name"
@@ -241,6 +242,35 @@ type FakeImpl struct {
 	storeAddReturnsOnCall map[int]struct {
 		result1 v1.Descriptor
 		result2 error
+	}
+	StoreFetchStub        func(context.Context, *file.Store, v1.Descriptor) (io.ReadCloser, error)
+	storeFetchMutex       sync.RWMutex
+	storeFetchArgsForCall []struct {
+		arg1 context.Context
+		arg2 *file.Store
+		arg3 v1.Descriptor
+	}
+	storeFetchReturns struct {
+		result1 io.ReadCloser
+		result2 error
+	}
+	storeFetchReturnsOnCall map[int]struct {
+		result1 io.ReadCloser
+		result2 error
+	}
+	StorePushStub        func(context.Context, *file.Store, v1.Descriptor, io.Reader) error
+	storePushMutex       sync.RWMutex
+	storePushArgsForCall []struct {
+		arg1 context.Context
+		arg2 *file.Store
+		arg3 v1.Descriptor
+		arg4 io.Reader
+	}
+	storePushReturns struct {
+		result1 error
+	}
+	storePushReturnsOnCall map[int]struct {
+		result1 error
 	}
 	StoreTagStub        func(context.Context, *file.Store, v1.Descriptor, string) error
 	storeTagMutex       sync.RWMutex
@@ -1252,6 +1282,136 @@ func (fake *FakeImpl) StoreAddReturnsOnCall(i int, result1 v1.Descriptor, result
 		result1 v1.Descriptor
 		result2 error
 	}{result1, result2}
+}
+
+func (fake *FakeImpl) StoreFetch(arg1 context.Context, arg2 *file.Store, arg3 v1.Descriptor) (io.ReadCloser, error) {
+	fake.storeFetchMutex.Lock()
+	ret, specificReturn := fake.storeFetchReturnsOnCall[len(fake.storeFetchArgsForCall)]
+	fake.storeFetchArgsForCall = append(fake.storeFetchArgsForCall, struct {
+		arg1 context.Context
+		arg2 *file.Store
+		arg3 v1.Descriptor
+	}{arg1, arg2, arg3})
+	stub := fake.StoreFetchStub
+	fakeReturns := fake.storeFetchReturns
+	fake.recordInvocation("StoreFetch", []interface{}{arg1, arg2, arg3})
+	fake.storeFetchMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeImpl) StoreFetchCallCount() int {
+	fake.storeFetchMutex.RLock()
+	defer fake.storeFetchMutex.RUnlock()
+	return len(fake.storeFetchArgsForCall)
+}
+
+func (fake *FakeImpl) StoreFetchCalls(stub func(context.Context, *file.Store, v1.Descriptor) (io.ReadCloser, error)) {
+	fake.storeFetchMutex.Lock()
+	defer fake.storeFetchMutex.Unlock()
+	fake.StoreFetchStub = stub
+}
+
+func (fake *FakeImpl) StoreFetchArgsForCall(i int) (context.Context, *file.Store, v1.Descriptor) {
+	fake.storeFetchMutex.RLock()
+	defer fake.storeFetchMutex.RUnlock()
+	argsForCall := fake.storeFetchArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeImpl) StoreFetchReturns(result1 io.ReadCloser, result2 error) {
+	fake.storeFetchMutex.Lock()
+	defer fake.storeFetchMutex.Unlock()
+	fake.StoreFetchStub = nil
+	fake.storeFetchReturns = struct {
+		result1 io.ReadCloser
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) StoreFetchReturnsOnCall(i int, result1 io.ReadCloser, result2 error) {
+	fake.storeFetchMutex.Lock()
+	defer fake.storeFetchMutex.Unlock()
+	fake.StoreFetchStub = nil
+	if fake.storeFetchReturnsOnCall == nil {
+		fake.storeFetchReturnsOnCall = make(map[int]struct {
+			result1 io.ReadCloser
+			result2 error
+		})
+	}
+	fake.storeFetchReturnsOnCall[i] = struct {
+		result1 io.ReadCloser
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeImpl) StorePush(arg1 context.Context, arg2 *file.Store, arg3 v1.Descriptor, arg4 io.Reader) error {
+	fake.storePushMutex.Lock()
+	ret, specificReturn := fake.storePushReturnsOnCall[len(fake.storePushArgsForCall)]
+	fake.storePushArgsForCall = append(fake.storePushArgsForCall, struct {
+		arg1 context.Context
+		arg2 *file.Store
+		arg3 v1.Descriptor
+		arg4 io.Reader
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.StorePushStub
+	fakeReturns := fake.storePushReturns
+	fake.recordInvocation("StorePush", []interface{}{arg1, arg2, arg3, arg4})
+	fake.storePushMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeImpl) StorePushCallCount() int {
+	fake.storePushMutex.RLock()
+	defer fake.storePushMutex.RUnlock()
+	return len(fake.storePushArgsForCall)
+}
+
+func (fake *FakeImpl) StorePushCalls(stub func(context.Context, *file.Store, v1.Descriptor, io.Reader) error) {
+	fake.storePushMutex.Lock()
+	defer fake.storePushMutex.Unlock()
+	fake.StorePushStub = stub
+}
+
+func (fake *FakeImpl) StorePushArgsForCall(i int) (context.Context, *file.Store, v1.Descriptor, io.Reader) {
+	fake.storePushMutex.RLock()
+	defer fake.storePushMutex.RUnlock()
+	argsForCall := fake.storePushArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeImpl) StorePushReturns(result1 error) {
+	fake.storePushMutex.Lock()
+	defer fake.storePushMutex.Unlock()
+	fake.StorePushStub = nil
+	fake.storePushReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeImpl) StorePushReturnsOnCall(i int, result1 error) {
+	fake.storePushMutex.Lock()
+	defer fake.storePushMutex.Unlock()
+	fake.StorePushStub = nil
+	if fake.storePushReturnsOnCall == nil {
+		fake.storePushReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.storePushReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
 }
 
 func (fake *FakeImpl) StoreTag(arg1 context.Context, arg2 *file.Store, arg3 v1.Descriptor, arg4 string) error {

--- a/internal/pkg/artifact/consts.go
+++ b/internal/pkg/artifact/consts.go
@@ -18,6 +18,7 @@ package artifact
 
 import (
 	"errors"
+	"regexp"
 	"time"
 )
 
@@ -25,13 +26,93 @@ const (
 	// defaultProfileYAML is the default name for the OCI artifact profile.
 	defaultProfileYAML = "profile.yaml"
 
+	// defaultProfileJSON is the layer name of an OCI runtime-spec seccomp
+	// profile artifact as consumed by container runtimes (KEP-6061). Those
+	// artifacts carry exactly one platform independent profile, so the name
+	// is not platform qualified.
+	defaultProfileJSON = "profile.json"
+
+	// defaultProfileName is the object name given to runtime-spec profiles
+	// when none can be derived from the artifact reference.
+	defaultProfileName = "profile"
+
+	// MediaTypeSeccompProfile identifies an artifact whose single layer is an
+	// OCI runtime-spec seccomp profile in JSON, as consumed by container
+	// runtimes (KEP-6061). It is set as the manifest config media type as
+	// well as the manifest artifact type.
+	MediaTypeSeccompProfile = "application/vnd.cncf.seccomp-profile.config.v1+json"
+
+	// extYAML is the layer name extension of profile CRDs.
+	extYAML = ".yaml"
+
+	// layerMediaTypeJSON is the layer media type of raw JSON profiles.
+	layerMediaTypeJSON = "application/json"
+
+	// maxProfileSize and maxSyscallEntries are the limits container runtimes
+	// apply by default when they validate a KEP-6061 artifact. They are
+	// runtime configuration rather than part of the format, so exceeding them
+	// is a warning on push and not an error.
+	maxProfileSize    = 1 << 20
+	maxSyscallEntries = 128
+
 	// defaultTimeout is the default timeout for push and pull operations.
 	defaultTimeout = 5 * time.Minute
 )
 
-// ErrDecodeYAML is the error returned if no matching type could be decoded on
-// artifact pull.
-var ErrDecodeYAML = errors.New("unable to decode YAML into seccomp, selinux or apparmor profile")
+// emptyConfig is the content of the manifest config blob of a runtime format
+// artifact. The profile itself is the layer, the config only carries the
+// media type which identifies the artifact.
+var emptyConfig = []byte("{}")
+
+// platformQualifiedName matches the layer names profileName generates for a
+// platform.
+var platformQualifiedName = regexp.MustCompile(
+	`^profile-.+` + regexp.QuoteMeta(extYAML) + `$`,
+)
+
+// invalidNameChars matches everything which is not allowed in a Kubernetes
+// object name.
+var invalidNameChars = regexp.MustCompile(`[^a-z0-9.-]+`)
+
+var (
+	// ErrDecodeYAML is the error returned if no matching type could be decoded on
+	// artifact pull.
+	ErrDecodeYAML = errors.New(
+		"unable to decode YAML or JSON into seccomp, selinux or apparmor profile",
+	)
+
+	// ErrNoKind is returned when a profile CRD has no kind.
+	ErrNoKind = errors.New("invalid yaml, kind missing")
+
+	// ErrNoDefaultAction is returned when a raw runtime-spec seccomp profile
+	// has no defaultAction.
+	ErrNoDefaultAction = errors.New("runtime-spec seccomp profile has no defaultAction")
+
+	// ErrTrailingData is returned when a raw runtime-spec seccomp profile is
+	// followed by additional data.
+	ErrTrailingData = errors.New("trailing data after runtime-spec seccomp profile")
+
+	// ErrMultipleRuntimeSpecProfiles is returned when more than one OCI
+	// runtime-spec seccomp profile is pushed into one artifact, which must
+	// contain exactly one layer.
+	ErrMultipleRuntimeSpecProfiles = errors.New(
+		"runtime-spec seccomp profile artifacts must contain exactly one profile",
+	)
+
+	// ErrMixedProfileFormats is returned when OCI runtime-spec seccomp
+	// profiles and profile CRDs are pushed into the same artifact.
+	ErrMixedProfileFormats = errors.New(
+		"cannot mix runtime-spec seccomp profiles and profile CRDs in one artifact",
+	)
+
+	// ErrNoSingleLayer is returned when an artifact without a known profile
+	// layer name does not have exactly one layer to fall back to.
+	ErrNoSingleLayer = errors.New("artifact has no single layer to read the profile from")
+
+	// ErrPlatformMismatch is returned when the only layer of an artifact is
+	// bound to another platform than the requested one.
+	ErrPlatformMismatch = errors.New("artifact layer is bound to another platform")
+)
 
 // PullResultType are the different types returned for a PullResult.
 type PullResultType string

--- a/internal/pkg/artifact/impl.go
+++ b/internal/pkg/artifact/impl.go
@@ -18,6 +18,7 @@ package artifact
 
 import (
 	"context"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -56,6 +57,8 @@ type impl interface {
 	ReadFile(string) ([]byte, error)
 	ReadProfile([]byte) (client.Object, error)
 	StoreAdd(context.Context, *file.Store, string, string, string) (ocispec.Descriptor, error)
+	StorePush(context.Context, *file.Store, ocispec.Descriptor, io.Reader) error
+	StoreFetch(context.Context, *file.Store, ocispec.Descriptor) (io.ReadCloser, error)
 	StoreTag(context.Context, *file.Store, ocispec.Descriptor, string) error
 	PackManifest(
 		context.Context, content.Pusher, oras.PackManifestVersion, string, oras.PackManifestOptions,
@@ -113,6 +116,20 @@ func (*defaultImpl) StoreAdd(
 	ctx context.Context, store *file.Store, name, mediaType, path string,
 ) (ocispec.Descriptor, error) {
 	return store.Add(ctx, name, mediaType, path)
+}
+
+//nolint:gocritic // intentional for the mock
+func (*defaultImpl) StorePush(
+	ctx context.Context, store *file.Store, desc ocispec.Descriptor, content io.Reader,
+) error {
+	return store.Push(ctx, desc, content)
+}
+
+//nolint:gocritic // intentional for the mock
+func (*defaultImpl) StoreFetch(
+	ctx context.Context, store *file.Store, desc ocispec.Descriptor,
+) (io.ReadCloser, error) {
+	return store.Fetch(ctx, desc)
 }
 
 //nolint:gocritic // intentional for the mock

--- a/internal/pkg/artifact/profile_reader.go
+++ b/internal/pkg/artifact/profile_reader.go
@@ -41,7 +41,7 @@ func ReadProfile(content []byte) (client.Object, error) {
 
 	kind, ok := genericCRD["kind"].(string)
 	if !ok {
-		return nil, fmt.Errorf("invalid yaml, kind missing: %w", err)
+		return nil, ErrNoKind
 	}
 
 	switch kind {

--- a/internal/pkg/cli/converter/converter.go
+++ b/internal/pkg/cli/converter/converter.go
@@ -22,6 +22,7 @@ import (
 	"log"
 
 	apparmorprofileapi "sigs.k8s.io/security-profiles-operator/api/apparmorprofile/v1"
+	profilebasev1 "sigs.k8s.io/security-profiles-operator/api/profilebase/v1"
 	seccompprofileapi "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/artifact"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/daemon/apparmorprofile/crd2armor"
@@ -78,7 +79,39 @@ func (p *Converter) Run() error {
 
 		out = []byte(outStr)
 	case *seccompprofileapi.SeccompProfile:
-		out, err = json.MarshalIndent(obj.Spec, "", "  ")
+		// Drop the CRD only fields, they are not part of the OCI runtime-spec
+		// seccomp profile and would make the output unusable for container
+		// runtimes.
+		spec := obj.Spec
+		spec.SpecBase = profilebasev1.SpecBase{}
+
+		if spec.BaseProfileName != "" {
+			log.Printf(
+				"Dropping base profile %q, its syscalls are not part of the raw profile.",
+				spec.BaseProfileName,
+			)
+
+			spec.BaseProfileName = ""
+		}
+
+		// The listener fields are valid runtime-spec, but tie the profile to
+		// the seccomp agent of this operator and are rejected in KEP-6061
+		// artifacts.
+		if spec.ListenerPath != "" || spec.ListenerMetadata != "" {
+			log.Print("Dropping the listener fields, they are specific to this operator.")
+
+			spec.ListenerPath = ""
+			spec.ListenerMetadata = ""
+		}
+
+		if usesNotify(&spec) {
+			log.Printf(
+				"Profile uses %s, so its consumer has to provide a listener path.",
+				seccompprofileapi.ActNotify,
+			)
+		}
+
+		out, err = json.MarshalIndent(spec, "", "  ")
 		if err != nil {
 			return fmt.Errorf("marshal JSON profile: %w", err)
 		}
@@ -94,4 +127,20 @@ func (p *Converter) Run() error {
 	log.Printf("Successfully wrote raw profile to %s.", p.options.outputFile)
 
 	return nil
+}
+
+// usesNotify reports whether the profile relies on a seccomp notifier, which
+// needs a listener path that the converted raw profile no longer carries.
+func usesNotify(spec *seccompprofileapi.SeccompProfileSpec) bool {
+	if spec.DefaultAction == seccompprofileapi.ActNotify {
+		return true
+	}
+
+	for i := range spec.Syscalls {
+		if spec.Syscalls[i].Action == seccompprofileapi.ActNotify {
+			return true
+		}
+	}
+
+	return false
 }

--- a/internal/pkg/cli/converter/converter_test.go
+++ b/internal/pkg/cli/converter/converter_test.go
@@ -19,7 +19,10 @@ limitations under the License.
 package converter
 
 import (
+	"bytes"
 	"errors"
+	"log"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -38,9 +41,11 @@ func TestRun(t *testing.T) {
 	}
 
 	for _, tc := range []struct {
-		name           string
-		input          string
-		outputContains []string
+		name              string
+		input             string
+		outputContains    []string
+		outputNotContains []string
+		logContains       string
 	}{
 		{
 			name: "AppArmor CRD in enforce mode by default",
@@ -97,23 +102,89 @@ spec:
 `,
 			outputContains: []string{`"defaultAction": "SCMP_ACT_ERRNO"`},
 		},
+		{
+			name: "seccomp without CRD only fields",
+			input: `
+apiVersion: security-profiles-operator.x-k8s.io/v1
+kind: SeccompProfile
+spec:
+  state: Enabled
+  baseProfileName: runc-v1.5.1
+  defaultAction: SCMP_ACT_ERRNO
+`,
+			outputContains:    []string{`"defaultAction": "SCMP_ACT_ERRNO"`},
+			outputNotContains: []string{`"state"`, `"baseProfileName"`},
+			logContains:       "Dropping base profile",
+		},
+		{
+			name: "seccomp with listener fields",
+			input: `
+apiVersion: security-profiles-operator.x-k8s.io/v1
+kind: SeccompProfile
+spec:
+  defaultAction: SCMP_ACT_ERRNO
+  listenerPath: /var/run/security-profiles-operator/agent.sock
+  listenerMetadata: some-metadata
+`,
+			outputContains:    []string{`"defaultAction": "SCMP_ACT_ERRNO"`},
+			outputNotContains: []string{`"listenerPath"`, `"listenerMetadata"`},
+			logContains:       "Dropping the listener fields",
+		},
+		{
+			name: "seccomp with listener metadata only",
+			input: `
+apiVersion: security-profiles-operator.x-k8s.io/v1
+kind: SeccompProfile
+spec:
+  defaultAction: SCMP_ACT_ERRNO
+  listenerMetadata: some-metadata
+`,
+			outputContains:    []string{`"defaultAction": "SCMP_ACT_ERRNO"`},
+			outputNotContains: []string{`"listenerMetadata"`},
+			logContains:       "Dropping the listener fields",
+		},
+		{
+			name: "seccomp using the notifier",
+			input: `
+apiVersion: security-profiles-operator.x-k8s.io/v1
+kind: SeccompProfile
+spec:
+  defaultAction: SCMP_ACT_ERRNO
+  listenerPath: /var/run/security-profiles-operator/agent.sock
+  syscalls:
+  - action: SCMP_ACT_NOTIFY
+    names:
+    - openat
+`,
+			outputNotContains: []string{`"listenerPath"`},
+			logContains:       "has to provide a listener path",
+		},
 	} {
-		input := tc.input
-		outputContains := tc.outputContains
 		t.Run(tc.name, func(t *testing.T) {
-			t.Parallel()
+			logs := &bytes.Buffer{}
+			log.SetOutput(logs)
+
+			defer log.SetOutput(os.Stderr)
 
 			mock := &converterfakes.FakeImpl{}
 			sut := New(defaultOptions())
 			sut.impl = mock
-			mock.ReadFileReturns([]byte(input), nil)
+			mock.ReadFileReturns([]byte(tc.input), nil)
 
 			err := sut.Run()
 			require.NoError(t, err)
 
 			_, actual, _ := mock.WriteFileArgsForCall(0)
-			for _, contain := range outputContains {
+			for _, contain := range tc.outputContains {
 				require.Contains(t, string(actual), contain)
+			}
+
+			for _, contain := range tc.outputNotContains {
+				require.NotContains(t, string(actual), contain)
+			}
+
+			if tc.logContains != "" {
+				require.Contains(t, logs.String(), tc.logContains)
 			}
 		})
 	}

--- a/internal/pkg/cli/puller/options.go
+++ b/internal/pkg/cli/puller/options.go
@@ -31,6 +31,7 @@ import (
 type Options struct {
 	pullFrom                     string
 	outputFile                   string
+	outputFileSet                bool
 	username                     string
 	password                     string
 	platform                     *v1.Platform
@@ -61,6 +62,7 @@ func FromContext(ctx *ucli.Context) (*Options, error) {
 
 	if ctx.IsSet(FlagOutputFile) {
 		options.outputFile = ctx.String(FlagOutputFile)
+		options.outputFileSet = true
 	}
 
 	if options.outputFile == "" {

--- a/internal/pkg/cli/puller/puller.go
+++ b/internal/pkg/cli/puller/puller.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/artifact"
 )
@@ -72,14 +73,29 @@ func (p *Puller) Run() error {
 
 	log.Printf("Got %s: %s", result.Type(), name)
 
-	log.Printf("Saving profile in: %s", p.options.outputFile)
+	outputFile := p.outputFile(result.IsRuntimeFormat())
+
+	log.Printf("Saving profile in: %s", outputFile)
 
 	const defaultFileMode = os.FileMode(0o644)
 	if err := p.WriteFile(
-		p.options.outputFile, result.Content(), defaultFileMode,
+		outputFile, result.Content(), defaultFileMode,
 	); err != nil {
 		return fmt.Errorf("save profile: %w", err)
 	}
 
 	return nil
+}
+
+// outputFile returns the location to save the profile in. The content of a
+// runtime format artifact is JSON, so the default YAML extension would be
+// misleading. An explicitly requested location is always used as is.
+func (p *Puller) outputFile(runtimeFormat bool) string {
+	const extYAML, extJSON = ".yaml", ".json"
+
+	if p.options.outputFileSet || !runtimeFormat {
+		return p.options.outputFile
+	}
+
+	return strings.TrimSuffix(p.options.outputFile, extYAML) + extJSON
 }

--- a/internal/pkg/cli/puller/puller_test.go
+++ b/internal/pkg/cli/puller/puller_test.go
@@ -82,3 +82,44 @@ func TestRun(t *testing.T) {
 		})
 	}
 }
+
+func TestOutputFile(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name          string
+		outputFile    string
+		outputFileSet bool
+		runtimeFormat bool
+		want          string
+	}{
+		{
+			name:          "default location for a runtime format artifact",
+			outputFile:    "/tmp/profile.yaml",
+			runtimeFormat: true,
+			want:          "/tmp/profile.json",
+		},
+		{
+			name:       "default location for a profile CRD artifact",
+			outputFile: "/tmp/profile.yaml",
+			want:       "/tmp/profile.yaml",
+		},
+		{
+			name:          "requested location is never changed",
+			outputFile:    "/tmp/my-profile.yaml",
+			outputFileSet: true,
+			runtimeFormat: true,
+			want:          "/tmp/my-profile.yaml",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			options := Default()
+			options.outputFile = tc.outputFile
+			options.outputFileSet = tc.outputFileSet
+
+			require.Equal(t, tc.want, New(options).outputFile(tc.runtimeFormat))
+		})
+	}
+}

--- a/profiles.md
+++ b/profiles.md
@@ -1184,6 +1184,16 @@ artifact profiles also support different architectures, where the operator
 always tries to select the correct one via `runtime.GOOS`/`runtime.GOARCH` but
 also allows to fallback to a default profile.
 
+Base profiles can also be runtime format artifacts as defined by
+[KEP-6061](https://github.com/kubernetes/enhancements/issues/6061): a single
+layer containing an OCI runtime-spec seccomp profile in JSON with the media
+type `application/vnd.cncf.seccomp-profile.config.v1+json`, as pushed by
+`spoc push` from a raw JSON input (see
+[cli.md](cli.md#pushing-profiles-for-container-runtimes)). The operator merges
+them like profile CRD artifacts, which means only `spec.syscalls` of the base
+profile gets unioned into the referencing profile. All other fields are
+ignored, including the ones the CRD cannot express such as `defaultErrnoRet`.
+
 The operator internally caches pulled artifacts up to 24 hours for 1000
 profiles, means that they will be refreshed after that time period, if the stack
 is full or the operator daemon gets restarted. It is also possible to define


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

KEP-6061 (kubernetes/enhancements#6062) defines how container runtimes consume seccomp profiles from OCI artifacts: exactly one layer holding the profile as OCI runtime-spec JSON, identified by the media type `application/vnd.cncf.seccomp-profile.config.v1+json`. `spoc push` currently packs everything with the generic `application/vnd.unknown.config.v1+json`, which runtimes will reject.

`spoc push` now detects a raw runtime-spec seccomp JSON input (for example the output of `spoc convert`) and produces the runtime format: one raw JSON layer, not platform qualified because such artifacts hold exactly one platform independent profile, with the media type on the manifest config as well as on `artifactType`. The config descriptor has to be set explicitly, ORAS otherwise defaults to the empty OCI config and leaves the media type in `artifactType` only.

Input which is neither a profile CRD nor a runtime-spec profile is rejected, so that no artifact gets published which no consumer understands, and content container runtimes reject is warned about: listener fields, `SCMP_ACT_NOTIFY`, and the 1 MiB size and 128 syscall entry limits they apply by default.

Profile CRD inputs keep the existing format used for `oci://` base profiles. `spoc pull` and `oci://` references accept both. Runtime format artifacts are recognized by their media type and read from the single layer the format requires, so layer names and annotations do not matter, which KEP-6061 mandates nothing about. Other artifacts keep using the layer names push produces, with a fallback to the single layer of the artifact if it is not bound to another platform. A runtime format artifact is exposed as a `SeccompProfile` whose spec drops fields the CRD cannot express.

`spoc convert` now writes a portable raw profile. `state` and `baseProfileName` are gone, they are CRD only fields which made its output fail the strict runtime-spec decode, and so are the listener fields, which tie the profile to the seccomp agent of this operator and are rejected in KEP-6061 artifacts. Dropping a base profile, whose syscalls are not part of the raw profile, and profiles which need a notifier are logged.

#### Which issue(s) this PR fixes:

Relates to kubernetes/enhancements#6061

#### Does this PR have test?

Unit tests for push format detection and rejection, the packed manifest, layer names and media types, the pull resolution by media type and its fallbacks, the conversion and the error cases.

#### Special notes for your reviewer:

None

#### Does this PR introduce a user-facing change?

```release-note
`spoc push` publishes raw OCI runtime-spec seccomp profiles as KEP-6061 artifacts (single raw JSON layer, media type `application/vnd.cncf.seccomp-profile.config.v1+json` on the manifest config and `artifactType`), and `spoc pull` as well as `oci://` base profiles accept that format. `spoc convert` no longer writes the CRD only fields `state` and `baseProfileName` nor the operator specific listener fields into the raw profile.
```

https://claude.ai/code/session_016cmWPv2zETBDBwk3hUv9zv
