### PR TITLE
Harden operator and webhook securityContext: runAsNonRoot, drop ALL

### DIFF
--- a/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/security-profiles-operator.clusterserviceversion.yaml
@@ -730,7 +730,11 @@ spec:
                     memory: 50Mi
                 securityContext:
                   allowPrivilegeEscalation: false
+                  capabilities:
+                    drop:
+                    - ALL
                   readOnlyRootFilesystem: true
+                  runAsNonRoot: true
               securityContext:
                 seccompProfile:
                   type: RuntimeDefault

--- a/deploy/helm/templates/deployment.yaml
+++ b/deploy/helm/templates/deployment.yaml
@@ -46,7 +46,11 @@ spec:
           {{- toYaml .Values.resources | nindent 10 }}
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
       {{- with .Values.podSecurityContext }}
       securityContext:
       {{- toYaml . | nindent 8 }}

--- a/deploy/kustomize-deployment/manager_deployment.yaml
+++ b/deploy/kustomize-deployment/manager_deployment.yaml
@@ -27,6 +27,10 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
           resources:
             requests:
               memory: 50Mi

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -3986,7 +3986,11 @@ spec:
             memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -3982,7 +3982,11 @@ spec:
             memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -4002,7 +4002,11 @@ spec:
             memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -3984,7 +3984,11 @@ spec:
             memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
       securityContext:
         seccompProfile:
           type: RuntimeDefault

--- a/deploy/overlays/webhook/webhook_deployment.yaml
+++ b/deploy/overlays/webhook/webhook_deployment.yaml
@@ -31,6 +31,10 @@ spec:
           securityContext:
             readOnlyRootFilesystem: true
             allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
           ports:
             - name: webhook
               containerPort: 9443 

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -3984,7 +3984,11 @@ spec:
             memory: 50Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
       securityContext:
         seccompProfile:
           type: RuntimeDefault
@@ -4043,7 +4047,11 @@ spec:
             memory: 32Mi
         securityContext:
           allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
           readOnlyRootFilesystem: true
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /tmp/k8s-webhook-server/serving-certs
           name: cert

--- a/internal/pkg/manager/spod/bindata/webhook.go
+++ b/internal/pkg/manager/spod/bindata/webhook.go
@@ -681,6 +681,10 @@ var webhookDeployment = &appsv1.Deployment{
 						SecurityContext: &corev1.SecurityContext{
 							AllowPrivilegeEscalation: &falsely,
 							ReadOnlyRootFilesystem:   &truly,
+							RunAsNonRoot:             &truly,
+							Capabilities: &corev1.Capabilities{
+								Drop: []corev1.Capability{"ALL"},
+							},
 						},
 						Resources: corev1.ResourceRequirements{
 							Requests: corev1.ResourceList{

--- a/internal/pkg/manager/spod/bindata/webhook_test.go
+++ b/internal/pkg/manager/spod/bindata/webhook_test.go
@@ -251,7 +251,11 @@ func TestWebhook_DeploymentSecurityContext(t *testing.T) {
 	podSpec := sut.deployment.Spec.Template.Spec
 	require.NotNil(t, podSpec.SecurityContext)
 	require.NotNil(t, podSpec.SecurityContext.SeccompProfile)
-	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, podSpec.SecurityContext.SeccompProfile.Type)
+	assert.Equal(
+		t,
+		corev1.SeccompProfileTypeRuntimeDefault,
+		podSpec.SecurityContext.SeccompProfile.Type,
+	)
 
 	require.Len(t, podSpec.Containers, 1)
 	sc := podSpec.Containers[0].SecurityContext

--- a/internal/pkg/manager/spod/bindata/webhook_test.go
+++ b/internal/pkg/manager/spod/bindata/webhook_test.go
@@ -268,4 +268,5 @@ func TestWebhook_DeploymentSecurityContext(t *testing.T) {
 	assert.True(t, *sc.RunAsNonRoot)
 	require.NotNil(t, sc.Capabilities)
 	assert.Equal(t, []corev1.Capability{"ALL"}, sc.Capabilities.Drop)
+	assert.Empty(t, sc.Capabilities.Add)
 }

--- a/internal/pkg/manager/spod/bindata/webhook_test.go
+++ b/internal/pkg/manager/spod/bindata/webhook_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	admissionregv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -237,4 +238,30 @@ func TestWebhook_getWebhookConfig(t *testing.T) {
 
 	webhookConfig = getWebhookConfig(true)
 	require.Len(t, webhookConfig.Webhooks, 4)
+}
+
+func TestWebhook_DeploymentSecurityContext(t *testing.T) {
+	t.Parallel()
+
+	sut := GetWebhook(
+		logr.Discard(), "test-ns", nil, "image", corev1.PullAlways,
+		CAInjectTypeCertManager, nil, nil, false,
+	)
+
+	podSpec := sut.deployment.Spec.Template.Spec
+	require.NotNil(t, podSpec.SecurityContext)
+	require.NotNil(t, podSpec.SecurityContext.SeccompProfile)
+	assert.Equal(t, corev1.SeccompProfileTypeRuntimeDefault, podSpec.SecurityContext.SeccompProfile.Type)
+
+	require.Len(t, podSpec.Containers, 1)
+	sc := podSpec.Containers[0].SecurityContext
+	require.NotNil(t, sc)
+	require.NotNil(t, sc.AllowPrivilegeEscalation)
+	assert.False(t, *sc.AllowPrivilegeEscalation)
+	require.NotNil(t, sc.ReadOnlyRootFilesystem)
+	assert.True(t, *sc.ReadOnlyRootFilesystem)
+	require.NotNil(t, sc.RunAsNonRoot)
+	assert.True(t, *sc.RunAsNonRoot)
+	require.NotNil(t, sc.Capabilities)
+	assert.Equal(t, []corev1.Capability{"ALL"}, sc.Capabilities.Drop)
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

## Problem

The `security-profiles-operator` manager container and the admission `webhook` container run with a minimal `securityContext` that only sets `readOnlyRootFilesystem: true` and `allowPrivilegeEscalation: false`. They do not declare `runAsNonRoot: true` or drop Linux capabilities, even though neither component needs any capability and both images already switch to `USER 65535:65535`. Pod Security admission in the `restricted` profile and common policy engines flag this, and it leaves the containers with the default capability set for no reason.

## Root cause

The hardening fields were simply never added at the places where these two Deployments are defined:

- `deploy/kustomize-deployment/manager_deployment.yaml:27-29` (manager container, source for `deploy/operator.yaml`, `deploy/namespace-operator.yaml`, `deploy/openshift-dev.yaml`, `deploy/openshift-downstream.yaml`, `deploy/webhook-operator.yaml`)
- `deploy/helm/templates/deployment.yaml:47-49` (manager container in the Helm chart)
- `internal/pkg/manager/spod/bindata/webhook.go:681-684` (webhook container in the Deployment the spod controller creates)
- `deploy/overlays/webhook/webhook_deployment.yaml:31-33` (webhook container in the standalone webhook overlay)
- `bundle/manifests/security-profiles-operator.clusterserviceversion.yaml:731-733` (manager container in the OLM bundle)

## Fix

Add `runAsNonRoot: true` and `capabilities.drop: ["ALL"]` to the container `securityContext` in all of the above, and regenerate the derived manifests with `kustomize build` (same output as `make deployments`). The Dockerfile and Dockerfile.ubi both end with `USER 65535:65535`, so `runAsNonRoot: true` is satisfied without changing the image. The pod-level `seccompProfile: RuntimeDefault` was already in place in the kustomize, OLM and webhook manifests and is unchanged; the Helm chart leaves the pod-level profile to `.Values.podSecurityContext`, which is also unchanged here.

The remaining items from the issue (making the SELinux/BPF `hostPath` volumes on the spod DaemonSet conditional and narrowing the host-root volume) touch the privileged daemon containers in `internal/pkg/manager/spod/bindata/spod.go` and are intentionally left for a follow-up.

#### Which issue(s) this PR fixes:

Part of https://github.com/kubernetes-sigs/security-profiles-operator/issues/3317 (the hostPath-volume items remain open, so this does not close it).

#### Does this PR have test?

## How tested

New unit test `TestWebhook_DeploymentSecurityContext` in `internal/pkg/manager/spod/bindata/webhook_test.go` builds the webhook Deployment via `GetWebhook` and asserts `RunAsNonRoot == true`, `Capabilities.Drop == ["ALL"]`, `AllowPrivilegeEscalation == false`, `ReadOnlyRootFilesystem == true`, and pod `SeccompProfile == RuntimeDefault`.

Before the fix:

```
$ go test -count=1 -run TestWebhook_DeploymentSecurityContext ./internal/pkg/manager/spod/bindata/
--- FAIL: TestWebhook_DeploymentSecurityContext (0.00s)
    webhook_test.go:263:
        	Error Trace:	.../internal/pkg/manager/spod/bindata/webhook_test.go:263
        	Error:      	Expected value not to be nil.
        	Test:       	TestWebhook_DeploymentSecurityContext
FAIL
FAIL	sigs.k8s.io/security-profiles-operator/internal/pkg/manager/spod/bindata	0.024s
```

After the fix:

```
$ go test -count=1 ./internal/pkg/manager/spod/...
ok  	sigs.k8s.io/security-profiles-operator/internal/pkg/manager/spod	0.022s
ok  	sigs.k8s.io/security-profiles-operator/internal/pkg/manager/spod/bindata	0.016s
```

`gofmt -l` and `go vet ./internal/pkg/manager/spod/...` are clean; `go build ./internal/pkg/manager/spod/...` succeeds. The generated `deploy/*.yaml` files were produced with kustomize v5.8.1 (the pinned `KUSTOMIZE_VERSION`) and differ from their sources only by the four added lines per container.

#### Special notes for your reviewer:

The OLM bundle CSV was edited by hand to mirror the kustomize output because `make bundle` needs operator-sdk and a cgo toolchain that were not available in my environment; `make verify-bundle` in CI will confirm it matches.

## Links

- Issue: https://github.com/kubernetes-sigs/security-profiles-operator/issues/3317
- Pod Security Standards (restricted profile): https://kubernetes.io/docs/concepts/security/pod-security-standards/

#### Does this PR introduce a user-facing change?

```release-note
The operator and webhook containers now set `runAsNonRoot: true` and drop all Linux capabilities in their `securityContext`.
```

This change was prepared with an AI agent operated by KR-Ravindra, who reviewed and tested it.

