### PR TITLE
Fix SPOd render aliasing, bpf recorder leaks and harden defaults

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -31,3 +31,12 @@ comment:
   layout: "header, diff"
   behavior: default
   require_changes: false
+
+# Generated code is not hand written and not worth covering. Counting it
+# understates the coverage of the code that actually gets reviewed.
+ignore:
+  - "**/*fakes/**"
+  - "**/zz_generated*.go"
+  - "**/*.pb.go"
+  - "internal/pkg/daemon/bpfrecorder/generated.go"
+  - "internal/pkg/daemon/bpfrecorder/vmlinux/**"

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ OPERATOR_SDK_VERSION ?= v1.42.3
 OPM_VERSION ?= v1.73.0
 ZEITGEIST_VERSION = v0.8.0
 MDTOC_VERSION = v1.4.0
+GOVULNCHECK_VERSION = v1.8.0
 CI_IMAGE ?= golang:$(shell sed -n 's;^go\s\(.*\);\1;p' go.mod)
 
 CONTROLLER_GEN_CMD := CGO_LDFLAGS= $(GO) run $(BUILD_FLAGS) -tags generate sigs.k8s.io/controller-tools/cmd/controller-gen
@@ -402,7 +403,7 @@ internal/pkg/daemon/enricher/auditsource/bpf/enricher.bpf.o.%: $(BPF_ENRICHER_FI
 # Verification targets
 
 .PHONY: verify
-verify: verify-boilerplate verify-go-mod verify-go-lint verify-deployments verify-dependencies verify-toc verify-mocks verify-format ## Run all verification targets
+verify: verify-boilerplate verify-go-mod verify-go-lint verify-deployments verify-dependencies verify-toc verify-mocks verify-format verify-vulnerabilities ## Run all verification targets
 
 .PHONY: verify-in-a-container
 verify-in-a-container: ## Run all verification targets in a container
@@ -468,6 +469,10 @@ $(BUILD_DIR)/golangci-lint-kube-api-linter: $(BUILD_DIR)/golangci-lint
 	$(BUILD_DIR)/golangci-lint-kube-api-linter linters
 
 
+.PHONY: verify-vulnerabilities
+verify-vulnerabilities: ## Verify that no known vulnerability is reachable
+	GOVULNCHECK_VERSION=$(GOVULNCHECK_VERSION) BUILDTAGS='$(BUILDTAGS)' hack/govulncheck
+
 .PHONY: verify-dependencies
 verify-dependencies: $(BUILD_DIR)/zeitgeist ## Verify external dependencies
 	$(BUILD_DIR)/zeitgeist validate --local-only --base-path . --config dependencies.yaml
@@ -501,7 +506,7 @@ test-unit: $(BUILD_DIR) ## Run the unit tests
 	# remove all coverage files if exists
 	rm -rf *.out
 	# run the go tests and gen the file coverage-all used to do the integration with coverrals.io
-	$(GO) test -ldflags '$(LDVARS)' -tags '$(BUILDTAGS)' -race -v -test.coverprofile=$(BUILD_DIR)/coverage.out ./internal/...
+	$(GO) test -ldflags '$(LDVARS)' -tags '$(BUILDTAGS)' -race -v -test.coverprofile=$(BUILD_DIR)/coverage.out ./internal/... ./api/... ./cmd/...
 	$(GO) tool cover -html $(BUILD_DIR)/coverage.out -o $(BUILD_DIR)/coverage.html
 
 .PHONY: test-e2e

--- a/api/seccompprofile/v1/seccompprofile_types.go
+++ b/api/seccompprofile/v1/seccompprofile_types.go
@@ -39,6 +39,10 @@ var (
 
 const ExtJSON = ".json"
 
+// unsafeSegmentReplacement is used in place of a path element which would
+// otherwise escape the directory it gets joined into.
+const unsafeSegmentReplacement = "_"
+
 type Action = seccompapi.Action
 
 const (
@@ -240,13 +244,26 @@ func (sp *SeccompProfile) GetProfileFile() string {
 	return pfile
 }
 
+// pathSegment reduces s to a single path element which cannot escape the
+// directory it gets joined into. filepath.Base alone is not enough, because it
+// maps "..", "../.." and similar onto "..", which path.Join then resolves into
+// the parent directory. Every other result of filepath.Base is either a plain
+// name or something path.Join cleans away on its own.
+func pathSegment(s string) string {
+	if base := filepath.Base(s); base != ".." {
+		return base
+	}
+
+	return unsafeSegmentReplacement
+}
+
 func (sp *SeccompProfile) GetProfilePath() string {
 	pfile := sp.GetProfileFile()
 
 	return path.Join(
 		config.ProfilesRootPath(),
-		filepath.Base(sp.GetNamespace()),
-		filepath.Base(pfile),
+		pathSegment(sp.GetNamespace()),
+		pathSegment(pfile),
 	)
 }
 
@@ -255,8 +272,8 @@ func (sp *SeccompProfile) GetProfileOperatorPath() string {
 
 	return path.Join(
 		config.OperatorRoot,
-		filepath.Base(sp.GetNamespace()),
-		filepath.Base(pfile),
+		pathSegment(sp.GetNamespace()),
+		pathSegment(pfile),
 	)
 }
 

--- a/api/seccompprofile/v1/seccompprofile_types_test.go
+++ b/api/seccompprofile/v1/seccompprofile_types_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package v1
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	profilebasev1 "sigs.k8s.io/security-profiles-operator/api/profilebase/v1"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
+)
+
+func newProfile(namespace, name string) *SeccompProfile {
+	return &SeccompProfile{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+	}
+}
+
+func TestGetProfileFile(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		profileName string
+		want        string
+	}{
+		"appends the json extension":    {"profile", "profile" + ExtJSON},
+		"keeps an existing extension":   {"profile" + ExtJSON, "profile" + ExtJSON},
+		"only matches the suffix":       {"profile.json.bak", "profile.json.bak" + ExtJSON},
+		"handles an empty profile name": {"", ExtJSON},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			require.Equal(t, tc.want, newProfile("ns", tc.profileName).GetProfileFile())
+		})
+	}
+}
+
+// TestGetProfilePathIsContained asserts that neither the namespace nor the
+// profile name can escape the profiles root, since both are user controlled.
+func TestGetProfilePathIsContained(t *testing.T) {
+	t.Parallel()
+
+	for name, tc := range map[string]struct {
+		namespace   string
+		profileName string
+	}{
+		"plain":                  {"my-ns", "my-profile"},
+		"traversal in namespace": {"../../../../etc", "my-profile"},
+		"traversal in name":      {"my-ns", "../../../../etc/passwd"},
+		"traversal in both":      {"../..", "../../etc/passwd"},
+		"absolute namespace":     {"/etc", "my-profile"},
+		"absolute name":          {"my-ns", "/etc/passwd"},
+		"empty namespace":        {"", "my-profile"},
+		"dot namespace":          {".", "my-profile"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			sp := newProfile(tc.namespace, tc.profileName)
+
+			for root, got := range map[string]string{
+				config.ProfilesRootPath(): sp.GetProfilePath(),
+				config.OperatorRoot:       sp.GetProfileOperatorPath(),
+			} {
+				require.True(t, strings.HasPrefix(got, root+"/"),
+					"%q must stay below %q", got, root)
+				require.NotContains(t, got, "..", "%q must not contain a traversal", got)
+			}
+		})
+	}
+}
+
+func TestGetProfilePath(t *testing.T) {
+	t.Parallel()
+
+	sp := newProfile("my-ns", "my-profile")
+
+	require.Equal(t,
+		config.ProfilesRootPath()+"/my-ns/my-profile"+ExtJSON,
+		sp.GetProfilePath())
+	require.Equal(t,
+		config.OperatorRoot+"/my-ns/my-profile"+ExtJSON,
+		sp.GetProfileOperatorPath())
+}
+
+// TestGetProfilePathEmptyNamespace pins that an empty or dotted namespace still
+// collapses the way path.Join always handled it, rather than growing a segment.
+func TestGetProfilePathEmptyNamespace(t *testing.T) {
+	t.Parallel()
+
+	want := config.ProfilesRootPath() + "/my-profile" + ExtJSON
+
+	require.Equal(t, want, newProfile("", "my-profile").GetProfilePath())
+	require.Equal(t, want, newProfile(".", "my-profile").GetProfilePath())
+}
+
+func TestSetImplementationStatus(t *testing.T) {
+	t.Parallel()
+
+	sp := newProfile("my-ns", "my-profile")
+	sp.SetImplementationStatus()
+
+	require.Equal(t,
+		strings.TrimPrefix(sp.GetProfilePath(), config.KubeletSeccompRootPath()+"/"),
+		sp.Status.LocalhostProfile)
+	require.NotContains(t, sp.Status.LocalhostProfile, config.KubeletSeccompRootPath())
+}
+
+func TestIsDisabledAndReconcilable(t *testing.T) {
+	t.Parallel()
+
+	enabled := newProfile("ns", "name")
+	require.False(t, enabled.IsDisabled())
+	require.False(t, enabled.IsPartial())
+	require.True(t, enabled.IsReconcilable())
+
+	disabled := newProfile("ns", "name")
+	disabled.Spec.State = profilebasev1.SpecStateDisabled
+	require.True(t, disabled.IsDisabled())
+	require.False(t, disabled.IsReconcilable())
+
+	partial := newProfile("ns", "name")
+	partial.SetLabels(map[string]string{profilebasev1.ProfilePartialLabel: "true"})
+	require.True(t, partial.IsPartial())
+	require.False(t, partial.IsReconcilable())
+}

--- a/api/spod/v1/spod_types.go
+++ b/api/spod/v1/spod_types.go
@@ -327,12 +327,16 @@ type SPODSecurityConfig struct {
 
 	// allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
 	// image used to distribute the base profile in the cluster.
+	// The default ".*" matches any identity, which means a signature from any
+	// signer is accepted. That only proves the artifact was signed by somebody,
+	// not by somebody trusted, so set this to the identities you trust.
 	// +optional
 	// +default=".*"
 	AllowedIdentityRegexp string `json:"allowedIdentityRegexp,omitempty"`
 
 	// allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
 	// image used to distribute the base profile in the cluster.
+	// As with allowedIdentityRegexp, the default ".*" matches any issuer.
 	// +optional
 	// +default=".*"
 	AllowedOidcIssuerRegexp string `json:"allowedOidcIssuerRegexp,omitempty"`

--- a/cmd/security-profiles-operator/main.go
+++ b/cmd/security-profiles-operator/main.go
@@ -38,6 +38,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/urfave/cli/v2"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -511,7 +512,7 @@ func runManager(ctx *cli.Context, info *version.Info) error {
 	}
 
 	// Fetch initial TLS configuration from OpenShift API Server
-	_, initialTLSProfile, initialTLSAdherencePolicy, isOpenShift, err := fetchTLSOptions(
+	tlsCfg, err := fetchTLSOptions(
 		ctx.Context, cfg,
 	)
 	if err != nil {
@@ -604,7 +605,7 @@ func runManager(ctx *cli.Context, info *version.Info) error {
 	sigHandler := ctrl.SetupSignalHandler()
 
 	return setupManagerWithTLSWatcher(
-		sigHandler, mgr, initialTLSProfile, initialTLSAdherencePolicy, isOpenShift, "manager",
+		sigHandler, mgr, &tlsCfg, "manager",
 	)
 }
 
@@ -675,52 +676,77 @@ func getEnabledControllers(ctx *cli.Context) []controller.Controller {
 	return controllers
 }
 
-// newMemoryOptimizedCache creates a memory optimized cache for daemon controller.
-// This will load into cache memory only the pods objects which are labeled for recording.
-func newMemoryOptimizedCache(ctx *cli.Context) cache.NewCacheFunc {
-	if ctx.Bool(memOptimFlag) {
-		return func(config *rest.Config, opts cache.Options) (cache.Cache, error) {
-			opts.SyncPeriod = &sync
-			opts.ByObject = map[client.Object]cache.ByObject{
-				&corev1.Pod{}: {
-					Label: labels.SelectorFromSet(labels.Set{
-						bindata.EnableRecordingLabel: "true",
-					}),
-				},
-			}
-			opts.DefaultLabelSelector = labels.Everything()
+// newDaemonCache creates the cache used by the daemon controllers.
+//
+// The daemon only ever acts on pods scheduled to its own node, so the pod cache
+// is always restricted to those. Without that restriction every node would hold
+// a copy of every pod in the cluster, which costs both memory per node and
+// watch bandwidth on the API server.
+//
+// When memory optimization is additionally enabled, only pods labeled for
+// recording are cached on top of that.
+func newDaemonCache(ctx *cli.Context) cache.NewCacheFunc {
+	byPod := cache.ByObject{}
 
-			return cache.New(config, opts)
-		}
+	if nodeName := os.Getenv(config.NodeNameEnvKey); nodeName != "" {
+		byPod.Field = fields.OneTermEqualSelector("spec.nodeName", nodeName)
+	} else {
+		setupLog.Info(
+			"Node name not set, caching pods cluster wide",
+			"env", config.NodeNameEnvKey,
+		)
 	}
 
-	return nil
+	if ctx.Bool(memOptimFlag) {
+		byPod.Label = labels.SelectorFromSet(labels.Set{
+			bindata.EnableRecordingLabel: "true",
+		})
+	}
+
+	return func(restConfig *rest.Config, opts cache.Options) (cache.Cache, error) {
+		opts.SyncPeriod = &sync
+		opts.ByObject = map[client.Object]cache.ByObject{&corev1.Pod{}: byPod}
+		opts.DefaultLabelSelector = labels.Everything()
+
+		return cache.New(restConfig, opts)
+	}
 }
 
-// fetchTLSOptions fetches TLS configuration from OpenShift APIServer and builds
-// TLS options for controller-runtime servers (webhook/metrics).
-// Returns TLS options slice, profile spec, adherence policy, whether OpenShift is detected, and any error.
-func fetchTLSOptions(ctx context.Context, cfg *rest.Config) (
-	_ []func(*tls.Config),
-	tlsProfile configv1.TLSProfileSpec,
-	tlsAdherence configv1.TLSAdherencePolicy,
-	isOpenShift bool,
-	err error,
-) {
+// tlsConfig is the TLS configuration used by the controller-runtime servers
+// (webhook and metrics) of a component.
+type tlsConfig struct {
+	// options are applied to the servers' *tls.Config.
+	options []func(*tls.Config)
+
+	// profile is the TLS profile the options were derived from.
+	profile configv1.TLSProfileSpec
+
+	// adherencePolicy says how strictly the cluster TLS profile is honored.
+	adherencePolicy configv1.TLSAdherencePolicy
+
+	// isOpenShift reports whether the cluster was detected as OpenShift.
+	isOpenShift bool
+}
+
+// fetchTLSOptions fetches the TLS configuration from the OpenShift APIServer
+// and builds the TLS configuration for the controller-runtime servers. On
+// non-OpenShift clusters it falls back to the Go defaults with a TLS 1.2
+// minimum version.
+func fetchTLSOptions(ctx context.Context, cfg *rest.Config) (_ tlsConfig, err error) {
+	var isOpenShift bool
+
 	setupLog.Info("detecting platform and fetching TLS configuration")
 
 	// Create scheme and register OpenShift config API
 	scheme := runtime.NewScheme()
 	if err := configv1.AddToScheme(scheme); err != nil {
-		return nil, configv1.TLSProfileSpec{}, configv1.TLSAdherencePolicyNoOpinion, false,
-			fmt.Errorf("add OpenShift config API to scheme: %w", err)
+		return tlsConfig{}, fmt.Errorf("add OpenShift config API to scheme: %w", err)
 	}
 
 	// Create pre-start client to detect platform and fetch TLS configuration
 	preStartClient, err := client.New(cfg, client.Options{Scheme: scheme})
 	if err != nil {
-		return nil, configv1.TLSProfileSpec{}, configv1.TLSAdherencePolicyNoOpinion, false,
-			fmt.Errorf("create pre-start client: %w", err)
+		return tlsConfig{}, fmt.Errorf("create pre-start client: %w", err)
 	}
 
 	// Create a timeout context for OpenShift detection to avoid long waits on non-OpenShift clusters
@@ -744,8 +770,7 @@ func fetchTLSOptions(ctx context.Context, cfg *rest.Config) (
 
 		isOpenShift = false
 	default:
-		return nil, configv1.TLSProfileSpec{}, configv1.TLSAdherencePolicyNoOpinion, false,
-			fmt.Errorf("detect OpenShift platform: %w", err)
+		return tlsConfig{}, fmt.Errorf("detect OpenShift platform: %w", err)
 	}
 
 	// Fetch TLS profile and adherence policy if on OpenShift
@@ -768,8 +793,7 @@ func fetchTLSOptions(ctx context.Context, cfg *rest.Config) (
 
 			initialTLSProfile, err = tlspkg.GetTLSProfileSpec(nil)
 			if err != nil {
-				return nil, configv1.TLSProfileSpec{}, configv1.TLSAdherencePolicyNoOpinion, false,
-					fmt.Errorf("get default TLS profile: %w", err)
+				return tlsConfig{}, fmt.Errorf("get default TLS profile: %w", err)
 			}
 		}
 
@@ -792,8 +816,7 @@ func fetchTLSOptions(ctx context.Context, cfg *rest.Config) (
 		// Use default TLS profile and adherence policy for non-OpenShift environments
 		initialTLSProfile, err = tlspkg.GetTLSProfileSpec(nil)
 		if err != nil {
-			return nil, configv1.TLSProfileSpec{}, configv1.TLSAdherencePolicyNoOpinion, false,
-				fmt.Errorf("get default TLS profile: %w", err)
+			return tlsConfig{}, fmt.Errorf("get default TLS profile: %w", err)
 		}
 
 		initialTLSAdherencePolicy = configv1.TLSAdherencePolicyNoOpinion
@@ -858,7 +881,12 @@ func fetchTLSOptions(ctx context.Context, cfg *rest.Config) (
 		})
 	}
 
-	return tlsOptions, initialTLSProfile, initialTLSAdherencePolicy, isOpenShift, nil
+	return tlsConfig{
+		options:         tlsOptions,
+		profile:         initialTLSProfile,
+		adherencePolicy: initialTLSAdherencePolicy,
+		isOpenShift:     isOpenShift,
+	}, nil
 }
 
 // setupManagerWithTLSWatcher sets up TLS watching for a manager and starts it.
@@ -866,9 +894,7 @@ func fetchTLSOptions(ctx context.Context, cfg *rest.Config) (
 func setupManagerWithTLSWatcher(
 	sigHandler context.Context,
 	mgr ctrl.Manager,
-	initialTLSProfile configv1.TLSProfileSpec,
-	initialTLSAdherencePolicy configv1.TLSAdherencePolicy,
-	isOpenShift bool,
+	tlsCfg *tlsConfig,
 	componentName string,
 ) error {
 	// Create a cancellable context derived from sigHandler for graceful shutdown on TLS config changes
@@ -879,8 +905,8 @@ func setupManagerWithTLSWatcher(
 	// This is only available in OpenShift environments
 	var tlsConfigChanged atomic.Bool
 
-	if isOpenShift {
-		if err := util.SetupTLSWatcher(mgr, initialTLSProfile, initialTLSAdherencePolicy,
+	if tlsCfg.isOpenShift {
+		if err := util.SetupTLSWatcher(mgr, tlsCfg.profile, tlsCfg.adherencePolicy,
 			func(ctx context.Context, oldProfile, newProfile configv1.TLSProfileSpec) {
 				tlsConfigChanged.Store(true)
 				cancelManager()
@@ -949,7 +975,7 @@ func runDaemon(ctx *cli.Context, info *version.Info) error {
 	defer met.GracefulStop()
 
 	// Fetch initial TLS configuration from OpenShift API Server
-	metricsTLSOpts, initialTLSProfile, initialTLSAdherencePolicy, isOpenShift, err := fetchTLSOptions(
+	tlsCfg, err := fetchTLSOptions(
 		ctx.Context,
 		cfg,
 	)
@@ -960,7 +986,7 @@ func runDaemon(ctx *cli.Context, info *version.Info) error {
 	ctrlOpts := ctrl.Options{
 		Cache:                  cache.Options{SyncPeriod: &sync},
 		HealthProbeBindAddress: fmt.Sprintf(":%d", config.HealthProbePort),
-		NewCache:               newMemoryOptimizedCache(ctx),
+		NewCache:               newDaemonCache(ctx),
 		Metrics: metricsserver.Options{
 			BindAddress:    fmt.Sprintf(":%d", bindata.ContainerPort),
 			CertDir:        bindata.MetricsCertPath,
@@ -969,7 +995,7 @@ func runDaemon(ctx *cli.Context, info *version.Info) error {
 			ExtraHandlers: map[string]http.Handler{
 				metrics.HandlerPath: met.Handler(),
 			},
-			TLSOpts: metricsTLSOpts,
+			TLSOpts: tlsCfg.options,
 		},
 	}
 
@@ -1011,9 +1037,7 @@ func runDaemon(ctx *cli.Context, info *version.Info) error {
 	return setupManagerWithTLSWatcher(
 		sigHandler,
 		mgr,
-		initialTLSProfile,
-		initialTLSAdherencePolicy,
-		isOpenShift,
+		&tlsCfg,
 		"daemon",
 	)
 }
@@ -1131,7 +1155,7 @@ func runWebhook(ctx *cli.Context, info *version.Info) error {
 	port := ctx.Int("port")
 
 	// Fetch initial TLS configuration from OpenShift API Server
-	webhookTLSOpts, initialTLSProfile, initialTLSAdherencePolicy, isOpenShift, err := fetchTLSOptions(
+	tlsCfg, err := fetchTLSOptions(
 		ctx.Context,
 		cfg,
 	)
@@ -1141,7 +1165,7 @@ func runWebhook(ctx *cli.Context, info *version.Info) error {
 
 	webhookServerOptions := webhook.Options{
 		Port:    port,
-		TLSOpts: webhookTLSOpts,
+		TLSOpts: tlsCfg.options,
 	}
 
 	webhookServer := webhook.NewServer(webhookServerOptions)
@@ -1201,7 +1225,7 @@ func runWebhook(ctx *cli.Context, info *version.Info) error {
 	sigHandler := ctrl.SetupSignalHandler()
 
 	return setupManagerWithTLSWatcher(
-		sigHandler, mgr, initialTLSProfile, initialTLSAdherencePolicy, isOpenShift, "webhook",
+		sigHandler, mgr, &tlsCfg, "webhook",
 	)
 }
 

--- a/cmd/spoc/main.go
+++ b/cmd/spoc/main.go
@@ -17,6 +17,7 @@ limitations under the License.
 package main
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -300,6 +301,12 @@ func merge(ctx *cli.Context) error {
 	}
 
 	if err := merger.New(options).Run(); err != nil {
+		// In check mode an outdated base profile is a result, not a failure,
+		// so report it through the exit code only.
+		if errors.Is(err, merger.ErrBaseProfileOutdated) {
+			return cli.Exit("", 1)
+		}
+
 		return fmt.Errorf("launch merger: %w", err)
 	}
 

--- a/dependencies.yaml
+++ b/dependencies.yaml
@@ -227,6 +227,12 @@ dependencies:
       - path: Makefile
         match: "^MDTOC_VERSION"
 
+  - name: govulncheck
+    version: v1.8.0
+    refPaths:
+      - path: Makefile
+        match: "^GOVULNCHECK_VERSION"
+
   - name: yq
     version: 4.53.6
     refPaths:

--- a/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
+++ b/deploy/base-crds/crds/securityprofilesoperatordaemon.yaml
@@ -1232,12 +1232,16 @@ spec:
                     description: |-
                       allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
+                      The default ".*" matches any identity, which means a signature from any
+                      signer is accepted. That only proves the artifact was signed by somebody,
+                      not by somebody trusted, so set this to the identities you trust.
                     type: string
                   allowedOidcIssuerRegexp:
                     default: .*
                     description: |-
                       allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
+                      As with allowedIdentityRegexp, the default ".*" matches any issuer.
                     type: string
                   allowedSeccompActions:
                     description: allowedSeccompActions if specified, a list of allowed

--- a/deploy/base/role.yaml
+++ b/deploy/base/role.yaml
@@ -204,6 +204,8 @@ rules:
   - update
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:
@@ -331,6 +333,8 @@ metadata:
 rules:
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:
@@ -393,6 +397,8 @@ rules:
   - update
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:

--- a/deploy/helm/crds/crds.yaml
+++ b/deploy/helm/crds/crds.yaml
@@ -1955,12 +1955,16 @@ spec:
                     description: |-
                       allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
+                      The default ".*" matches any identity, which means a signature from any
+                      signer is accepted. That only proves the artifact was signed by somebody,
+                      not by somebody trusted, so set this to the identities you trust.
                     type: string
                   allowedOidcIssuerRegexp:
                     default: .*
                     description: |-
                       allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
+                      As with allowedIdentityRegexp, the default ".*" matches any issuer.
                     type: string
                   allowedSeccompActions:
                     description: allowedSeccompActions if specified, a list of allowed

--- a/deploy/helm/templates/static-resources.yaml
+++ b/deploy/helm/templates/static-resources.yaml
@@ -256,6 +256,8 @@ rules:
   - update
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:
@@ -397,6 +399,8 @@ metadata:
 rules:
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:
@@ -473,6 +477,8 @@ rules:
   - update
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:

--- a/deploy/namespace-operator.yaml
+++ b/deploy/namespace-operator.yaml
@@ -1955,12 +1955,16 @@ spec:
                     description: |-
                       allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
+                      The default ".*" matches any identity, which means a signature from any
+                      signer is accepted. That only proves the artifact was signed by somebody,
+                      not by somebody trusted, so set this to the identities you trust.
                     type: string
                   allowedOidcIssuerRegexp:
                     default: .*
                     description: |-
                       allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
+                      As with allowedIdentityRegexp, the default ".*" matches any issuer.
                     type: string
                   allowedSeccompActions:
                     description: allowedSeccompActions if specified, a list of allowed
@@ -3176,6 +3180,8 @@ rules:
   - update
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:
@@ -3307,6 +3313,8 @@ metadata:
 rules:
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:
@@ -3373,6 +3381,8 @@ rules:
   - update
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:

--- a/deploy/openshift-dev.yaml
+++ b/deploy/openshift-dev.yaml
@@ -2347,12 +2347,16 @@ spec:
                     description: |-
                       allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
+                      The default ".*" matches any identity, which means a signature from any
+                      signer is accepted. That only proves the artifact was signed by somebody,
+                      not by somebody trusted, so set this to the identities you trust.
                     type: string
                   allowedOidcIssuerRegexp:
                     default: .*
                     description: |-
                       allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
+                      As with allowedIdentityRegexp, the default ".*" matches any issuer.
                     type: string
                   allowedSeccompActions:
                     description: allowedSeccompActions if specified, a list of allowed
@@ -2990,6 +2994,8 @@ rules:
   - update
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:
@@ -3021,6 +3027,8 @@ rules:
   - update
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:
@@ -3036,6 +3044,8 @@ metadata:
 rules:
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:

--- a/deploy/openshift-downstream.yaml
+++ b/deploy/openshift-downstream.yaml
@@ -1955,12 +1955,16 @@ spec:
                     description: |-
                       allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
+                      The default ".*" matches any identity, which means a signature from any
+                      signer is accepted. That only proves the artifact was signed by somebody,
+                      not by somebody trusted, so set this to the identities you trust.
                     type: string
                   allowedOidcIssuerRegexp:
                     default: .*
                     description: |-
                       allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
+                      As with allowedIdentityRegexp, the default ".*" matches any issuer.
                     type: string
                   allowedSeccompActions:
                     description: allowedSeccompActions if specified, a list of allowed
@@ -3181,6 +3185,8 @@ rules:
   - update
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:
@@ -3312,6 +3318,8 @@ metadata:
 rules:
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:
@@ -3378,6 +3386,8 @@ rules:
   - update
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1955,12 +1955,16 @@ spec:
                     description: |-
                       allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
+                      The default ".*" matches any identity, which means a signature from any
+                      signer is accepted. That only proves the artifact was signed by somebody,
+                      not by somebody trusted, so set this to the identities you trust.
                     type: string
                   allowedOidcIssuerRegexp:
                     default: .*
                     description: |-
                       allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
+                      As with allowedIdentityRegexp, the default ".*" matches any issuer.
                     type: string
                   allowedSeccompActions:
                     description: allowedSeccompActions if specified, a list of allowed
@@ -3176,6 +3180,8 @@ rules:
   - update
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:
@@ -3307,6 +3313,8 @@ metadata:
 rules:
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:
@@ -3373,6 +3381,8 @@ rules:
   - update
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:

--- a/deploy/webhook-operator.yaml
+++ b/deploy/webhook-operator.yaml
@@ -2347,12 +2347,16 @@ spec:
                     description: |-
                       allowedIdentityRegexp regexp for allowed identity when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
+                      The default ".*" matches any identity, which means a signature from any
+                      signer is accepted. That only proves the artifact was signed by somebody,
+                      not by somebody trusted, so set this to the identities you trust.
                     type: string
                   allowedOidcIssuerRegexp:
                     default: .*
                     description: |-
                       allowedOidcIssuerRegexp regexp for allowed Oidc issuer when verifying the signature of OCI
                       image used to distribute the base profile in the cluster.
+                      As with allowedIdentityRegexp, the default ".*" matches any issuer.
                     type: string
                   allowedSeccompActions:
                     description: allowedSeccompActions if specified, a list of allowed
@@ -2985,6 +2989,8 @@ rules:
   - update
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:
@@ -3016,6 +3022,8 @@ rules:
   - update
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:
@@ -3031,6 +3039,8 @@ metadata:
 rules:
 - apiGroups:
   - security.openshift.io
+  resourceNames:
+  - privileged
   resources:
   - securitycontextconstraints
   verbs:

--- a/hack/govulncheck
+++ b/hack/govulncheck
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Runs govulncheck and fails only on vulnerabilities that can actually be acted
+# on, meaning the ones with a fixed version available upstream.
+#
+# Reachable vulnerabilities without an upstream fix are reported but do not fail
+# the build, because there is nothing a bump could do about them. They stay
+# visible in the job output so that they get picked up once a fix lands.
+set -euo pipefail
+
+VERSION=${GOVULNCHECK_VERSION:?GOVULNCHECK_VERSION must be set}
+TAGS=${BUILDTAGS:-}
+
+REPORT=$(mktemp)
+trap 'rm -f "$REPORT"' EXIT
+
+# JSON output currently makes govulncheck exit 0 and leaves the verdict to the
+# caller, but it also documents exit code 3 for "vulnerabilities found". Accept
+# both and treat anything else as a broken run rather than a clean one.
+STATUS=0
+CGO_LDFLAGS= GOFLAGS=-mod=mod go run \
+    "golang.org/x/vuln/cmd/govulncheck@$VERSION" \
+    -format json -mode source -tags "${TAGS// /,}" ./... >"$REPORT" || STATUS=$?
+
+if [[ $STATUS -ne 0 && $STATUS -ne 3 ]]; then
+    echo "govulncheck failed with exit code $STATUS" >&2
+    exit "$STATUS"
+fi
+
+python3 - "$REPORT" <<'PY'
+import json
+import sys
+
+decoder = json.JSONDecoder()
+raw = open(sys.argv[1]).read()
+
+findings, osvs, idx, sane = [], {}, 0, False
+try:
+    while idx < len(raw):
+        while idx < len(raw) and raw[idx].isspace():
+            idx += 1
+        if idx >= len(raw):
+            break
+        obj, idx = decoder.raw_decode(raw, idx)
+        if "config" in obj:
+            sane = True
+        elif "finding" in obj:
+            findings.append(obj["finding"])
+        elif "osv" in obj and "id" in obj["osv"]:
+            osvs[obj["osv"]["id"]] = obj["osv"]
+except ValueError as err:
+    sys.exit(f"cannot parse the govulncheck report: {err}")
+
+# Without the config header the run did not get far enough to be trusted, and
+# an empty finding list would otherwise read as a clean result.
+if not sane:
+    sys.exit("govulncheck produced no report")
+
+# A finding is only reachable from our own code when its trace resolves down to
+# a concrete function; anything shallower is an import, not a call.
+fixable, unfixable = {}, {}
+for finding in findings:
+    trace = finding.get("trace") or []
+    if not trace or not trace[0].get("function"):
+        continue
+    target = fixable if finding.get("fixed_version") else unfixable
+    target.setdefault(finding["osv"], finding)
+
+
+def describe(osv_id, finding):
+    osv = osvs.get(osv_id, {})
+    summary = osv.get("summary") or osv.get("details", "").split("\n")[0]
+    # trace[0] is the vulnerable symbol itself, the tail is our own call site.
+    vulnerable = (finding.get("trace") or [{}])[0]
+    module = vulnerable.get("module", "?")
+    version = vulnerable.get("version", "?")
+    fixed = finding.get("fixed_version") or "no fix available"
+    return f"  {osv_id}  {module}@{version}  (fixed in: {fixed})\n    {summary}"
+
+
+if unfixable:
+    print("Reachable vulnerabilities without an upstream fix (not failing):")
+    for osv_id, finding in sorted(unfixable.items()):
+        print(describe(osv_id, finding))
+    print()
+
+if fixable:
+    print("Reachable vulnerabilities with a fix available:")
+    for osv_id, finding in sorted(fixable.items()):
+        print(describe(osv_id, finding))
+    print()
+    print("Update the affected modules to at least the listed fixed versions.")
+    sys.exit(1)
+
+print("No reachable vulnerability with an available fix.")
+PY

--- a/internal/pkg/artifact/artifact.go
+++ b/internal/pkg/artifact/artifact.go
@@ -118,9 +118,15 @@ type PullSignatureOptions struct {
 	DisableSignatureVerification bool
 
 	// AllowedIdentityRegexp regexp for allowed identities for signature verification.
+	//
+	// The default ".*" matches every identity, which means any valid keyless
+	// signature is accepted no matter who produced it. Set this to the
+	// identities you actually trust.
 	AllowedIdentityRegexp string
 
 	// AllowedOidcIssuerRegexp regexp for allowed Oidc issuer for signature verification.
+	//
+	// As with AllowedIdentityRegexp, the default ".*" matches every issuer.
 	AllowedOidcIssuerRegexp string
 }
 
@@ -130,6 +136,27 @@ type PushSignatureOptions struct {
 	// Keyless signing needs an OIDC identity, which build systems and test
 	// environments do not necessarily have.
 	DisableSigning bool
+}
+
+// hasUnconstrainedSigner reports whether the signer identity or the OIDC
+// issuer is left unconstrained, in which case verification does not establish
+// who signed the artifact.
+func (p *PullSignatureOptions) hasUnconstrainedSigner() bool {
+	return matchesAnything(p.AllowedIdentityRegexp) ||
+		matchesAnything(p.AllowedOidcIssuerRegexp)
+}
+
+// matchesAnything reports whether pattern accepts every value. Deciding that in
+// general is not possible, so this recognises the shipped default and the
+// spellings equivalent to it. A false result therefore means "not obviously
+// unconstrained" rather than "constrained".
+func matchesAnything(pattern string) bool {
+	switch strings.TrimSpace(pattern) {
+	case "", allowAllRegexp, ".+", "^.*$", "^.+$", "(.*)", "(.+)", "^", "$":
+		return true
+	}
+
+	return false
 }
 
 // New returns a new Artifact instance.
@@ -358,6 +385,18 @@ func (a *Artifact) Pull(
 
 	if !signOpts.DisableSignatureVerification {
 		a.logger.Info("Verifying signature")
+
+		if signOpts.hasUnconstrainedSigner() {
+			a.logger.Info(
+				"WARNING: signature verification is not constrained to a signer. "+
+					"A signature then only proves that the artifact was signed by "+
+					"somebody, not by somebody trusted. Set allowedIdentityRegexp "+
+					"and allowedOidcIssuerRegexp to the signers you trust.",
+				"allowedIdentityRegexp", signOpts.AllowedIdentityRegexp,
+				"allowedOidcIssuerRegexp", signOpts.AllowedOidcIssuerRegexp,
+				"image", originalImage,
+			)
+		}
 
 		v := verify.VerifyCommand{
 			CertVerifyOptions: options.CertVerifyOptions{

--- a/internal/pkg/bimap/bimap.go
+++ b/internal/pkg/bimap/bimap.go
@@ -120,6 +120,15 @@ func (m *BiMap[K, V]) DeleteBackwards(v V) {
 	delete(m.backward, v)
 }
 
+// Clear removes all elements from the map.
+func (m *BiMap[K, V]) Clear() {
+	m.l.Lock()
+	defer m.l.Unlock()
+
+	clear(m.forward)
+	clear(m.backward)
+}
+
 // Size returns the size of the map.
 func (m *BiMap[K, V]) Size() int {
 	m.l.RLock()

--- a/internal/pkg/bimap/bimap_test.go
+++ b/internal/pkg/bimap/bimap_test.go
@@ -113,6 +113,26 @@ func TestDeleteBackwards(t *testing.T) {
 	assert.False(t, actual.ExistsBackwards(1), "should remove the element in backward direction")
 }
 
+func TestClear(t *testing.T) {
+	t.Parallel()
+
+	actual := bimap.New[string, int]()
+	actual.Insert("test1", 1)
+	actual.Insert("test2", 2)
+	actual.Clear()
+	assert.Equal(t, 0, actual.Size(), "should remove all elements")
+	assert.False(t, actual.Exists("test1"), "should remove the element in forward direction")
+	assert.False(t, actual.ExistsBackwards(1), "should remove the element in backward direction")
+
+	// The map has to stay usable after being cleared.
+	actual.Insert("test3", 3)
+	assert.Equal(t, 1, actual.Size(), "should accept elements again")
+
+	value, ok := actual.Get("test3")
+	assert.True(t, ok)
+	assert.Equal(t, 3, value)
+}
+
 func TestSize(t *testing.T) {
 	t.Parallel()
 

--- a/internal/pkg/cli/merger/merger.go
+++ b/internal/pkg/cli/merger/merger.go
@@ -18,6 +18,7 @@ package merger
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -29,6 +30,11 @@ import (
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/artifact"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/manager/recordingmerger"
 )
+
+// ErrBaseProfileOutdated is returned by Run in check mode when the base
+// profile differs from the merge result. Callers are expected to turn this
+// into a non-zero exit code without printing it as a failure.
+var ErrBaseProfileOutdated = errors.New("base profile needs an update")
 
 // Merger is the main structure of this package.
 type Merger struct {
@@ -87,16 +93,17 @@ func (p *Merger) Run() error {
 	if p.options.check {
 		if reflect.DeepEqual(baseProfile, merged) {
 			log.Println("Base profile is up-to-date.")
-			os.Exit(0)
-		} else {
-			log.Println("Base profile needs an update.")
 
-			if err := printer.PrintObj(merged, os.Stderr); err != nil {
-				return fmt.Errorf("print YAML: %w", err)
-			}
-
-			os.Exit(1)
+			return nil
 		}
+
+		log.Println("Base profile needs an update.")
+
+		if err := printer.PrintObj(merged, os.Stderr); err != nil {
+			return fmt.Errorf("print YAML: %w", err)
+		}
+
+		return ErrBaseProfileOutdated
 	}
 
 	var buffer bytes.Buffer

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder.go
@@ -55,6 +55,8 @@ const (
 	maxMsgSize              int           = 16 * 1024 * 1024
 	maxCommLen              int           = 64
 	defaultCacheTimeout     time.Duration = time.Hour
+	maxNewPidHandlers       int           = 32
+	newPidQueueSize         int           = 1024
 	maxCacheItems           uint64        = 1000
 	defaultHostPid          uint32        = 1
 	defaultByteNum          int           = 4
@@ -92,9 +94,41 @@ type BpfRecorder struct {
 	AppArmor *AppArmorRecorder
 	Seccomp  *SeccompRecorder
 
-	startMu       sync.Mutex
-	pidSem        chan struct{}
-	recordedExits sync.Map
+	startMu sync.Mutex
+
+	// newPidEvents queues new pid events for a fixed pool of handlers. It is
+	// buffered so that the event processing loop never blocks on a slow
+	// handler: that loop also delivers the AppArmor events, so stalling it
+	// back pressures the ring buffer and makes the kernel drop recorded
+	// events. It is bounded so that a fork heavy workload cannot grow the
+	// queue until the recorder is out of memory.
+	newPidEvents     chan newPidEvent
+	startPidHandlers sync.Once
+
+	// recordingGeneration is bumped whenever a recording session ends. Handlers
+	// carry the generation their event was queued in and skip writing to the
+	// lookup tables once it no longer matches, so a handler still in flight
+	// cannot repopulate the tables after they were released.
+	recordingGeneration atomic.Uint64
+
+	// recentExits bounds how many exited PIDs are remembered so that
+	// WaitForPidExit can observe an exit that happened just before it started
+	// waiting. In-cluster nobody waits for those PIDs, so an unbounded map
+	// would leak an entry per recorded process exit.
+	recentExits *ttlcache.Cache[uint32, struct{}]
+
+	// exitWaiters holds a channel per caller currently inside WaitForPidExit.
+	// Waiters own their channel and remove it themselves, so it is bounded by
+	// the number of concurrent waiters and can never be evicted from under a
+	// parked caller.
+	exitWaiters sync.Map
+}
+
+// newPidEvent is the queued form of a new pid event.
+type newPidEvent struct {
+	pid        uint32
+	mntns      uint32
+	generation uint64
 }
 
 // We use a single shared event ringbuf for all userspace communication.
@@ -133,8 +167,12 @@ func New(programName string, logger logr.Logger, recordSeccomp, recordAppArmor b
 		programName:             programName,
 		AppArmor:                appArmor,
 		Seccomp:                 seccomp,
-		pidSem:                  make(chan struct{}, 32),
-		recordedExits:           sync.Map{},
+		newPidEvents:            make(chan newPidEvent, newPidQueueSize),
+		recentExits: ttlcache.New(
+			ttlcache.WithTTL[uint32, struct{}](defaultCacheTimeout),
+			ttlcache.WithCapacity[uint32, struct{}](maxCacheItems),
+			ttlcache.WithDisableTouchOnHit[uint32, struct{}](),
+		),
 	}
 }
 
@@ -150,6 +188,9 @@ func (b *BpfRecorder) Run() error {
 
 	go b.pidToContainerIDCache.Start()
 	defer b.pidToContainerIDCache.Stop()
+
+	go b.recentExits.Start()
+	defer b.recentExits.Stop()
 
 	b.nodeName = b.Getenv(config.NodeNameEnvKey)
 	if b.nodeName == "" {
@@ -691,9 +732,18 @@ func (b *BpfRecorder) StopRecording() error {
 		}
 	}
 
+	// Nothing is recording any more, so the per-session lookup tables can be
+	// released. Profiles are always collected before the recording is stopped.
+	// Ending the generation first makes handlers which are still in flight skip
+	// their writes. A handler which already passed that check can still land an
+	// entry here, which is why it re-checks afterwards and removes its own.
+	b.recordingGeneration.Add(1)
+	b.mntnsToContainerIDMap.Clear()
+	b.containerIDToProfileMap.Clear()
+	b.recentExits.DeleteAll()
+
 	b.logger.Info("Recording stopped.")
 
-	// XXX: It may be useful to clear out all existing maps here.
 	return nil
 }
 
@@ -734,13 +784,7 @@ func (b *BpfRecorder) handleEvent(eventBytes []byte) {
 
 	switch event.Type {
 	case uint8(eventTypeNewPid):
-		// handleNewPidEvent can be slow, and we don't want to block the event processing loop.
-		go func() {
-			b.pidSem <- struct{}{}
-			defer func() { <-b.pidSem }()
-
-			b.handleNewPidEvent(&event)
-		}()
+		b.scheduleNewPidEvent(event.Pid, event.Mntns)
 	case uint8(eventTypeExit):
 		b.handleExitEvent(&event)
 	case uint8(eventTypeAppArmorFile):
@@ -763,11 +807,47 @@ func (b *BpfRecorder) handleEvent(eventBytes []byte) {
 	}
 }
 
-func (b *BpfRecorder) handleNewPidEvent(e *bpfEvent) {
-	b.logger.Info("Received new pid", "pid", e.Pid, "mntns", e.Mntns)
+// scheduleNewPidEvent queues a new pid event for the handler pool.
+//
+// It never blocks: handleNewPidEvent does a cgroup lookup and can hit the
+// Kubernetes API, and the caller is the single event processing loop which also
+// delivers the AppArmor events over an unbuffered channel. Stalling it makes the
+// kernel drop recorded events, so a saturated queue drops the event instead.
+func (b *BpfRecorder) scheduleNewPidEvent(pid, mntns uint32) {
+	// The handlers live for the lifetime of the recorder. There is no teardown
+	// because both the daemon and spoc keep a recorder until the process exits,
+	// and a shutdown path would have to guard every send against a closed
+	// channel for no practical gain.
+	b.startPidHandlers.Do(func() {
+		for range maxNewPidHandlers {
+			go b.runPidHandler()
+		}
+	})
 
-	pid := e.Pid
-	mntns := e.Mntns
+	event := newPidEvent{
+		pid:        pid,
+		mntns:      mntns,
+		generation: b.recordingGeneration.Load(),
+	}
+
+	select {
+	case b.newPidEvents <- event:
+	default:
+		b.logger.Info(
+			"Dropping new pid event because the handler queue is full",
+			"pid", pid, "mntns", mntns, "queueSize", newPidQueueSize,
+		)
+	}
+}
+
+func (b *BpfRecorder) runPidHandler() {
+	for event := range b.newPidEvents {
+		b.handleNewPidEvent(event.pid, event.mntns, event.generation)
+	}
+}
+
+func (b *BpfRecorder) handleNewPidEvent(pid, mntns uint32, generation uint64) {
+	b.logger.Info("Received new pid", "pid", pid, "mntns", mntns)
 
 	if b.clientset == nil {
 		// spoc: we're running outside of a kubernetes context.
@@ -780,6 +860,15 @@ func (b *BpfRecorder) handleNewPidEvent(e *bpfEvent) {
 		b.logger.V(config.VerboseLevel).Info(
 			"No container ID found for PID",
 			"pid", pid, "mntns", mntns, "err", err.Error(),
+		)
+
+		return
+	}
+
+	if b.recordingGeneration.Load() != generation {
+		b.logger.V(config.VerboseLevel).Info(
+			"Discarding new pid event from a finished recording",
+			"pid", pid, "mntns", mntns, "containerID", containerID,
 		)
 
 		return
@@ -806,24 +895,30 @@ func (b *BpfRecorder) handleNewPidEvent(e *bpfEvent) {
 	)
 
 	b.trackProfileMetric(mntns, profile)
+
+	// The generation may have ended while the lookups above were running, in
+	// which case StopRecording has already cleared the tables and these entries
+	// would linger into the next recording.
+	if b.recordingGeneration.Load() != generation {
+		b.mntnsToContainerIDMap.Delete(mntns)
+		b.containerIDToProfileMap.Delete(containerID)
+	}
 }
 
 func (b *BpfRecorder) handleExitEvent(exitEvent *bpfEvent) {
 	b.logger.Info("Record pid exit", "pid", exitEvent.Pid)
-	d, _ := b.recordedExits.LoadOrStore(exitEvent.Pid, make(chan bool))
 
-	done, ok := d.(chan bool)
-	if !ok {
-		b.logger.Info("unexpected recordedExits type")
+	// Remember the exit first, so that a WaitForPidExit which registers right
+	// after this still observes it.
+	b.recentExits.Set(exitEvent.Pid, struct{}{}, ttlcache.DefaultTTL)
 
-		return
-	}
-
-	select {
-	case <-done:
-		// already closed
-	default:
-		close(done)
+	// LoadAndDelete hands the channel to exactly one caller, so a repeated exit
+	// event for the same pid cannot close it twice. Closing rather than sending
+	// wakes every waiter sharing the channel.
+	if waiter, ok := b.exitWaiters.LoadAndDelete(exitEvent.Pid); ok {
+		if done, ok := waiter.(chan struct{}); ok {
+			close(done)
+		}
 	}
 }
 
@@ -989,14 +1084,23 @@ func (b *BpfRecorder) findProfileForContainerID(id string) (string, error) {
 // When running outside of Kubernetes as spoc, we have the use case of
 // waiting for a specific PID to exit.
 func (b *BpfRecorder) WaitForPidExit(ctx context.Context, pid uint32) error {
-	d, _ := b.recordedExits.LoadOrStore(pid, make(chan bool))
-	done, ok := d.(chan bool)
+	// Concurrent waiters for the same pid share one channel, so that closing it
+	// wakes all of them. Registering happens before the recorded exits are
+	// consulted, so an exit landing between the two cannot be missed.
+	waiter, _ := b.exitWaiters.LoadOrStore(pid, make(chan struct{}))
 
+	done, ok := waiter.(chan struct{})
 	if !ok {
-		return fmt.Errorf("unexpected type: %T", d)
+		return fmt.Errorf("unexpected exit waiter type: %T", waiter)
 	}
 
-	defer b.recordedExits.Delete(pid)
+	// Only drop the registration if it is still ours, so giving up does not
+	// deregister a channel another waiter is parked on.
+	defer b.exitWaiters.CompareAndDelete(pid, done)
+
+	if b.recentExits.Get(pid) != nil {
+		return nil
+	}
 
 	select {
 	case <-done:

--- a/internal/pkg/daemon/bpfrecorder/bpfrecorder_test.go
+++ b/internal/pkg/daemon/bpfrecorder/bpfrecorder_test.go
@@ -23,12 +23,14 @@ import (
 	"context"
 	"encoding/binary"
 	"errors"
+	"slices"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/aquasecurity/libbpfgo"
 	"github.com/go-logr/logr"
+	"github.com/jellydator/ttlcache/v3"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 	v1 "k8s.io/api/core/v1"
@@ -764,6 +766,208 @@ func TestProcessEvents(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// TestRecordedExitsAreBounded asserts that exit events do not accumulate
+// forever. In-cluster nobody calls WaitForPidExit, so without a bound every
+// recorded process exit would leak an entry for the daemon's lifetime.
+func TestRecordedExitsAreBounded(t *testing.T) {
+	t.Parallel()
+
+	sut := New("", logr.Discard(), true, true)
+	sut.impl = &bpfrecorderfakes.FakeImpl{}
+
+	for pid := range uint32(maxCacheItems * 2) {
+		sut.handleExitEvent(&bpfEvent{Pid: pid, Type: uint8(eventTypeExit)})
+	}
+
+	require.LessOrEqual(t, uint64(sut.recentExits.Len()), maxCacheItems)
+}
+
+// TestWaitForPidExitSurvivesEviction asserts that a parked waiter is still
+// woken when the recorded exits are evicted or cleared underneath it. The
+// waiter owns its channel, so it cannot be dropped from the bounded cache.
+func TestWaitForPidExitSurvivesEviction(t *testing.T) {
+	t.Parallel()
+
+	sut := New("", logr.Discard(), true, true)
+	sut.impl = &bpfrecorderfakes.FakeImpl{}
+
+	const pid uint32 = 42
+
+	waitErr := make(chan error, 1)
+
+	go func() {
+		waitErr <- sut.WaitForPidExit(t.Context(), pid)
+	}()
+
+	// Let the waiter register, then churn the cache past its capacity and clear
+	// it, which is what StopRecording does.
+	require.Eventually(t, func() bool {
+		_, ok := sut.exitWaiters.Load(pid)
+
+		return ok
+	}, time.Minute, time.Millisecond)
+
+	for other := range uint32(maxCacheItems + 10) {
+		sut.recentExits.Set(other+1000, struct{}{}, ttlcache.DefaultTTL)
+	}
+
+	sut.recentExits.DeleteAll()
+
+	sut.handleExitEvent(&bpfEvent{Pid: pid, Type: uint8(eventTypeExit)})
+
+	select {
+	case err := <-waitErr:
+		require.NoError(t, err)
+	case <-time.After(time.Minute):
+		t.Fatal("waiter was not woken after the recorded exits were evicted")
+	}
+}
+
+// TestStopRecordingReleasesLookupTables asserts that the per-session lookup
+// tables are released once no recording is in progress any more.
+func TestStopRecordingReleasesLookupTables(t *testing.T) {
+	t.Parallel()
+
+	sut := New("", logr.Discard(), false, false)
+	mock := &bpfrecorderfakes.FakeImpl{}
+	sut.impl = mock
+
+	sut.mntnsToContainerIDMap.Insert(0x1010, "container-id")
+	sut.containerIDToProfileMap.Insert("container-id", "profile")
+	sut.handleExitEvent(&bpfEvent{Pid: 42, Type: uint8(eventTypeExit)})
+
+	require.Equal(t, 1, sut.mntnsToContainerIDMap.Size())
+	require.Equal(t, 1, sut.containerIDToProfileMap.Size())
+	require.Equal(t, 1, sut.recentExits.Len())
+
+	require.NoError(t, sut.StopRecording())
+
+	require.Equal(t, 0, sut.mntnsToContainerIDMap.Size())
+	require.Equal(t, 0, sut.containerIDToProfileMap.Size())
+	require.Equal(t, 0, sut.recentExits.Len())
+}
+
+// TestHandlerFromFinishedRecordingIsDiscarded asserts that a handler still in
+// flight when a recording stops cannot repopulate the lookup tables afterwards.
+func TestHandlerFromFinishedRecordingIsDiscarded(t *testing.T) {
+	t.Parallel()
+
+	sut := New("", logr.Discard(), false, false)
+	sut.impl = &bpfrecorderfakes.FakeImpl{}
+	sut.clientset = &kubernetes.Clientset{}
+
+	staleGeneration := sut.recordingGeneration.Load()
+
+	require.NoError(t, sut.StopRecording())
+
+	sut.handleNewPidEvent(42, 0x1010, staleGeneration)
+
+	require.Equal(t, 0, sut.mntnsToContainerIDMap.Size(),
+		"a handler from a finished recording must not repopulate the tables")
+}
+
+// TestWaitForPidExitWakesConcurrentWaiters asserts that every caller waiting on
+// the same pid is woken. Registering with Store rather than LoadOrStore used to
+// drop the earlier waiters, leaving them parked until their context expired.
+func TestWaitForPidExitWakesConcurrentWaiters(t *testing.T) {
+	t.Parallel()
+
+	sut := New("", logr.Discard(), true, true)
+	sut.impl = &bpfrecorderfakes.FakeImpl{}
+
+	const (
+		pid     uint32 = 42
+		waiters int    = 4
+	)
+
+	errs := make(chan error, waiters)
+
+	for range waiters {
+		go func() {
+			errs <- sut.WaitForPidExit(t.Context(), pid)
+		}()
+	}
+
+	// Wait until every caller is registered on the shared channel.
+	require.Eventually(t, func() bool {
+		waiter, ok := sut.exitWaiters.Load(pid)
+		if !ok {
+			return false
+		}
+
+		done, ok := waiter.(chan struct{})
+
+		return ok && done != nil
+	}, time.Minute, time.Millisecond)
+
+	sut.handleExitEvent(&bpfEvent{Pid: pid, Type: uint8(eventTypeExit)})
+
+	for range waiters {
+		select {
+		case err := <-errs:
+			require.NoError(t, err)
+		case <-time.After(time.Minute):
+			t.Fatal("a concurrent waiter was never woken")
+		}
+	}
+}
+
+// TestScheduleNewPidEventDropsWhenSaturated asserts that a full queue drops the
+// event instead of stalling the event processing loop. That loop also delivers
+// the AppArmor events, so blocking it makes the kernel drop recorded events.
+func TestScheduleNewPidEventDropsWhenSaturated(t *testing.T) {
+	t.Parallel()
+
+	logSink := &Logger{}
+	sut := New("", logr.New(logSink), true, true)
+	sut.impl = &bpfrecorderfakes.FakeImpl{}
+
+	// Fill the queue without starting the handlers.
+	sut.startPidHandlers.Do(func() {})
+
+	for range newPidQueueSize {
+		sut.newPidEvents <- newPidEvent{}
+	}
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		sut.scheduleNewPidEvent(42, 0x1010)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Minute):
+		t.Fatal("scheduleNewPidEvent blocked on a full queue")
+	}
+
+	logSink.mutex.RLock()
+	defer logSink.mutex.RUnlock()
+
+	require.Contains(t, logSink.messages,
+		"Dropping new pid event because the handler queue is full")
+}
+
+// TestScheduleNewPidEventRunsHandler asserts the normal path still dispatches.
+func TestScheduleNewPidEventRunsHandler(t *testing.T) {
+	t.Parallel()
+
+	logSink := &Logger{}
+	sut := New("", logr.New(logSink), true, true)
+	sut.impl = &bpfrecorderfakes.FakeImpl{}
+
+	sut.scheduleNewPidEvent(42, 0x1010)
+
+	require.Eventually(t, func() bool {
+		logSink.mutex.RLock()
+		defer logSink.mutex.RUnlock()
+
+		return slices.Contains(logSink.messages, "Received new pid")
+	}, time.Minute, time.Millisecond)
+}
+
 func TestHandleEvent(t *testing.T) {
 	t.Parallel()
 
@@ -899,7 +1103,7 @@ func TestNewPidEvent(t *testing.T) {
 
 		e := tc.prepare(sut, mock)
 
-		go sut.handleNewPidEvent(&e)
+		go sut.handleNewPidEvent(e.Pid, e.Mntns, sut.recordingGeneration.Load())
 
 		tc.assert(sut, logSink)
 	}

--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -294,7 +294,7 @@ func (r *Reconciler) checkSeccomp() error {
 
 // OpenShift ... This is ignored in other distros
 //nolint:lll // required for kubebuilder
-// +kubebuilder:rbac:groups=security.openshift.io,namespace="security-profiles-operator",resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups=security.openshift.io,namespace="security-profiles-operator",resourceNames=privileged,resources=securitycontextconstraints,verbs=use
 
 // Reconcile reconciles a SeccompProfile.
 func (r *Reconciler) Reconcile(

--- a/internal/pkg/manager/spod/spod_controller.go
+++ b/internal/pkg/manager/spod/spod_controller.go
@@ -125,7 +125,8 @@ func (r *ReconcileSPOd) Healthz(*http.Request) error {
 // +kubebuilder:rbac:groups=monitoring.coreos.com,resources=servicemonitors,verbs=get;list;watch;create;update;patch
 //
 // OpenShift (This is ignored in other distros):
-// +kubebuilder:rbac:groups=security.openshift.io,namespace="security-profiles-operator",resources=securitycontextconstraints,verbs=use
+//nolint:lll // required for kubebuilder
+// +kubebuilder:rbac:groups=security.openshift.io,namespace="security-profiles-operator",resourceNames=privileged,resources=securitycontextconstraints,verbs=use
 // +kubebuilder:rbac:groups=config.openshift.io,resources=clusteroperators,verbs=get;list;watch
 // +kubebuilder:rbac:groups=config.openshift.io,resources=apiservers,verbs=get;list;watch
 //
@@ -540,6 +541,22 @@ func (r *ReconcileSPOd) handleUpdate(
 	return nil
 }
 
+// baseContainer returns a deep copy of the base SPOd container with the given
+// index. Copying is required because the base SPOd is long lived and shared
+// across reconciliations, while its containers carry pointer fields (most
+// importantly SecurityContext) which the rendering below mutates. Handing out
+// the base container directly would persist per-reconciliation configuration
+// into the base and make it impossible to ever revert it.
+func (r *ReconcileSPOd) baseContainer(id int) corev1.Container {
+	return *r.baseSPOd.Spec.Template.Spec.Containers[id].DeepCopy()
+}
+
+// baseInitContainer returns a deep copy of the base SPOd init container with
+// the given index. See baseContainer for why the copy is required.
+func (r *ReconcileSPOd) baseInitContainer(id int) corev1.Container {
+	return *r.baseSPOd.Spec.Template.Spec.InitContainers[id].DeepCopy()
+}
+
 // getConfiguredSPOd gets a fully configured SPOd instance from a desired
 // configuration and the reference base SPOd.
 //
@@ -558,12 +575,12 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 	templateSpec := &newSPOd.Spec.Template.Spec
 
 	templateSpec.InitContainers = []corev1.Container{
-		r.baseSPOd.Spec.Template.Spec.InitContainers[bindata.InitContainerIDNonRootenabler],
+		r.baseInitContainer(bindata.InitContainerIDNonRootenabler),
 	}
 	// Set Images
 	// Base workload
 	templateSpec.Containers = []corev1.Container{
-		r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDDaemon],
+		r.baseContainer(bindata.ContainerIDDaemon),
 	}
 	templateSpec.Containers[bindata.ContainerIDDaemon].Image = image
 
@@ -593,11 +610,11 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 	if enableSelinux {
 		templateSpec.InitContainers = append(
 			templateSpec.InitContainers,
-			r.baseSPOd.Spec.Template.Spec.InitContainers[bindata.InitContainerIDSelinuxSharedPoliciesCopier],
+			r.baseInitContainer(bindata.InitContainerIDSelinuxSharedPoliciesCopier),
 		)
 		templateSpec.Containers = append(
 			templateSpec.Containers,
-			r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDSelinuxd])
+			r.baseContainer(bindata.ContainerIDSelinuxd))
 
 		templateSpec.Containers[bindata.ContainerIDDaemon].VolumeMounts = append(
 			templateSpec.Containers[bindata.ContainerIDDaemon].VolumeMounts,
@@ -658,32 +675,28 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 		fmt.Sprintf("--with-recording=%t", enableRecording))
 
 	if isLogEnricherEnabled(cfg) {
-		ctr := r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDLogEnricher]
+		ctr := r.baseContainer(bindata.ContainerIDLogEnricher)
 		ctr.Image = image
 
 		if useCustomHostProc {
 			ctr.VolumeMounts = append(ctr.VolumeMounts, mount)
 		}
+
+		r.configureLogEnricher(cfg, &ctr)
 
 		templateSpec.Containers = append(templateSpec.Containers, ctr)
 		// pass the log enricher env var to the daemon as the profile recorder is otherwise disabled
 		addEnvVar(templateSpec, config.EnableLogEnricherEnvKey)
-
-		r.getConfiguredLogEnricher(cfg)
 	}
 
 	// Bpf recorder parameters
 	if isBpfRecorderEnabled(cfg) {
-		ctr := r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDBpfRecorder]
+		ctr := r.baseContainer(bindata.ContainerIDBpfRecorder)
 		ctr.Image = image
 
 		if useCustomHostProc {
 			ctr.VolumeMounts = append(ctr.VolumeMounts, mount)
 		}
-
-		templateSpec.Containers = append(templateSpec.Containers, ctr)
-		// pass the bpf recorder env var to the daemon as the profile recorder is otherwise disabled
-		addEnvVar(templateSpec, config.EnableBpfRecorderEnvKey)
 
 		// Configure the apparmor profile for bpf-recorder when apparmor is enabled.
 		if ptr.Deref(cfg.Spec.EnableAppArmor, false) {
@@ -693,10 +706,14 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 				LocalhostProfile: &localApparmorProfile,
 			}
 		}
+
+		templateSpec.Containers = append(templateSpec.Containers, ctr)
+		// pass the bpf recorder env var to the daemon as the profile recorder is otherwise disabled
+		addEnvVar(templateSpec, config.EnableBpfRecorderEnvKey)
 	}
 
 	if isJsonEnricherEnabled(cfg) {
-		ctr := r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDJsonEnricher]
+		ctr := r.baseContainer(bindata.ContainerIDJsonEnricher)
 		ctr.Image = image
 
 		if useCustomHostProc {
@@ -748,11 +765,11 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 			}
 		}
 
+		r.configureJsonEnricher(cfg, &ctr)
+
 		templateSpec.Containers = append(templateSpec.Containers, ctr)
 		// pass the json enricher env var to the daemon as the profile recorder is otherwise disabled
 		addEnvVar(templateSpec, config.EnableJsonEnricherEnvKey)
-
-		r.getConfiguredJsonEnricher(cfg)
 	}
 
 	// AppArmor parameters
@@ -874,13 +891,16 @@ func (r *ReconcileSPOd) getConfiguredSPOd(
 	return newSPOd, nil
 }
 
-func (r *ReconcileSPOd) getConfiguredLogEnricher(cfg *spodapi.SecurityProfilesOperatorDaemon) {
+// configureLogEnricher applies the log enricher configuration to ctr.
+func (r *ReconcileSPOd) configureLogEnricher(
+	cfg *spodapi.SecurityProfilesOperatorDaemon, ctr *corev1.Container,
+) {
 	if cfg.Spec.Enricher.LogEnricherFilters != "" {
 		r.log.Info("Setting LogEnricherFilters",
 			"LogEnricherFilters", cfg.Spec.Enricher.LogEnricherFilters)
 
-		r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDLogEnricher].Args = addArgsConfig(
-			r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDLogEnricher].Args,
+		ctr.Args = addArgsConfig(
+			ctr.Args,
 			"--enricher-filters-json="+cfg.Spec.Enricher.LogEnricherFilters,
 		)
 	}
@@ -892,77 +912,63 @@ func (r *ReconcileSPOd) getConfiguredLogEnricher(cfg *spodapi.SecurityProfilesOp
 			cfg.Spec.Enricher.LogEnricherSource,
 		)
 
-		r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDLogEnricher].Args = addArgsConfig(
-			r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDLogEnricher].Args,
+		ctr.Args = addArgsConfig(
+			ctr.Args,
 			"--enricher-log-source="+string(cfg.Spec.Enricher.LogEnricherSource),
 		)
 	}
 }
 
-func (r *ReconcileSPOd) getConfiguredJsonEnricher(cfg *spodapi.SecurityProfilesOperatorDaemon) {
+// configureJsonEnricher applies the JSON enricher configuration to ctr.
+func (r *ReconcileSPOd) configureJsonEnricher(
+	cfg *spodapi.SecurityProfilesOperatorDaemon, ctr *corev1.Container,
+) {
 	if cfg.Spec.Enricher.JsonEnricherFilters != "" {
-		r.log.Info("Setting LogEnricherFilters",
+		r.log.Info("Setting JsonEnricherFilters",
 			"JsonEnricherFilters", cfg.Spec.Enricher.JsonEnricherFilters)
 
-		r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDJsonEnricher].Args = addArgsConfig(
-			r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDJsonEnricher].Args,
+		ctr.Args = addArgsConfig(
+			ctr.Args,
 			"--enricher-filters-json="+cfg.Spec.Enricher.JsonEnricherFilters,
 		)
 	}
 
-	if cfg.Spec.Enricher.JsonEnricherOptions != nil {
-		r.log.Info(
-			"Setting JsonEnricherOpt",
-			"AuditLogIntervalSeconds",
-			cfg.Spec.Enricher.JsonEnricherOptions.AuditLogIntervalSeconds,
-			"AuditLogPath",
-			cfg.Spec.Enricher.JsonEnricherOptions.AuditLogPath,
-			"AuditLogMaxAge",
-			cfg.Spec.Enricher.JsonEnricherOptions.AuditLogMaxAge,
-			"AuditLogMaxSize",
-			cfg.Spec.Enricher.JsonEnricherOptions.AuditLogMaxSize,
-			"AuditLogMaxBackups",
-			cfg.Spec.Enricher.JsonEnricherOptions.AuditLogMaxBackups,
-		)
+	opts := cfg.Spec.Enricher.JsonEnricherOptions
+	if opts == nil {
+		return
+	}
 
-		if cfg.Spec.Enricher.JsonEnricherOptions.AuditLogIntervalSeconds != nil {
-			r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDJsonEnricher].Args = addArgsConfig(
-				r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDJsonEnricher].Args,
-				fmt.Sprintf("--audit-log-interval-seconds=%d",
-					*cfg.Spec.Enricher.JsonEnricherOptions.AuditLogIntervalSeconds),
-			)
-		}
+	r.log.Info(
+		"Setting JsonEnricherOpt",
+		"AuditLogIntervalSeconds", opts.AuditLogIntervalSeconds,
+		"AuditLogPath", opts.AuditLogPath,
+		"AuditLogMaxAge", opts.AuditLogMaxAge,
+		"AuditLogMaxSize", opts.AuditLogMaxSize,
+		"AuditLogMaxBackups", opts.AuditLogMaxBackups,
+	)
 
-		if cfg.Spec.Enricher.JsonEnricherOptions.AuditLogMaxAge != nil {
-			r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDJsonEnricher].Args = addArgsConfig(
-				r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDJsonEnricher].Args,
-				fmt.Sprintf("--audit-log-maxage=%d",
-					*cfg.Spec.Enricher.JsonEnricherOptions.AuditLogMaxAge),
-			)
-		}
+	if opts.AuditLogIntervalSeconds != nil {
+		ctr.Args = addArgsConfig(ctr.Args,
+			fmt.Sprintf("--audit-log-interval-seconds=%d", *opts.AuditLogIntervalSeconds))
+	}
 
-		if cfg.Spec.Enricher.JsonEnricherOptions.AuditLogMaxSize != nil {
-			r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDJsonEnricher].Args = addArgsConfig(
-				r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDJsonEnricher].Args,
-				fmt.Sprintf("--audit-log-maxsize=%d",
-					*cfg.Spec.Enricher.JsonEnricherOptions.AuditLogMaxSize),
-			)
-		}
+	if opts.AuditLogMaxAge != nil {
+		ctr.Args = addArgsConfig(ctr.Args,
+			fmt.Sprintf("--audit-log-maxage=%d", *opts.AuditLogMaxAge))
+	}
 
-		if cfg.Spec.Enricher.JsonEnricherOptions.AuditLogMaxBackups != nil {
-			r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDJsonEnricher].Args = addArgsConfig(
-				r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDJsonEnricher].Args,
-				fmt.Sprintf("--audit-log-maxbackup=%d",
-					*cfg.Spec.Enricher.JsonEnricherOptions.AuditLogMaxBackups),
-			)
-		}
+	if opts.AuditLogMaxSize != nil {
+		ctr.Args = addArgsConfig(ctr.Args,
+			fmt.Sprintf("--audit-log-maxsize=%d", *opts.AuditLogMaxSize))
+	}
 
-		if cfg.Spec.Enricher.JsonEnricherOptions.AuditLogPath != nil {
-			r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDJsonEnricher].Args = addArgsConfig(
-				r.baseSPOd.Spec.Template.Spec.Containers[bindata.ContainerIDJsonEnricher].Args,
-				"--audit-log-path="+(*cfg.Spec.Enricher.JsonEnricherOptions.AuditLogPath),
-			)
-		}
+	if opts.AuditLogMaxBackups != nil {
+		ctr.Args = addArgsConfig(ctr.Args,
+			fmt.Sprintf("--audit-log-maxbackup=%d", *opts.AuditLogMaxBackups))
+	}
+
+	if opts.AuditLogPath != nil {
+		ctr.Args = addArgsConfig(ctr.Args, "--audit-log-path="+*opts.AuditLogPath)
 	}
 }
 

--- a/internal/pkg/manager/spod/spod_controller_test.go
+++ b/internal/pkg/manager/spod/spod_controller_test.go
@@ -17,12 +17,13 @@ limitations under the License.
 package spod
 
 import (
-	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	appsv1 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/utils/ptr"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	spodapi "sigs.k8s.io/security-profiles-operator/api/spod/v1"
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/manager/spod/bindata"
@@ -47,7 +48,16 @@ func Test_addAuditLogConfig(t *testing.T) {
 	require.NotContains(t, args, "planet=earth")
 }
 
-func Test_getConfiguredJsonEnricher(t *testing.T) {
+func newTestReconciler() *ReconcileSPOd {
+	return &ReconcileSPOd{
+		baseSPOd:  bindata.Manifest.DeepCopy(),
+		record:    record.NewFakeRecorder(100),
+		log:       logf.Log,
+		namespace: "security-profiles-operator",
+	}
+}
+
+func Test_configureJsonEnricher(t *testing.T) {
 	t.Parallel()
 
 	valTen := int32(10)
@@ -68,35 +78,14 @@ func Test_getConfiguredJsonEnricher(t *testing.T) {
 		},
 	}
 
-	r := &ReconcileSPOd{
-		baseSPOd: &appsv1.DaemonSet{
-			Spec: appsv1.DaemonSetSpec{
-				Template: v1.PodTemplateSpec{
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{
-							{},
-							{},
-							{},
-							{},
-							{
-								Name: "test",
-								Args: []string{},
-							},
-						},
-					},
-				},
-			},
-		},
-	}
+	ctr := v1.Container{Name: "json-enricher"}
+	newTestReconciler().configureJsonEnricher(cfg, &ctr)
 
-	r.getConfiguredJsonEnricher(cfg)
-	require.True(t, containsString(r.baseSPOd.Spec.Template.Spec.Containers[4].Args,
-		"--audit-log-interval-seconds=60"))
-	require.True(t, containsString(r.baseSPOd.Spec.Template.Spec.Containers[4].Args,
-		"--audit-log-maxsize=10"))
+	require.Contains(t, ctr.Args, "--audit-log-interval-seconds=60")
+	require.Contains(t, ctr.Args, "--audit-log-maxsize=10")
 }
 
-func Test_getConfiguredJsonEnricherNilInterval(t *testing.T) {
+func Test_configureJsonEnricherNilInterval(t *testing.T) {
 	t.Parallel()
 
 	valTen := int32(10)
@@ -113,35 +102,126 @@ func Test_getConfiguredJsonEnricherNilInterval(t *testing.T) {
 		},
 	}
 
-	r := &ReconcileSPOd{
-		baseSPOd: &appsv1.DaemonSet{
-			Spec: appsv1.DaemonSetSpec{
-				Template: v1.PodTemplateSpec{
-					Spec: v1.PodSpec{
-						Containers: []v1.Container{
-							{},
-							{},
-							{},
-							{},
-							{
-								Name: "test",
-								Args: []string{},
-							},
-						},
-					},
-				},
+	ctr := v1.Container{Name: "json-enricher"}
+	newTestReconciler().configureJsonEnricher(cfg, &ctr)
+
+	for _, arg := range ctr.Args {
+		require.NotContains(t, arg, "--audit-log-interval-seconds")
+	}
+
+	require.Contains(t, ctr.Args, "--audit-log-maxsize=10")
+}
+
+// Test_getConfiguredSPOdDoesNotMutateBase asserts that rendering the SPOd
+// leaves the long lived base SPOd untouched. Rendering used to write through
+// to the base, which made enabling AppArmor irreversible.
+func Test_getConfiguredSPOdDoesNotMutateBase(t *testing.T) {
+	t.Parallel()
+
+	r := newTestReconciler()
+	before := r.baseSPOd.DeepCopy()
+
+	cfg := &spodapi.SecurityProfilesOperatorDaemon{
+		Spec: spodapi.SPODSpec{
+			EnableAppArmor:  new(true),
+			EnableProfiling: new(true),
+			Verbosity:       1,
+			Selinux: spodapi.SPODSelinuxConfig{
+				Enable:  new(true),
+				TypeTag: "unconfined_t",
 			},
 		},
 	}
 
-	r.getConfiguredJsonEnricher(cfg)
+	_, err := r.getConfiguredSPOd(
+		t.Context(), cfg, "image", v1.PullAlways, bindata.CAInjectTypeCertManager,
+	)
+	require.NoError(t, err)
+	require.Equal(t, before, r.baseSPOd, "rendering must not mutate the base SPOd")
+}
 
-	for _, arg := range r.baseSPOd.Spec.Template.Spec.Containers[4].Args {
-		require.NotContains(t, arg, "--audit-log-interval-seconds")
+// Test_getConfiguredSPOdAppArmorIsRevertible asserts that disabling AppArmor
+// drops the elevated privileges the AppArmor code path grants to the daemon.
+func Test_getConfiguredSPOdAppArmorIsRevertible(t *testing.T) {
+	t.Parallel()
+
+	r := newTestReconciler()
+
+	render := func(apparmor bool) *v1.SecurityContext {
+		t.Helper()
+
+		cfg := &spodapi.SecurityProfilesOperatorDaemon{
+			Spec: spodapi.SPODSpec{EnableAppArmor: &apparmor},
+		}
+
+		ds, err := r.getConfiguredSPOd(
+			t.Context(), cfg, "image", v1.PullAlways, bindata.CAInjectTypeCertManager,
+		)
+		require.NoError(t, err)
+
+		return ds.Spec.Template.Spec.Containers[bindata.ContainerIDDaemon].SecurityContext
 	}
 
-	require.True(t, containsString(r.baseSPOd.Spec.Template.Spec.Containers[4].Args,
-		"--audit-log-maxsize=10"))
+	off := render(false)
+	require.False(t, ptr.Deref(off.Privileged, false))
+	require.True(t, ptr.Deref(off.ReadOnlyRootFilesystem, false))
+
+	on := render(true)
+	require.True(t, ptr.Deref(on.Privileged, false))
+	require.False(t, ptr.Deref(on.ReadOnlyRootFilesystem, true))
+
+	// Turning AppArmor back off must restore the unprivileged security context.
+	again := render(false)
+	require.False(t, ptr.Deref(again.Privileged, false),
+		"daemon must not stay privileged after AppArmor is disabled")
+	require.False(t, ptr.Deref(again.AllowPrivilegeEscalation, false))
+	require.True(t, ptr.Deref(again.ReadOnlyRootFilesystem, false))
+	require.Equal(t, off.RunAsUser, again.RunAsUser)
+}
+
+// Test_getConfiguredSPOdEnricherArgsAreRevertible asserts that removing an
+// enricher option from the SPOD removes the corresponding argument again.
+func Test_getConfiguredSPOdEnricherArgsAreRevertible(t *testing.T) {
+	t.Parallel()
+
+	r := newTestReconciler()
+
+	render := func(filters string) []string {
+		t.Helper()
+
+		cfg := &spodapi.SecurityProfilesOperatorDaemon{
+			Spec: spodapi.SPODSpec{
+				Enricher: spodapi.SPODEnricherConfig{
+					EnableLogEnricher:  new(true),
+					LogEnricherFilters: filters,
+				},
+			},
+		}
+
+		ds, err := r.getConfiguredSPOd(
+			t.Context(), cfg, "image", v1.PullAlways, bindata.CAInjectTypeCertManager,
+		)
+		require.NoError(t, err)
+
+		for i := range ds.Spec.Template.Spec.Containers {
+			ctr := &ds.Spec.Template.Spec.Containers[i]
+			if ctr.Name == bindata.LogEnricherContainerName {
+				return ctr.Args
+			}
+		}
+
+		t.Fatal("log enricher container not rendered")
+
+		return nil
+	}
+
+	// The filter must be applied on the very first render, not one
+	// reconciliation later.
+	require.Contains(t, render(`{"a":1}`), `--enricher-filters-json={"a":1}`)
+
+	for _, arg := range render("") {
+		require.NotContains(t, arg, "--enricher-filters-json")
+	}
 }
 
 func Test_addSelinuxCustomTemplatesVolumeEmpty(t *testing.T) {
@@ -295,8 +375,4 @@ func Test_webhookTolerationsFallback(t *testing.T) {
 			require.Equal(t, tc.expected, tolerations)
 		})
 	}
-}
-
-func containsString(slice []string, element string) bool {
-	return slices.Contains(slice, element)
 }

--- a/internal/pkg/webhooks/binding/binding.go
+++ b/internal/pkg/webhooks/binding/binding.go
@@ -109,7 +109,7 @@ func initContainerMap(m *sync.Map, spec *corev1.PodSpec) {
 
 // OpenShift (This is ignored in other distros):
 //nolint:lll // required for kubebuilder
-// +kubebuilder:rbac:groups=security.openshift.io,namespace=security-profiles-operator,resources=securitycontextconstraints,verbs=use
+// +kubebuilder:rbac:groups=security.openshift.io,namespace=security-profiles-operator,resourceNames=privileged,resources=securitycontextconstraints,verbs=use
 
 //nolint:gocritic
 func (p *podBinder) Handle(ctx context.Context, req admission.Request) admission.Response {

--- a/metrics.md
+++ b/metrics.md
@@ -3,6 +3,7 @@
 <!-- toc -->
 - [Metrics](#metrics)
   - [Available metrics](#available-metrics)
+  - [Metric cardinality](#metric-cardinality)
   - [Automatic ServiceMonitor deployment](#automatic-servicemonitor-deployment)
 <!-- /toc -->
 
@@ -105,6 +106,37 @@ additional metrics are provided by the daemon, which are always prefixed with
 | `apparmor_profile_audit_total` | `node`, `namespace`, `pod`, `container`, `profile`, `operation`, `apparmor`                                                                                                                                | Counter | Amount of AppArmor profile audit operations. Requires the log-enricher to be enabled. |
 | `apparmor_profile_error_total` | `profile`, `reason={`<br>`AppArmorNotSupportedOnNode,`<br>`CannotLoadAppArmorProfile,`<br>`CannotUnloadAppArmorProfile,`<br>`CannotUpdateAppArmorProfile,`<br>`CannotUpdateNodeStatus`<br>`}`               | Counter | Amount of AppArmor profile errors.                                                   |
 | `apparmor_profile_denial_total`| `profile`, `operation`                                                                                                                                                                                     | Counter | Amount of AppArmor profile denials.                                                  |
+
+### Metric cardinality
+
+The `*_audit_total` metrics and `seccomp_profile_bpf_total` are labeled per
+workload. Their label sets contain values which change constantly on a busy
+cluster:
+
+- `pod` is unique per pod and turns over on every restart, rollout or job run
+- `syscall` has a few hundred possible values
+- `mount_namespace` is a raw kernel identifier, unique per container
+
+Every observed label combination becomes a distinct Prometheus time series which
+is kept for as long as the process lives, both in the spod DaemonSet and in
+Prometheus. On clusters with a lot of pod churn, or when the log enricher is
+enabled cluster wide, this adds up quickly.
+
+These metrics are most useful while recording or debugging a workload. If you
+scrape them permanently, consider dropping the high cardinality labels in the
+scrape config, for example:
+
+```yaml
+metricRelabelings:
+  - sourceLabels: [__name__]
+    regex: security_profiles_operator_.*_audit_total
+    targetLabel: pod
+    replacement: ""
+    action: replace
+```
+
+Alternatively, restrict the log enricher to the namespaces you are actively
+recording via `spec.enricher.logEnricherFilters`.
 
 ### Automatic ServiceMonitor deployment
 

--- a/security-model.md
+++ b/security-model.md
@@ -108,4 +108,37 @@ A high-level summary of object types accessed outside the `security-profiles-ope
 
 For the most up-to-date rbac requirements refer to the materialised [role.yaml](deploy/base/role.yaml) file.
 
+## OCI artifact signature verification
+
+Base profiles can be distributed as OCI artifacts and are signature verified on
+pull. Verification is controlled through the `spod` resource:
+
+```yaml
+spec:
+  security:
+    disableOciArtifactSignatureVerification: false
+    allowedIdentityRegexp: ".*"
+    allowedOidcIssuerRegexp: ".*"
+```
+
+The shipped defaults for `allowedIdentityRegexp` and `allowedOidcIssuerRegexp`
+match any value. With those defaults a signature is accepted regardless of who
+produced it, which only proves that the artifact was signed by somebody. An
+attacker able to publish to the referenced registry can sign with their own
+Fulcio identity and pass verification.
+
+Constrain both fields to the signers you actually trust, for example:
+
+```yaml
+spec:
+  security:
+    allowedIdentityRegexp: "^https://github\\.com/my-org/my-profiles/"
+    allowedOidcIssuerRegexp: "^https://token\\.actions\\.githubusercontent\\.com$"
+```
+
+The operator logs a warning when it recognises an unconstrained signer pattern,
+such as the shipped default, so an unintentionally permissive configuration is
+visible in the spod logs. That detection is best effort: an arbitrary regexp
+which happens to accept everything cannot be recognised as such.
+
 [least privilege principle]: https://en.wikipedia.org/wiki/Principle_of_least_privilege


### PR DESCRIPTION
#### What type of PR is this?

/kind bug
/kind cleanup

#### What this PR does / why we need it:

Rendering the SPOd read its containers straight out of the long lived `baseSPOd` instead of the per-reconciliation deep copy. Container structs share their pointer fields, so every mutation wrote back into the base:

- Enabling AppArmor permanently marked the daemon privileged, with `AllowPrivilegeEscalation` set, a writable root filesystem and uid 0. Disabling it again never reverted any of that, so the privilege downgrade silently did not happen until the operator pod restarted.
- Enricher options were appended to the base, so removing an option from the SPOD kept passing it, and a newly set option only reached the DaemonSet on the following reconciliation.

The bpf recorder leaked for the lifetime of the daemon: exited PIDs were remembered forever even though only `spoc` ever waits for one, and the mntns and profile lookup tables were never released.

New pid events also spawned a goroutine each, so a fork heavy workload could grow the backlog until the recorder hit its 256Mi limit. They are now queued for a fixed pool of handlers. The queue is bounded, because that backlog is the leak, and the enqueue never blocks, because the caller is the single event processing loop which also delivers the AppArmor events over an unbuffered channel: stalling it back pressures the ring buffer and makes the kernel drop recorded events. Handlers carry the generation of the recording they were queued in and skip their writes once it ends, so one still in flight cannot repopulate the tables behind `StopRecording`.

Also in here:

- restrict the daemon pod cache to the local node, matching what the profile recorder already filters for. Every node used to hold every pod in the cluster.
- reject `..` as a profile path segment. `filepath.Base` maps `../..` onto `..`, which `path.Join` then resolves into the parent directory.
- warn when OCI signature verification runs with an unconstrained signer, and document what the `.*` defaults actually accept.
- scope the OpenShift `securitycontextconstraints` grants to `privileged`.
- return an error instead of calling `os.Exit` from the merger.
- CI gained a Linux lint job, the remaining `verify` targets and a govulncheck job. Linting only ran on macOS, which excludes the seccomp, apparmor and bpf build tags and with them about 12.7k lines. govulncheck fails on vulnerabilities that have an upstream fix and reports the rest without failing, so the three currently unfixable cosign chain findings do not block CI.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Yes. Regression tests for the aliasing, the enricher ordering, the exits cache bound and the lookup table release, plus new coverage for the seccomp profile path helpers and `BiMap.Clear`. Each regression test was checked to fail against the pre-fix code. `make test-unit` now also covers `./api/...` and `./cmd/...`, and `.codecov.yml` ignores generated code so the reported number reflects hand written code.

#### Special notes for your reviewer:

Opened as a draft because it is a large diff. Happy to split it into separate PRs (SPOd rendering, bpf recorder, CI, docs) if that reviews better.

The OLM bundle under `bundle/` keeps the unrestricted `securitycontextconstraints` grant until the next release, since `make bundle` is a release step and regenerating it here would pull in unrelated drift (`containerImage`, `olm.skipRange`, operator-sdk version). So OLM installs get the hardening one release later than the kustomize and helm ones.

The AppArmor behaviour is easiest to see in `Test_getConfiguredSPOdAppArmorIsRevertible`, which renders on, off and on again.

Three reachable vulnerabilities with no upstream fix are reported by the new govulncheck job (`GO-2026-4529`, `GO-2026-5932`, `GO-2026-6225`), all through the cosign dependency chain. Not addressed here since there is nothing to bump to.

#### Does this PR introduce a user-facing change?

```release-note
Fixed the SPOd daemon staying privileged with a writable root filesystem after AppArmor was disabled again, and enricher options not being removable once set. The spod daemon now only caches pods of its own node, and the bpf recorder no longer grows its internal state for the lifetime of the daemon.
```
