### PR TITLE
Publish the KEP-6061 test artifacts and cover the runtime format in e2e

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -287,6 +287,10 @@ update-go-mod: ## Cleanup, vendor and verify go modules
 		$(GO) mod vendor && \
 		$(GO) mod verify
 
+.PHONY: push-test-artifacts
+push-test-artifacts: $(BUILD_DIR)/$(CLI_BINARY) ## Push the KEP-6061 e2e test artifacts to the staging registry
+	./hack/push-test-artifacts.sh
+
 .PHONY: update-mocks
 update-mocks: ## Update all generated mocks
 	$(GO) generate ./...

--- a/cli.md
+++ b/cli.md
@@ -221,9 +221,12 @@ Pushing signature to: ghcr.io/security-profiles/crun
 ```
 
 We can specify a username and password in the same way as for `spoc pull`.
-Please also note that signing is always required for push and pull. It is
-possible to add custom annotations to the security profile by using the
-`--annotations` / `-a` flag multiple times in `KEY:VALUE` format.
+Artifacts are signed on push and verified on pull by default. Keyless signing
+needs an OIDC identity, which build systems and test environments do not
+necessarily have, so `--disable-signing` skips it. Consumers of an unsigned
+artifact have to skip verification as well. It is possible to add custom
+annotations to the security profile by using the `--annotations` / `-a` flag
+multiple times in `KEY:VALUE` format.
 
 ### Pushing profiles for container runtimes
 
@@ -235,6 +238,10 @@ differs from the profile CRD artifacts above, which keep the generic
 `application/vnd.unknown.config.v1+json` artifact type together with the empty
 OCI config descriptor, and are used by the operator for `oci://` base
 profiles.
+
+The profiles the Kubernetes end-to-end tests for KEP-6061 consume are pushed
+from this repository by `make push-test-artifacts`, which also converts the
+recorded runtime base profiles into the runtime format.
 
 `spoc push` produces the runtime format automatically when the input file is a
 raw runtime-spec seccomp profile in JSON, for example the output of

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -17,6 +17,21 @@ steps:
       echo '{"default": [{"type": "insecureAcceptAnything"}]}' > /etc/containers/policy.json && \
       gcloud auth configure-docker && \
       make image-cross
+  - name: gcr.io/k8s-staging-test-infra/gcb-docker-gcloud:v20260205-38cfa9523f
+    entrypoint: bash
+    env:
+      - REGISTRY=gcr.io/$PROJECT_ID
+      - USERNAME=oauth2accesstoken
+    args:
+    - -c
+    - |
+      IMAGE=gcr.io/k8s-staging-sp-operator/security-profiles-operator-amd64:$_GIT_TAG && \
+      CONTAINER=$$(docker create $$IMAGE) && \
+      mkdir -p build && \
+      docker cp $$CONTAINER:/spoc build/spoc && \
+      docker rm $$CONTAINER && \
+      PASSWORD=$$(gcloud auth print-access-token) \
+      ./hack/push-test-artifacts.sh
 substitutions:
   # _GIT_TAG will be filled with a git-based tag for the image, of the form
   # vYYYYMMDD-hash, and can be used as a substitution

--- a/cmd/spoc/main.go
+++ b/cmd/spoc/main.go
@@ -207,6 +207,11 @@ func main() {
 						spocli.EnvKeyPassword,
 					),
 				},
+				&cli.BoolFlag{
+					Name: pusher.FlagDisableSigning,
+					Usage: "do not sign the artifact after pushing it, " +
+						"for environments without an OIDC identity",
+				},
 				&cli.StringSliceFlag{
 					Name:    pusher.FlagPlatforms,
 					Aliases: []string{"p"},

--- a/examples/test-profiles/deny-chmod.json
+++ b/examples/test-profiles/deny-chmod.json
@@ -1,0 +1,10 @@
+{
+  "defaultAction": "SCMP_ACT_ALLOW",
+  "syscalls": [
+    {
+      "names": ["chmod", "fchmod", "fchmodat"],
+      "action": "SCMP_ACT_ERRNO",
+      "errnoRet": 1
+    }
+  ]
+}

--- a/examples/test-profiles/invalid.json
+++ b/examples/test-profiles/invalid.json
@@ -1,0 +1,10 @@
+{
+  "defaultAction": "SCMP_ACT_ALLOW",
+  "listenerPath": "/run/seccomp-listener.sock",
+  "syscalls": [
+    {
+      "names": ["mount"],
+      "action": "SCMP_ACT_NOTIFY"
+    }
+  ]
+}

--- a/examples/test-profiles/permissive.json
+++ b/examples/test-profiles/permissive.json
@@ -1,0 +1,3 @@
+{
+  "defaultAction": "SCMP_ACT_ALLOW"
+}

--- a/hack/push-test-artifacts.sh
+++ b/hack/push-test-artifacts.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Copyright The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Pushes the seccomp profiles used by the Kubernetes e2e_node tests for
+# KEP-6061 as OCI artifacts. The artifacts are pushed unsigned because build
+# systems have no OIDC identity, and are promoted to registry.k8s.io from the
+# staging registry afterwards.
+
+set -euo pipefail
+
+BUILD_DIR="${BUILD_DIR:-build}"
+SPOC="${SPOC:-$BUILD_DIR/spoc}"
+REGISTRY="${REGISTRY:-gcr.io/k8s-staging-sp-operator}"
+REPOSITORY="${REPOSITORY:-seccomp-test-profiles}"
+EXAMPLES="${EXAMPLES:-examples/test-profiles}"
+
+# Larger than the 1 MiB an artifact may have by default, to test the runtime
+# size limit. Generated rather than committed to keep the repository small.
+oversized="$BUILD_DIR/oversized.json"
+mkdir -p "$BUILD_DIR"
+{
+  printf '{"defaultAction":"SCMP_ACT_ALLOW","syscalls":[{"action":"SCMP_ACT_ERRNO","names":['
+  for i in $(seq 1 60000); do
+    if [[ $i -gt 1 ]]; then printf ','; fi
+    printf '"syscall_that_does_not_exist_%d"' "$i"
+  done
+  printf ']}]}'
+} > "$oversized"
+
+push() {
+  local file="$1" tag="$2"
+  echo "Pushing $file as $REGISTRY/$REPOSITORY:$tag"
+  "$SPOC" push --disable-signing -f "$file" "$REGISTRY/$REPOSITORY:$tag"
+}
+
+push "$EXAMPLES/deny-chmod.json" deny-chmod
+push "$EXAMPLES/permissive.json" permissive
+push "$EXAMPLES/invalid.json" invalid
+push "$oversized" oversized
+
+# The recorded runtime base profiles in the runtime format, so that they can
+# serve as oci:// base profiles for the operator's own end-to-end tests.
+for runtime in runc crun; do
+  converted="$BUILD_DIR/baseprofile-$runtime.json"
+  "$SPOC" convert -o "$converted" "examples/baseprofile-$runtime.yaml"
+  push "$converted" "baseprofile-$runtime"
+done
+
+echo
+echo "Add the digests logged above to images.yaml in kubernetes/k8s.io under"
+echo "registry.k8s.io/images/k8s-staging-sp-operator to promote them."

--- a/internal/pkg/artifact/artifact.go
+++ b/internal/pkg/artifact/artifact.go
@@ -124,6 +124,14 @@ type PullSignatureOptions struct {
 	AllowedOidcIssuerRegexp string
 }
 
+// PushSignatureOptions options for signing the OCI artifact during pushing.
+type PushSignatureOptions struct {
+	// DisableSigning skips signing the artifact after it has been pushed.
+	// Keyless signing needs an OIDC identity, which build systems and test
+	// environments do not necessarily have.
+	DisableSigning bool
+}
+
 // New returns a new Artifact instance.
 func New(logger logr.Logger) *Artifact {
 	return &Artifact{
@@ -137,6 +145,7 @@ func (a *Artifact) Push(
 	files map[*v1.Platform]string,
 	to, username, password string,
 	annotations map[string]string,
+	signOpts *PushSignatureOptions,
 ) error {
 	dir, err := a.MkdirTemp("", "push-")
 	if err != nil {
@@ -258,6 +267,14 @@ func (a *Artifact) Push(
 	descriptor, err := a.Copy(ctx, store, tag, repo, tag, oras.DefaultCopyOptions)
 	if err != nil {
 		return fmt.Errorf("copy to repository: %w", err)
+	}
+
+	a.logger.Info("Pushed artifact", "reference", fmt.Sprintf("%s@%s", ref, descriptor.Digest))
+
+	if signOpts != nil && signOpts.DisableSigning {
+		a.logger.Info("Signing disabled, not signing the OCI artifact")
+
+		return nil
 	}
 
 	a.logger.Info("Signing OCI artifact")

--- a/internal/pkg/artifact/artifact_test.go
+++ b/internal/pkg/artifact/artifact_test.go
@@ -51,6 +51,35 @@ func defaultDescriptor() ocispec.Descriptor {
 	return ocispec.Descriptor{Annotations: map[string]string{}}
 }
 
+func TestPushDisableSigning(t *testing.T) {
+	testRef, err := name.ParseReference("docker.io/foo/bar:v1")
+	require.NoError(t, err)
+
+	t.Parallel()
+
+	mock := &artifactfakes.FakeImpl{}
+	mock.StoreAddReturns(defaultDescriptor(), nil)
+	mock.ParseReferenceReturns(testRef, nil)
+	mock.NewRepositoryReturns(&remote.Repository{}, nil)
+	// Signing would fail if it ran at all.
+	mock.ClientSecretReturns("", errTest)
+
+	sut := New(logr.Discard())
+	sut.impl = mock
+
+	require.NoError(t, sut.Push(
+		map[*ocispec.Platform]string{
+			{OS: runtime.GOOS, Architecture: runtime.GOARCH}: "test",
+		},
+		"",
+		"",
+		"",
+		nil,
+		&PushSignatureOptions{DisableSigning: true},
+	))
+	require.Zero(t, mock.SignCmdCallCount())
+}
+
 func TestPush(t *testing.T) {
 	testRef, err := name.ParseReference("docker.io/foo/bar:v1")
 	require.NoError(t, err)
@@ -226,6 +255,7 @@ func TestPush(t *testing.T) {
 				"foo",
 				"bar",
 				map[string]string{"foo": "bar"},
+				nil,
 			)
 			assert(err)
 		})
@@ -725,7 +755,7 @@ func TestPushMediaTypes(t *testing.T) {
 			sut := New(logr.Discard())
 			sut.impl = mock
 
-			err := sut.Push(map[*ocispec.Platform]string{platform: "profile"}, "", "", "", nil)
+			err := sut.Push(map[*ocispec.Platform]string{platform: "profile"}, "", "", "", nil, nil)
 			require.NoError(t, err)
 
 			require.Equal(t, 1, mock.StoreAddCallCount())
@@ -918,7 +948,7 @@ func TestPushRuntimeSpecSeccompProfileErrors(t *testing.T) {
 			sut := New(logr.Discard())
 			sut.impl = mock
 
-			err := sut.Push(tc.files, "", "", "", nil)
+			err := sut.Push(tc.files, "", "", "", nil, nil)
 			require.ErrorIs(t, err, tc.wantErr)
 		})
 	}

--- a/internal/pkg/cli/pusher/consts.go
+++ b/internal/pkg/cli/pusher/consts.go
@@ -36,6 +36,9 @@ var (
 )
 
 const (
+	// FlagDisableSigning is the flag for skipping the artifact signature.
+	FlagDisableSigning string = "disable-signing"
+
 	// FlagProfiles is the flag for defining the input file locations.
 	FlagProfiles string = "profiles"
 

--- a/internal/pkg/cli/pusher/impl.go
+++ b/internal/pkg/cli/pusher/impl.go
@@ -29,13 +29,22 @@ type defaultImpl struct{}
 //go:generate go run github.com/maxbrunsfeld/counterfeiter/v6 -generate -header ../../../../hack/boilerplate/boilerplate.generatego.txt
 //counterfeiter:generate . impl
 type impl interface {
-	Push(map[*v1.Platform]string, string, string, string, map[string]string) error
+	Push(
+		map[*v1.Platform]string,
+		string,
+		string,
+		string,
+		map[string]string,
+		*artifact.PushSignatureOptions,
+	) error
 }
 
 func (*defaultImpl) Push(
 	files map[*v1.Platform]string,
 	to, username, password string,
 	annotations map[string]string,
+	signOpts *artifact.PushSignatureOptions,
 ) error {
-	return artifact.New(logr.New(&cli.LogSink{})).Push(files, to, username, password, annotations)
+	return artifact.New(logr.New(&cli.LogSink{})).
+		Push(files, to, username, password, annotations, signOpts)
 }

--- a/internal/pkg/cli/pusher/options.go
+++ b/internal/pkg/cli/pusher/options.go
@@ -31,11 +31,12 @@ import (
 
 // Options define all possible options for the pusher.
 type Options struct {
-	pushTo      string
-	inputFiles  map[*v1.Platform]string
-	username    string
-	password    string
-	annotations map[string]string
+	pushTo         string
+	inputFiles     map[*v1.Platform]string
+	username       string
+	password       string
+	annotations    map[string]string
+	disableSigning bool
 }
 
 // Default returns a default options instance.
@@ -100,6 +101,7 @@ func FromContext(ctx *ucli.Context) (*Options, error) {
 	}
 
 	options.password = os.Getenv(cli.EnvKeyPassword)
+	options.disableSigning = ctx.Bool(FlagDisableSigning)
 	options.annotations = map[string]string{}
 
 	for _, a := range ctx.StringSlice(FlagAnnotations) {

--- a/internal/pkg/cli/pusher/pusher.go
+++ b/internal/pkg/cli/pusher/pusher.go
@@ -19,6 +19,8 @@ package pusher
 import (
 	"fmt"
 	"log"
+
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/artifact"
 )
 
 // Pusher is the main structure of this package.
@@ -45,6 +47,7 @@ func (p *Pusher) Run() error {
 		p.options.username,
 		p.options.password,
 		p.options.annotations,
+		&artifact.PushSignatureOptions{DisableSigning: p.options.disableSigning},
 	); err != nil {
 		return fmt.Errorf("push profile: %w", err)
 	}

--- a/internal/pkg/cli/pusher/pusherfakes/fake_impl.go
+++ b/internal/pkg/cli/pusher/pusherfakes/fake_impl.go
@@ -21,10 +21,11 @@ import (
 	"sync"
 
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/artifact"
 )
 
 type FakeImpl struct {
-	PushStub        func(map[*v1.Platform]string, string, string, string, map[string]string) error
+	PushStub        func(map[*v1.Platform]string, string, string, string, map[string]string, *artifact.PushSignatureOptions) error
 	pushMutex       sync.RWMutex
 	pushArgsForCall []struct {
 		arg1 map[*v1.Platform]string
@@ -32,6 +33,7 @@ type FakeImpl struct {
 		arg3 string
 		arg4 string
 		arg5 map[string]string
+		arg6 *artifact.PushSignatureOptions
 	}
 	pushReturns struct {
 		result1 error
@@ -43,7 +45,7 @@ type FakeImpl struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeImpl) Push(arg1 map[*v1.Platform]string, arg2 string, arg3 string, arg4 string, arg5 map[string]string) error {
+func (fake *FakeImpl) Push(arg1 map[*v1.Platform]string, arg2 string, arg3 string, arg4 string, arg5 map[string]string, arg6 *artifact.PushSignatureOptions) error {
 	fake.pushMutex.Lock()
 	ret, specificReturn := fake.pushReturnsOnCall[len(fake.pushArgsForCall)]
 	fake.pushArgsForCall = append(fake.pushArgsForCall, struct {
@@ -52,13 +54,14 @@ func (fake *FakeImpl) Push(arg1 map[*v1.Platform]string, arg2 string, arg3 strin
 		arg3 string
 		arg4 string
 		arg5 map[string]string
-	}{arg1, arg2, arg3, arg4, arg5})
+		arg6 *artifact.PushSignatureOptions
+	}{arg1, arg2, arg3, arg4, arg5, arg6})
 	stub := fake.PushStub
 	fakeReturns := fake.pushReturns
-	fake.recordInvocation("Push", []interface{}{arg1, arg2, arg3, arg4, arg5})
+	fake.recordInvocation("Push", []interface{}{arg1, arg2, arg3, arg4, arg5, arg6})
 	fake.pushMutex.Unlock()
 	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+		return stub(arg1, arg2, arg3, arg4, arg5, arg6)
 	}
 	if specificReturn {
 		return ret.result1
@@ -72,17 +75,17 @@ func (fake *FakeImpl) PushCallCount() int {
 	return len(fake.pushArgsForCall)
 }
 
-func (fake *FakeImpl) PushCalls(stub func(map[*v1.Platform]string, string, string, string, map[string]string) error) {
+func (fake *FakeImpl) PushCalls(stub func(map[*v1.Platform]string, string, string, string, map[string]string, *artifact.PushSignatureOptions) error) {
 	fake.pushMutex.Lock()
 	defer fake.pushMutex.Unlock()
 	fake.PushStub = stub
 }
 
-func (fake *FakeImpl) PushArgsForCall(i int) (map[*v1.Platform]string, string, string, string, map[string]string) {
+func (fake *FakeImpl) PushArgsForCall(i int) (map[*v1.Platform]string, string, string, string, map[string]string, *artifact.PushSignatureOptions) {
 	fake.pushMutex.RLock()
 	defer fake.pushMutex.RUnlock()
 	argsForCall := fake.pushArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5, argsForCall.arg6
 }
 
 func (fake *FakeImpl) PushReturns(result1 error) {

--- a/test/e2e_flaky_test.go
+++ b/test/e2e_flaky_test.go
@@ -50,6 +50,10 @@ func (e *e2e) TestSecurityProfilesOperator_Flaky() {
 			e.testCaseSeccompMetrics,
 		},
 		{
+			"Seccomp: Verify CRD format OCI base profile",
+			e.testCaseBaseProfileOCI,
+		},
+		{
 			"SPOD: Test webhook HTTP version",
 			e.testCaseWebhookHTTP,
 		},

--- a/test/e2e_test.go
+++ b/test/e2e_test.go
@@ -74,6 +74,10 @@ func (e *e2e) TestSecurityProfilesOperator() {
 			e.testCaseBaseProfile,
 		},
 		{
+			"Seccomp: Verify runtime format OCI base profile",
+			e.testCaseBaseProfileOCIRuntimeFormat,
+		},
+		{
 			"Seccomp: Allowed syscalls",
 			e.testCaseAllowedSyscalls,
 		},

--- a/test/tc_base_profiles_oci_runtime_test.go
+++ b/test/tc_base_profiles_oci_runtime_test.go
@@ -19,16 +19,28 @@ package e2e_test
 import (
 	"fmt"
 	"os"
+	"path"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 )
 
-// testCaseBaseProfileOCI covers the CRD artifact format. It is flaky because
-// it depends on artifacts published to a public registry, so it runs in the
-// flaky suite.
-func (e *e2e) testCaseBaseProfileOCI([]string) {
+// runtimeFormatBaseProfileRepo holds the profiles from examples/test-profiles
+// as well as the recorded runtime base profiles in the format container runtimes
+// consume, pushed by hack/push-test-artifacts.sh.
+const runtimeFormatBaseProfileRepo = "oci://ghcr.io/security-profiles/seccomp-test-profiles:"
+
+// testCaseBaseProfileOCIRuntimeFormat verifies that a base profile referencing
+// an artifact in the runtime format, a single raw runtime-spec JSON layer with
+// the seccomp config media type, is pulled, merged and applied. The artifact
+// side of that format is covered by unit tests; this exercises the operator
+// pulling one it did not create itself.
+func (e *e2e) testCaseBaseProfileOCIRuntimeFormat(nodes []string) {
 	e.seccompOnlyTestCase()
 
+	// The published artifacts are unsigned, because the build that pushes them
+	// has no OIDC identity for keyless signing.
 	e.kubectlOperatorNS(
 		"patch", "spod", "spod",
 		"-p", `{"spec":{"security":{"disableOciArtifactSignatureVerification": true}}}`,
@@ -38,7 +50,6 @@ func (e *e2e) testCaseBaseProfileOCI([]string) {
 	e.waitInOperatorNSFor("condition=ready", "spod", "spod")
 	e.kubectlOperatorNS("rollout", "status", "ds", "spod", "--timeout", defaultLongOpTimeout)
 
-	// Other cases run after this one, so the daemon has to be left as found.
 	defer func() {
 		e.kubectlOperatorNS(
 			"patch", "spod", "spod",
@@ -49,16 +60,12 @@ func (e *e2e) testCaseBaseProfileOCI([]string) {
 		e.waitInOperatorNSFor("condition=ready", "spod", "spod")
 	}()
 
-	baseProfileName := "oci://ghcr.io/security-profiles/"
-
+	baseProfileName := runtimeFormatBaseProfileRepo + "baseprofile-runc"
 	if clusterType == clusterTypeVanilla && e.containerRuntime != containerRuntimeDocker {
-		baseProfileName += strings.ReplaceAll(baseProfileNameCrun, "-", ":")
-	} else {
-		baseProfileName += strings.ReplaceAll(baseProfileNameRunc, "-", ":")
+		baseProfileName = runtimeFormatBaseProfileRepo + "baseprofile-crun"
 	}
 
-	namespace := e.getCurrentContextNamespace(defaultNamespace)
-	profileName := fmt.Sprintf("profile-%v", time.Now().Unix())
+	profileName := fmt.Sprintf("hello-oci-runtime-%v", time.Now().Unix())
 	profileYAML := fmt.Sprintf(`
 apiVersion: security-profiles-operator.x-k8s.io/v1
 kind: SeccompProfile
@@ -75,7 +82,42 @@ spec:
     - exit_group
 `, profileName, baseProfileName)
 
+	namespace := e.getCurrentContextNamespace(defaultNamespace)
 	podName := fmt.Sprintf("pod-%v", time.Now().Unix())
+
+	e.logf("Creating profile with a runtime format base profile")
+
+	profileFile, err := os.CreateTemp("", "profile-*.yaml")
+	e.Require().NoError(err)
+
+	defer os.Remove(profileFile.Name())
+
+	_, err = profileFile.WriteString(profileYAML)
+	e.Require().NoError(err)
+	e.Require().NoError(profileFile.Close())
+	e.kubectl("create", "-f", profileFile.Name())
+
+	defer e.kubectl("delete", "-f", profileFile.Name())
+
+	e.logf("Waiting for profile to be reconciled")
+	e.waitForProfile(profileName)
+
+	// The merged profile only exists on the node, the custom resource keeps
+	// the spec as written.
+	localhostProfile := e.kubectl(
+		"get", "sp", profileName, "-o", "jsonpath={.status.localhostProfile}",
+	)
+	e.Require().NotEmpty(localhostProfile)
+
+	e.logf("Verifying that the base profile got merged into %s", localhostProfile)
+
+	profilePath := path.Join(
+		e.nodeRootfsPrefix, config.KubeletSeccompRootPath(), localhostProfile,
+	)
+	merged := e.execNode(nodes[0], "cat", profilePath)
+	e.Contains(merged, "execve", "base profile syscalls are missing from the merged profile")
+	e.Contains(merged, "arch_prctl", "profile syscalls are missing from the merged profile")
+
 	podYAML := fmt.Sprintf(`
 apiVersion: v1
 kind: Pod
@@ -89,27 +131,9 @@ spec:
   securityContext:
     seccompProfile:
       type: Localhost
-      localhostProfile: operator/%s/%s.json
+      localhostProfile: %s
   restartPolicy: OnFailure
-`, podName, namespace, namespace, profileName)
-
-	e.logf("Creating profile")
-
-	profileFile, err := os.CreateTemp("", "profile-*.yaml")
-	e.Require().NoError(err)
-
-	defer os.Remove(profileFile.Name())
-
-	_, err = profileFile.WriteString(profileYAML)
-	e.Require().NoError(err)
-	err = profileFile.Close()
-	e.Require().NoError(err)
-	e.kubectl("create", "-f", profileFile.Name())
-
-	defer e.kubectl("delete", "-f", profileFile.Name())
-
-	e.logf("Waiting for profile to be reconciled")
-	e.waitForProfile(profileName)
+`, podName, namespace, localhostProfile)
 
 	e.logf("Creating pod")
 
@@ -120,8 +144,7 @@ spec:
 
 	_, err = podFile.WriteString(podYAML)
 	e.Require().NoError(err)
-	err = podFile.Close()
-	e.Require().NoError(err)
+	e.Require().NoError(podFile.Close())
 	e.kubectl("create", "-f", podFile.Name())
 
 	defer e.kubectl("delete", "pod", podName)
@@ -131,23 +154,34 @@ spec:
 
 	e.logf("Waiting for pod to be completed")
 
+	completed := false
+
 	for range 20 {
 		output := e.kubectl("get", "pod", podName)
 		if strings.Contains(output, "Completed") {
+			completed = true
+
 			break
 		}
 
 		if strings.Contains(output, "CreateContainerError") {
 			e.kubectlOperatorNS("logs", "-l", "name=spod")
-			e.kubectl("get", "sp", profileName, "-o", "yaml")
-			output := e.kubectl("describe", "pod", podName)
-			e.FailNowf("Unable to create container", output)
+			e.FailNowf(
+				"Unable to create container",
+				"%s", e.kubectl("describe", "pod", podName),
+			)
 		}
 
 		time.Sleep(time.Second)
 	}
 
+	if !completed {
+		e.FailNowf(
+			"Pod did not complete in time",
+			"%s", e.kubectl("describe", "pod", podName),
+		)
+	}
+
 	e.logf("Testing that container ran successfully")
-	output := e.kubectl("logs", podName)
-	e.Contains(output, "Hello from Docker!")
+	e.Contains(e.kubectl("logs", podName), "Hello from Docker!")
 }


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

The Kubernetes e2e_node tests for KEP-6061 need seccomp profiles served from `registry.k8s.io`: one that constrains an observable syscall, one more permissive than any node baseline, one the runtime has to reject, and one above the default size limit. They are pushed to the staging registry by the Cloud Build job and promoted from there.
The recorded runtime base profiles are converted and published next to them, which gives the operator its own `oci://` base profile in the runtime format, so the new end-to-end case pulls an artifact it did not create itself.
Pushing always signed the artifact keylessly, which needs an OIDC identity that build systems do not have, so `spoc push` learns `--disable-signing`. The push also logs the artifact digest now, which is what the promoter manifest in kubernetes/k8s.io refers to.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Yes. `spoc push` gains a unit test asserting that signing is skipped when disabled, and `test/tc_base_profiles_oci_runtime_test.go` covers a runtime format artifact used as an `oci://` base profile. The artifacts it consumes are published at `ghcr.io/security-profiles/seccomp-test-profiles`.
The CRD format OCI base profile case sat in the tree unreferenced behind a `//nolint:unused` and now runs in the flaky suite, where its dependency on a public registry belongs.

#### Special notes for your reviewer:

The e2e case skips signature verification because the published artifacts are unsigned, which is the same thing the CRD format case does.
Artifacts are pushed under one repository with a tag per profile, so promoting them to `registry.k8s.io` adds a single name to `images.yaml` in kubernetes/k8s.io rather than one per profile.

#### Does this PR introduce a user-facing change?

```release-note
`spoc push` supports `--disable-signing` for environments without an OIDC identity, and logs the digest of the pushed artifact.
```
