### PR TITLE
helm: Pin image tag and registry during release

### DIFF
--- a/hack/back-to-dev.sh
+++ b/hack/back-to-dev.sh
@@ -86,4 +86,12 @@ sed -i \
     -e 's;newTag: v'"$VERSION"';newTag: latest;g' \
     deploy/overlays/webhook/kustomization.yaml
 
+# Revert Helm chart values to staging
+sed -i \
+    -e 's;registry: registry.k8s.io;registry: gcr.io;g' \
+    -e 's;repository: security-profiles-operator/security-profiles-operator;repository: k8s-staging-sp-operator/security-profiles-operator;g' \
+    -e 's;tag: v'"$VERSION"';tag: latest;g' \
+    -e 's;pullPolicy: IfNotPresent;pullPolicy: Always;g' \
+    deploy/helm/values.yaml
+
 echo "Done. Commit the changes to a new branch and create a PR from it"

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -55,6 +55,13 @@ FILE=deploy/overlays/webhook/kustomization.yaml
 sed -i 's;newName: gcr.io/k8s-staging-sp-operator/security-profiles-operator;newName: registry.k8s.io/security-profiles-operator/security-profiles-operator;g' $FILE
 sed -i 's;newTag: latest;newTag: v'"$VERSION"';g' $FILE
 
+# Update Helm chart values to use release image
+FILE=deploy/helm/values.yaml
+sed -i 's;registry: gcr.io;registry: registry.k8s.io;g' $FILE
+sed -i 's;repository: k8s-staging-sp-operator/security-profiles-operator;repository: security-profiles-operator/security-profiles-operator;g' $FILE
+sed -i '0,/tag: latest/{s;tag: latest;tag: v'"$VERSION"';}' $FILE
+sed -i 's;pullPolicy: Always;pullPolicy: IfNotPresent;g' $FILE
+
 # Update dependencies.yaml
 FILES=(
     dependencies.yaml


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

The Helm chart hardcodes `spoImage.tag` to `latest` and the registry to the staging `gcr.io` location. When users install a released chart, the `latest` image may contain code requiring permissions the chart's RBAC doesn't grant, causing failures like the `profilebindings` watch error in #3423.

This updates the release script to rewrite `values.yaml` during release, pinning the SPO image tag to `v$VERSION`, the registry to `registry.k8s.io`, and the pull policy to `IfNotPresent`. The back-to-dev script is also updated to revert these changes. This matches the pattern already used for the kustomize overlays. Selinuxd images are left on `latest`/`quay.io` since they have independent versioning.

#### Which issue(s) this PR fixes:

Fixes #3423

#### Does this PR have test?

N/A - verified the sed commands produce correct output for both release and back-to-dev round-trips.

#### Special notes for your reviewer:

On `main`, `values.yaml` keeps `tag: latest` and `registry: gcr.io` for development. The release script (`hack/release.sh`) already rewrites kustomize overlays to use `registry.k8s.io` and `v$VERSION`; this PR adds the same treatment for `values.yaml`. The `tag: latest` replacement uses `0,/pattern/` to only match the first occurrence (spoImage), avoiding unintended changes to selinuxd image tags.

#### Does this PR introduce a user-facing change?

```release-note
Pin Helm chart SPO image to the release version and production registry during release to prevent RBAC/binary version drift.
```