### PR TITLE
Fix the duplicate -o flag on spoc pull

### DIFF
--- a/cmd/spoc/main.go
+++ b/cmd/spoc/main.go
@@ -40,6 +40,12 @@ import (
 func main() {
 	log.SetFlags(log.Lmicroseconds)
 
+	if err := newApp().Run(os.Args); err != nil {
+		log.Fatalf("Unable to run: %v", err)
+	}
+}
+
+func newApp() *cli.App {
 	app, _ := cmd.DefaultApp()
 	app.Usage = "Security Profiles Operator CLI"
 
@@ -260,7 +266,6 @@ func main() {
 				},
 				&cli.StringFlag{
 					Name:    puller.FlagAllowedOidcIssuerRegexp,
-					Aliases: []string{"o"},
 					EnvVars: []string{"ALLOWED_OIDC_ISSUER_REGEXP"},
 					Usage:   "regexp for allowed Oidc issuer in signature verification",
 				},
@@ -268,9 +273,7 @@ func main() {
 		},
 	)
 
-	if err := app.Run(os.Args); err != nil {
-		log.Fatalf("Unable to run: %v", err)
-	}
+	return app
 }
 
 // record runs the `spoc record` subcommand.

--- a/cmd/spoc/main_test.go
+++ b/cmd/spoc/main_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
+)
+
+// TestCommandFlagNamesAreUnique guards against a duplicate flag name or alias
+// within a command, which urfave/cli only reports by panicking when the
+// command runs.
+func TestCommandFlagNamesAreUnique(t *testing.T) {
+	t.Parallel()
+
+	var assertCommand func(t *testing.T, command *cli.Command)
+
+	assertCommand = func(t *testing.T, command *cli.Command) {
+		t.Helper()
+
+		seen := map[string]bool{}
+
+		for _, flag := range command.Flags {
+			for _, name := range flag.Names() {
+				require.False(
+					t, seen[name],
+					"flag %q defined more than once for command %q", name, command.Name,
+				)
+
+				seen[name] = true
+			}
+		}
+
+		for _, subCommand := range command.Subcommands {
+			assertCommand(t, subCommand)
+		}
+	}
+
+	for _, command := range newApp().Commands {
+		assertCommand(t, command)
+	}
+}


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

`spoc pull` panics on every invocation, including `spoc pull --help`:

```
pull flag redefined: o
panic: pull flag redefined: o
```

Both `--output-file` and `--allowed-oidc-issuer-regexp` claim the `-o` alias, and urfave/cli panics while building the flag set. The alias belongs to `--output-file`, which is what `record`, `merge` and `convert` use it for, so the OIDC issuer regexp keeps its long name only. Neither alias worked while the command panicked, so nothing that previously functioned changes behavior.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Yes. A test walks the command tree and fails on a duplicate flag name or alias, which is the class of bug urfave/cli only reports by panicking at run time. It needs `main` to expose the app it builds, so that construction moved into `newApp()`. Verified the test catches the regression by reintroducing the duplicate.

#### Special notes for your reviewer:

Nothing in CI runs the pull command, which is why this went unnoticed. The predecessor of the new test would have caught it.

#### Does this PR introduce a user-facing change?

```release-note
`spoc pull` no longer panics on startup. The `-o` short flag now refers to `--output-file` only; use `--allowed-oidc-issuer-regexp` by its full name.
```
