### PR TITLE
Make artifact pushes reproducible and spoc tests hermetic

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -227,7 +227,18 @@ needs an OIDC identity, which build systems and test environments do not
 necessarily have, so `--disable-signing` skips it. Consumers of an unsigned
 artifact have to skip verification as well. It is possible to add custom
 annotations to the security profile by using the `--annotations` / `-a` flag
-multiple times in `KEY:VALUE` format.
+multiple times in `KEY:VALUE` format; only the first colon separates the key
+from the value, so timestamps keep theirs.
+
+The manifest's `org.opencontainers.image.created` annotation is fixed to
+`1970-01-01T00:00:00Z` unless it is set explicitly with `--annotations` or
+`SOURCE_DATE_EPOCH` is exported (seconds since the epoch, the reproducible
+builds convention). Pushing identical content again therefore yields the
+same digest instead of a new, untagged manifest.
+
+`--plain-http` on `spoc push` and `spoc pull` reaches the registry over HTTP
+instead of HTTPS, for local registries in tests and other registries without
+TLS.
 
 ### Pushing profiles for container runtimes
 
@@ -302,7 +313,7 @@ the single layer is not platform qualified:
     }
   ],
   "annotations": {
-    "org.opencontainers.image.created": "2026-09-09T07:32:11Z"
+    "org.opencontainers.image.created": "1970-01-01T00:00:00Z"
   }
 }
 ```

--- a/cmd/spoc/main.go
+++ b/cmd/spoc/main.go
@@ -225,6 +225,10 @@ func newApp() *cli.App {
 						"container runtimes would reject it as a KEP-6061 " +
 						"artifact, for publishing test fixtures",
 				},
+				&cli.BoolFlag{
+					Name:  pusher.FlagPlainHTTP,
+					Usage: "use HTTP instead of HTTPS to reach the registry, for local registries in tests",
+				},
 				&cli.StringSliceFlag{
 					Name:    pusher.FlagPlatforms,
 					Aliases: []string{"p"},
@@ -269,6 +273,10 @@ func newApp() *cli.App {
 					Aliases: []string{"s"},
 					EnvVars: []string{"DISABLE_SIGNATURE_VERIFICATION"},
 					Usage:   "disable signature verification",
+				},
+				&cli.BoolFlag{
+					Name:  puller.FlagPlainHTTP,
+					Usage: "use HTTP instead of HTTPS to reach the registry, for local registries in tests",
 				},
 				&cli.StringFlag{
 					Name:    puller.FlagAllowedIdentityRegexp,

--- a/hack/back-to-dev.sh
+++ b/hack/back-to-dev.sh
@@ -76,6 +76,7 @@ sed -i \
     hack/ci/e2e-olm.sh
 
 sed -i 's;registry.k8s.io;gcr.io/k8s-staging-sp-operator;g' test/e2e_test.go
+sed -i 's;registry.k8s.io/security-profiles-operator/base/;gcr.io/k8s-staging-sp-operator/base/;g' test/tc_base_profiles_oci_runtime_test.go
 
 sed -i 's;registry.k8s.io/security-profiles-operator.*;gcr.io/k8s-staging-sp-operator/security-profiles-operator:latest;g' \
     hack/deploy-localhost.patch

--- a/hack/ci/e2e-apparmor.sh
+++ b/hack/ci/e2e-apparmor.sh
@@ -101,8 +101,7 @@ check_apparmor_profile_recording() {
 
   echo "Enable Apparmor profile"
   k patch spod spod --type=merge -p '{"spec":{"enableAppArmor":true}}'
-  k rollout status ds spod --timeout 360s
-  k_wait spod spod
+  wait_for_spod
 
   ensure_runtime_classes
 
@@ -175,8 +174,7 @@ check_apparmor_complain_mode() {
 
   echo "Enable Apparmor profile"
   k patch spod spod --type=merge -p '{"spec":{"enableAppArmor":true}}'
-  k rollout status ds spod --timeout 360s
-  k_wait spod spod
+  wait_for_spod
 
   echo "---------------------------"
   echo "Installing apparmor profile"

--- a/hack/ci/install-spo.sh
+++ b/hack/ci/install-spo.sh
@@ -27,6 +27,27 @@ k_wait() {
   k wait --timeout 120s --for condition=ready "$@"
 }
 
+# Waits until the spod daemonset finished rolling out and its generation
+# stayed unchanged for a grace period. A spec change makes the operator update
+# the daemonset more than once, and "rollout status" can return between two of
+# those updates, so a test that continues right away races the next restart.
+wait_for_spod() {
+  local generation previous=""
+  for ((i = 0; i < 30; i++)); do
+    k rollout status ds spod --timeout 360s
+    generation=$(k get ds spod -o jsonpath='{.metadata.generation}')
+    if [[ "$generation" == "$previous" ]]; then
+      k_wait spod spod
+      echo "spod daemonset settled at generation $generation"
+      return 0
+    fi
+    previous="$generation"
+    sleep 10
+  done
+  echo "spod daemonset did not settle"
+  return 1
+}
+
 wait_for_pod_name_label() {
   echo "Waiting for pod with label name=$1"
 

--- a/hack/push-base-profiles.sh
+++ b/hack/push-base-profiles.sh
@@ -29,9 +29,9 @@ REGISTRY="${REGISTRY:-gcr.io/k8s-staging-sp-operator}"
 # Keyless signing needs an OIDC identity. Publishing from a build system that
 # has none, such as the staging Cloud Build job, has to turn it off.
 SIGN="${SIGN:-true}"
-# Republishing identical content produces a new digest, because the artifact
-# carries a creation timestamp, so what is already published is left alone.
-# Set this to false to publish regardless.
+# Identical content yields the same digest, so republishing is a no-op for the
+# registry; what is already published is left alone to spare the pushes and
+# the latest repoint. Set this to false to publish regardless.
 SKIP_EXISTING="${SKIP_EXISTING:-true}"
 EXAMPLES="${EXAMPLES:-examples}"
 # Base profiles live under their own path, which keeps them apart from the test
@@ -93,11 +93,11 @@ for runtime in "${RUNTIMES[@]}"; do
   converted="$BUILD_DIR/baseprofile-$runtime.json"
   "$SPOC" convert -o "$converted" "$profile"
 
-  # latest follows the newest recording so that tests do not have to be updated
-  # for every runtime version. It moves only when a version is published, since
-  # repointing it on every build would leave a trail of untagged digests. It is
-  # deliberately never promoted: tags in registry.k8s.io cannot be repointed, so
-  # a promoted latest would be frozen at whatever it pointed to first.
+  # latest follows the newest recording for manual pulls; the tests derive the
+  # versioned tag from the recorded profile. It moves only when a version is
+  # published. It is deliberately never promoted: tags in registry.k8s.io cannot
+  # be repointed, so a promoted latest would be frozen at whatever it pointed to
+  # first.
   version_ref="$REGISTRY/$NAME_PREFIX$runtime:$version"
   latest_ref="$REGISTRY/$NAME_PREFIX$runtime:latest"
 

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -46,6 +46,8 @@ sed -i 's;image: .*;image: registry.k8s.io/security-profiles-operator/security-p
 sed -i 's;gcr.io.*catalog.*;registry.k8s.io/security-profiles-operator/security-profiles-operator-catalog:v'"$VERSION"'#${CATALOG_IMG}#g" examples/olm/install-resources.yaml;g' hack/ci/e2e-olm.sh
 sed -i 's;gcr.io/k8s-staging-sp-operator/;registry.k8s.io/;g' hack/ci/e2e-olm.sh
 sed -i 's;gcr.io/k8s-staging-sp-operator/;registry.k8s.io/;g' test/e2e_test.go
+# The base profile artifacts are promoted under the project name.
+sed -i 's;gcr.io/k8s-staging-sp-operator/base/;registry.k8s.io/security-profiles-operator/base/;g' test/tc_base_profiles_oci_runtime_test.go
 
 # Update patches
 sed -i 's;gcr.io.*;registry.k8s.io/security-profiles-operator/security-profiles-operator:v'"$VERSION"';g' hack/deploy-localhost.patch

--- a/internal/pkg/artifact/artifact.go
+++ b/internal/pkg/artifact/artifact.go
@@ -24,8 +24,11 @@ import (
 	"fmt"
 	"io"
 	"maps"
+	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/opencontainers/go-digest"
@@ -113,10 +116,15 @@ func (a *Artifact) setRepoCredentials(repo *remote.Repository, username, passwor
 	}
 }
 
-// PullSignatureOptions options for verifying the OCI image signature during pulling.
-type PullSignatureOptions struct {
+// PullOptions are the options for pulling an OCI artifact: how to reach the
+// registry and how to verify the artifact's signature.
+type PullOptions struct {
 	// DisableSignatureVerification disables signature verification during pulling.
 	DisableSignatureVerification bool
+
+	// PlainHTTP talks to the registry over HTTP instead of HTTPS, for local
+	// registries in tests. Signature verification then uses HTTP as well.
+	PlainHTTP bool
 
 	// AllowedIdentityRegexp regexp for allowed identities for signature verification.
 	//
@@ -142,12 +150,16 @@ type PushOptions struct {
 	// apply to a KEP-6061 artifact, so that deliberately invalid profiles
 	// can be published for testing. Runtimes still reject them when pulled.
 	DisableArtifactValidation bool
+
+	// PlainHTTP talks to the registry over HTTP instead of HTTPS, for local
+	// registries in tests. Signing then uses HTTP as well.
+	PlainHTTP bool
 }
 
 // hasUnconstrainedSigner reports whether the signer identity or the OIDC
 // issuer is left unconstrained, in which case verification does not establish
 // who signed the artifact.
-func (p *PullSignatureOptions) hasUnconstrainedSigner() bool {
+func (p *PullOptions) hasUnconstrainedSigner() bool {
 	return matchesAnything(p.AllowedIdentityRegexp) ||
 		matchesAnything(p.AllowedOidcIssuerRegexp)
 }
@@ -245,8 +257,18 @@ func (a *Artifact) Push(
 		fileDescriptors = append(fileDescriptors, fileDescriptor)
 	}
 
+	created, err := createdAnnotation(annotations)
+	if err != nil {
+		return err
+	}
+
 	mediaType := oras.MediaTypeUnknownConfig
-	packOptions := oras.PackManifestOptions{Layers: fileDescriptors}
+	packOptions := oras.PackManifestOptions{
+		Layers: fileDescriptors,
+		// ORAS stamps the current time otherwise, which gives identical
+		// content a different digest on every push.
+		ManifestAnnotations: map[string]string{v1.AnnotationCreated: created},
+	}
 
 	if runtimeSpecProfiles > 0 {
 		mediaType = MediaTypeSeccompProfile
@@ -295,6 +317,9 @@ func (a *Artifact) Push(
 		return fmt.Errorf("create repository: %w", err)
 	}
 
+	plainHTTP := opts != nil && opts.PlainHTTP
+	repo.PlainHTTP = plainHTTP
+
 	a.setRepoCredentials(repo, username, password)
 
 	a.logger.Info("Copying profile to repository")
@@ -318,6 +343,7 @@ func (a *Artifact) Push(
 		Upload:           true,
 		TlogUpload:       true,
 		SkipConfirmation: true,
+		Registry:         options.RegistryOptions{AllowHTTPRegistry: plainHTTP},
 		Rekor:            options.RekorOptions{URL: options.DefaultRekorURL},
 		Fulcio:           options.FulcioOptions{URL: options.DefaultFulcioURL},
 		OIDC: options.OIDCOptions{
@@ -366,7 +392,7 @@ func (a *Artifact) Pull(
 	c context.Context,
 	from, username, password string,
 	platform *v1.Platform,
-	signOpts *PullSignatureOptions,
+	signOpts *PullOptions,
 ) (*PullResult, error) {
 	ctx, cancel := context.WithTimeout(c, defaultTimeout)
 	defer cancel()
@@ -379,13 +405,15 @@ func (a *Artifact) Pull(
 	// prevent a TOCTOU attack on the mutable tag of the base image, which
 	// might lead to a malicious base profile being injected between
 	// verification and copying the content.
-	from, repo, sha, err := a.imageWithDigest(ctx, originalImage, username, password)
+	plainHTTP := signOpts != nil && signOpts.PlainHTTP
+
+	from, repo, sha, err := a.imageWithDigest(ctx, originalImage, username, password, plainHTTP)
 	if err != nil {
 		return nil, fmt.Errorf("resolving digest for image %q: %w", originalImage, err)
 	}
 
 	if signOpts == nil {
-		signOpts = &PullSignatureOptions{
+		signOpts = &PullOptions{
 			AllowedIdentityRegexp:   allowAllRegexp,
 			AllowedOidcIssuerRegexp: allowAllRegexp,
 		}
@@ -407,6 +435,7 @@ func (a *Artifact) Pull(
 		}
 
 		v := verify.VerifyCommand{
+			RegistryOptions: options.RegistryOptions{AllowHTTPRegistry: plainHTTP},
 			CertVerifyOptions: options.CertVerifyOptions{
 				CertIdentityRegexp:   signOpts.AllowedIdentityRegexp,
 				CertOidcIssuerRegexp: signOpts.AllowedOidcIssuerRegexp,
@@ -510,9 +539,9 @@ func (a *Artifact) Pull(
 // imageWithDigest transforms the given image into an image with digest instead of a tag.
 // It retrieves the digest from the remote repository. Returns the updated image with
 // digest and the repository and the digest as separate return arguments.
-func (a *Artifact) imageWithDigest(ctx context.Context, image, username, password string) (
-	string, *remote.Repository, digest.Digest, error,
-) {
+func (a *Artifact) imageWithDigest(
+	ctx context.Context, image, username, password string, plainHTTP bool,
+) (string, *remote.Repository, digest.Digest, error) {
 	ref, err := a.ParseReference(image)
 	if err != nil {
 		return "", nil, "", fmt.Errorf("parsing ref for image %q: %w", image, err)
@@ -523,6 +552,8 @@ func (a *Artifact) imageWithDigest(ctx context.Context, image, username, passwor
 		return "", nil, "", fmt.Errorf("creating repository for %q: %w",
 			ref.Name(), err)
 	}
+
+	repo.PlainHTTP = plainHTTP
 
 	a.setRepoCredentials(repo, username, password)
 
@@ -964,4 +995,26 @@ func platformToString(platform *v1.Platform) string {
 	}
 
 	return name.String()
+}
+
+// createdAnnotation returns the org.opencontainers.image.created value for
+// a pushed manifest: the caller's annotation if set, otherwise
+// SOURCE_DATE_EPOCH, otherwise a fixed epoch so that identical content
+// always produces the same digest.
+func createdAnnotation(annotations map[string]string) (string, error) {
+	if created, ok := annotations[v1.AnnotationCreated]; ok {
+		return created, nil
+	}
+
+	epoch, ok := os.LookupEnv(envSourceDateEpoch)
+	if !ok || epoch == "" {
+		return annotationCreatedDefault, nil
+	}
+
+	seconds, err := strconv.ParseInt(epoch, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("%w: %q", ErrInvalidSourceDateEpoch, epoch)
+	}
+
+	return time.Unix(seconds, 0).UTC().Format(time.RFC3339), nil
 }

--- a/internal/pkg/artifact/artifact_test.go
+++ b/internal/pkg/artifact/artifact_test.go
@@ -687,7 +687,7 @@ func TestPull(t *testing.T) {
 			sut := New(logr.Discard())
 			sut.impl = mock
 
-			res, err := sut.Pull(t.Context(), "", "foo", "bar", nil, &PullSignatureOptions{})
+			res, err := sut.Pull(t.Context(), "", "foo", "bar", nil, &PullOptions{})
 			assert(res, err)
 		})
 	}
@@ -1288,4 +1288,85 @@ func manyEntriesFor(syscall string) []specs.LinuxSyscall {
 	}
 
 	return entries
+}
+
+// Not parallel: it sets SOURCE_DATE_EPOCH, which the other push tests must
+// not observe.
+func TestPushCreatedAnnotation(t *testing.T) {
+	push := func(t *testing.T, annotations map[string]string) (string, error) {
+		t.Helper()
+
+		mock := &artifactfakes.FakeImpl{}
+		mock.ReadFileReturns([]byte(`{"defaultAction":"SCMP_ACT_ERRNO"}`), nil)
+		mock.StoreAddReturns(defaultDescriptor(), nil)
+
+		ref, err := name.ParseReference("docker.io/foo/bar:v1")
+		require.NoError(t, err)
+		mock.ParseReferenceReturns(ref, nil)
+		mock.NewRepositoryReturns(&remote.Repository{}, nil)
+
+		sut := New(logr.Discard())
+		sut.impl = mock
+
+		err = sut.Push(
+			map[*ocispec.Platform]string{nil: "profile.json"},
+			"", "", "", annotations, &PushOptions{DisableSigning: true},
+		)
+		if err != nil {
+			return "", err
+		}
+
+		require.Equal(t, 1, mock.PackManifestCallCount())
+		_, _, _, _, opts := mock.PackManifestArgsForCall(0)
+
+		return opts.ManifestAnnotations[ocispec.AnnotationCreated], nil
+	}
+
+	// Build environments such as nix-shell export SOURCE_DATE_EPOCH; empty
+	// counts as unset, so the default case is exercised regardless.
+	t.Setenv(envSourceDateEpoch, "")
+
+	created, err := push(t, nil)
+	require.NoError(t, err)
+	require.Equal(t, "1970-01-01T00:00:00Z", created,
+		"default must be fixed for reproducible digests")
+
+	created, err = push(t, map[string]string{ocispec.AnnotationCreated: "2026-09-11T07:00:00Z"})
+	require.NoError(t, err)
+	require.Equal(t, "2026-09-11T07:00:00Z", created, "an explicit annotation wins")
+
+	t.Setenv("SOURCE_DATE_EPOCH", "1789110000")
+
+	created, err = push(t, nil)
+	require.NoError(t, err)
+	require.Equal(t, "2026-09-11T07:00:00Z", created, "SOURCE_DATE_EPOCH is honored")
+
+	t.Setenv("SOURCE_DATE_EPOCH", "yesterday")
+
+	_, err = push(t, nil)
+	require.ErrorIs(t, err, ErrInvalidSourceDateEpoch)
+}
+
+func TestPushPlainHTTP(t *testing.T) {
+	t.Parallel()
+
+	repo := &remote.Repository{}
+	mock := &artifactfakes.FakeImpl{}
+	mock.ReadFileReturns([]byte(`{"defaultAction":"SCMP_ACT_ERRNO"}`), nil)
+	mock.StoreAddReturns(defaultDescriptor(), nil)
+
+	ref, err := name.ParseReference("docker.io/foo/bar:v1")
+	require.NoError(t, err)
+	mock.ParseReferenceReturns(ref, nil)
+	mock.NewRepositoryReturns(repo, nil)
+
+	sut := New(logr.Discard())
+	sut.impl = mock
+
+	err = sut.Push(
+		map[*ocispec.Platform]string{nil: "profile.json"},
+		"", "", "", nil, &PushOptions{DisableSigning: true, PlainHTTP: true},
+	)
+	require.NoError(t, err)
+	require.True(t, repo.PlainHTTP, "the repository must use plain HTTP when asked")
 }

--- a/internal/pkg/artifact/consts.go
+++ b/internal/pkg/artifact/consts.go
@@ -57,6 +57,16 @@ const (
 
 	// defaultTimeout is the default timeout for push and pull operations.
 	defaultTimeout = 5 * time.Minute
+
+	// annotationCreatedDefault is the org.opencontainers.image.created value
+	// a pushed manifest carries unless the caller sets the annotation or
+	// SOURCE_DATE_EPOCH. ORAS would stamp the current time, which makes
+	// identical content produce a new digest on every push.
+	annotationCreatedDefault = "1970-01-01T00:00:00Z"
+
+	// envSourceDateEpoch is the reproducible-builds convention for the
+	// timestamp to embed, in seconds since the Unix epoch.
+	envSourceDateEpoch = "SOURCE_DATE_EPOCH"
 )
 
 // emptyConfig is the content of the manifest config blob of a runtime format
@@ -91,6 +101,10 @@ var (
 	// ErrTrailingData is returned when a raw runtime-spec seccomp profile is
 	// followed by additional data.
 	ErrTrailingData = errors.New("trailing data after runtime-spec seccomp profile")
+
+	// ErrInvalidSourceDateEpoch is returned when SOURCE_DATE_EPOCH is set
+	// but is not an integer number of seconds.
+	ErrInvalidSourceDateEpoch = errors.New("SOURCE_DATE_EPOCH is not a number of seconds")
 
 	// ErrRuntimeRestrictions is returned when a runtime-spec seccomp profile
 	// contains content container runtimes reject in a KEP-6061 artifact, such

--- a/internal/pkg/cli/consts.go
+++ b/internal/pkg/cli/consts.go
@@ -29,6 +29,9 @@ const (
 	// authentication.
 	FlagUsername string = "username"
 
+	// FlagPlainHTTP is the flag for talking to the registry over HTTP.
+	FlagPlainHTTP string = "plain-http"
+
 	// EnvKeyPassword is the environment variable key for defining the password
 	// for registry authentication.
 	EnvKeyPassword string = "PASSWORD"

--- a/internal/pkg/cli/puller/consts.go
+++ b/internal/pkg/cli/puller/consts.go
@@ -40,6 +40,9 @@ const (
 	// regexp when verifying the image signature.
 	FlagAllowedIdentityRegexp string = "allowed-identity-regexp"
 
+	// FlagPlainHTTP is the flag for talking to the registry over HTTP.
+	FlagPlainHTTP string = cli.FlagPlainHTTP
+
 	// FlagAllowedOidcIssuerRegexp is the flag for defining the allowed Oidc issuers
 	// regexp when verifying the image signature.
 	FlagAllowedOidcIssuerRegexp string = "allowed-oidc-issuer-regexp"

--- a/internal/pkg/cli/puller/impl.go
+++ b/internal/pkg/cli/puller/impl.go
@@ -37,13 +37,13 @@ type impl interface {
 		string,
 		string,
 		*v1.Platform,
-		*artifact.PullSignatureOptions,
+		*artifact.PullOptions,
 	) (*artifact.PullResult, error)
 	WriteFile(string, []byte, os.FileMode) error
 }
 
 func (*defaultImpl) Pull(
-	from, username, password string, platform *v1.Platform, signOpts *artifact.PullSignatureOptions,
+	from, username, password string, platform *v1.Platform, signOpts *artifact.PullOptions,
 ) (*artifact.PullResult, error) {
 	return artifact.New(logr.New(&cli.LogSink{})).Pull(
 		context.Background(), from, username, password, platform, signOpts,

--- a/internal/pkg/cli/puller/options.go
+++ b/internal/pkg/cli/puller/options.go
@@ -38,6 +38,7 @@ type Options struct {
 	disableSignatureVerification bool
 	allowedIdentityRegexp        string
 	allowedOidcIssuerRegexp      string
+	plainHTTP                    bool
 }
 
 // Default returns a default options instance.
@@ -84,6 +85,8 @@ func FromContext(ctx *ucli.Context) (*Options, error) {
 	if ctx.IsSet(FlagAllowedOidcIssuerRegexp) {
 		options.allowedOidcIssuerRegexp = ctx.String(FlagAllowedOidcIssuerRegexp)
 	}
+
+	options.plainHTTP = ctx.Bool(FlagPlainHTTP)
 
 	options.password = os.Getenv(cli.EnvKeyPassword)
 

--- a/internal/pkg/cli/puller/puller.go
+++ b/internal/pkg/cli/puller/puller.go
@@ -48,10 +48,11 @@ func (p *Puller) Run() error {
 		p.options.username,
 		p.options.password,
 		p.options.platform,
-		&artifact.PullSignatureOptions{
+		&artifact.PullOptions{
 			DisableSignatureVerification: p.options.disableSignatureVerification,
 			AllowedIdentityRegexp:        p.options.allowedIdentityRegexp,
 			AllowedOidcIssuerRegexp:      p.options.allowedOidcIssuerRegexp,
+			PlainHTTP:                    p.options.plainHTTP,
 		},
 	)
 	if err != nil {

--- a/internal/pkg/cli/puller/pullerfakes/fake_impl.go
+++ b/internal/pkg/cli/puller/pullerfakes/fake_impl.go
@@ -26,14 +26,14 @@ import (
 )
 
 type FakeImpl struct {
-	PullStub        func(string, string, string, *v1.Platform, *artifact.PullSignatureOptions) (*artifact.PullResult, error)
+	PullStub        func(string, string, string, *v1.Platform, *artifact.PullOptions) (*artifact.PullResult, error)
 	pullMutex       sync.RWMutex
 	pullArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
 		arg4 *v1.Platform
-		arg5 *artifact.PullSignatureOptions
+		arg5 *artifact.PullOptions
 	}
 	pullReturns struct {
 		result1 *artifact.PullResult
@@ -60,7 +60,7 @@ type FakeImpl struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeImpl) Pull(arg1 string, arg2 string, arg3 string, arg4 *v1.Platform, arg5 *artifact.PullSignatureOptions) (*artifact.PullResult, error) {
+func (fake *FakeImpl) Pull(arg1 string, arg2 string, arg3 string, arg4 *v1.Platform, arg5 *artifact.PullOptions) (*artifact.PullResult, error) {
 	fake.pullMutex.Lock()
 	ret, specificReturn := fake.pullReturnsOnCall[len(fake.pullArgsForCall)]
 	fake.pullArgsForCall = append(fake.pullArgsForCall, struct {
@@ -68,7 +68,7 @@ func (fake *FakeImpl) Pull(arg1 string, arg2 string, arg3 string, arg4 *v1.Platf
 		arg2 string
 		arg3 string
 		arg4 *v1.Platform
-		arg5 *artifact.PullSignatureOptions
+		arg5 *artifact.PullOptions
 	}{arg1, arg2, arg3, arg4, arg5})
 	stub := fake.PullStub
 	fakeReturns := fake.pullReturns
@@ -89,13 +89,13 @@ func (fake *FakeImpl) PullCallCount() int {
 	return len(fake.pullArgsForCall)
 }
 
-func (fake *FakeImpl) PullCalls(stub func(string, string, string, *v1.Platform, *artifact.PullSignatureOptions) (*artifact.PullResult, error)) {
+func (fake *FakeImpl) PullCalls(stub func(string, string, string, *v1.Platform, *artifact.PullOptions) (*artifact.PullResult, error)) {
 	fake.pullMutex.Lock()
 	defer fake.pullMutex.Unlock()
 	fake.PullStub = stub
 }
 
-func (fake *FakeImpl) PullArgsForCall(i int) (string, string, string, *v1.Platform, *artifact.PullSignatureOptions) {
+func (fake *FakeImpl) PullArgsForCall(i int) (string, string, string, *v1.Platform, *artifact.PullOptions) {
 	fake.pullMutex.RLock()
 	defer fake.pullMutex.RUnlock()
 	argsForCall := fake.pullArgsForCall[i]

--- a/internal/pkg/cli/pusher/consts.go
+++ b/internal/pkg/cli/pusher/consts.go
@@ -43,6 +43,9 @@ const (
 	// profiles which container runtimes would reject.
 	FlagDisableArtifactValidation string = "disable-artifact-validation"
 
+	// FlagPlainHTTP is the flag for talking to the registry over HTTP.
+	FlagPlainHTTP string = cli.FlagPlainHTTP
+
 	// FlagProfiles is the flag for defining the input file locations.
 	FlagProfiles string = "profiles"
 

--- a/internal/pkg/cli/pusher/options.go
+++ b/internal/pkg/cli/pusher/options.go
@@ -39,6 +39,7 @@ type Options struct {
 	disableSigning bool
 
 	disableArtifactValidation bool
+	plainHTTP                 bool
 }
 
 // Default returns a default options instance.
@@ -105,14 +106,16 @@ func FromContext(ctx *ucli.Context) (*Options, error) {
 	options.password = os.Getenv(cli.EnvKeyPassword)
 	options.disableSigning = ctx.Bool(FlagDisableSigning)
 	options.disableArtifactValidation = ctx.Bool(FlagDisableArtifactValidation)
+	options.plainHTTP = ctx.Bool(FlagPlainHTTP)
 	options.annotations = map[string]string{}
 
 	for _, a := range ctx.StringSlice(FlagAnnotations) {
-		split := strings.Split(a, ":")
+		// Only the first colon separates key and value, so that values
+		// such as RFC 3339 timestamps keep their own colons.
+		const parts = 2
 
-		const minparts = 2
-
-		if len(split) < minparts {
+		split := strings.SplitN(a, ":", parts)
+		if len(split) < parts {
 			return nil, fmt.Errorf("wrong annotation format: %s", a)
 		}
 

--- a/internal/pkg/cli/pusher/options_test.go
+++ b/internal/pkg/cli/pusher/options_test.go
@@ -49,13 +49,16 @@ func TestFromContext(t *testing.T) {
 			prepare: func(set *flag.FlagSet) {
 				require.NoError(t, set.Parse([]string{"echo"}))
 				set.Var(cli.NewStringSlice(""), FlagAnnotations, "")
-				require.NoError(t, set.Set(FlagAnnotations, "foo:bar,hello:world"))
+				require.NoError(t, set.Set(FlagAnnotations,
+					"foo:bar,hello:world,org.opencontainers.image.created:2026-09-11T07:00:00Z",
+				))
 			},
 			assert: func(res *Options, err error) {
 				require.NoError(t, err)
-				assert.Len(t, res.annotations, 2)
+				assert.Len(t, res.annotations, 3)
 				assert.Equal(t, "bar", res.annotations["foo"])
 				assert.Equal(t, "world", res.annotations["hello"])
+				assert.Equal(t, "2026-09-11T07:00:00Z", res.annotations["org.opencontainers.image.created"])
 			},
 		},
 		{

--- a/internal/pkg/cli/pusher/pusher.go
+++ b/internal/pkg/cli/pusher/pusher.go
@@ -50,6 +50,7 @@ func (p *Pusher) Run() error {
 		&artifact.PushOptions{
 			DisableSigning:            p.options.disableSigning,
 			DisableArtifactValidation: p.options.disableArtifactValidation,
+			PlainHTTP:                 p.options.plainHTTP,
 		},
 	); err != nil {
 		return fmt.Errorf("push profile: %w", err)

--- a/internal/pkg/daemon/seccompprofile/impl.go
+++ b/internal/pkg/daemon/seccompprofile/impl.go
@@ -38,7 +38,7 @@ type defaultImpl struct{}
 //counterfeiter:generate . impl
 type impl interface {
 	Pull(context.Context, logr.Logger, string, string, string, *v1.Platform,
-		*artifact.PullSignatureOptions) (*artifact.PullResult, error)
+		*artifact.PullOptions) (*artifact.PullResult, error)
 	PullResultType(*artifact.PullResult) artifact.PullResultType
 	PullResultSeccompProfile(*artifact.PullResult) *seccompprofileapi.SeccompProfile
 	ClientGetProfile(
@@ -54,7 +54,7 @@ func (*defaultImpl) Pull(
 	l logr.Logger,
 	from, username, password string,
 	platform *v1.Platform,
-	signOpts *artifact.PullSignatureOptions,
+	signOpts *artifact.PullOptions,
 ) (*artifact.PullResult, error) {
 	return artifact.New(l).Pull(ctx, from, username, password, platform, signOpts)
 }

--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -415,7 +415,7 @@ func (r *Reconciler) resolveSyscallsForProfile(
 				spod.Spec.Security.AllowedOidcIssuerRegexp = allowedAllRegexp
 			}
 
-			signOpts := &artifact.PullSignatureOptions{
+			signOpts := &artifact.PullOptions{
 				DisableSignatureVerification: ptr.Deref(
 					spod.Spec.Security.DisableOCIArtifactSignatureVerification,
 					false,

--- a/internal/pkg/daemon/seccompprofile/seccompprofilefakes/fake_impl.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofilefakes/fake_impl.go
@@ -69,7 +69,7 @@ type FakeImpl struct {
 		arg1 *metrics.Metrics
 		arg2 string
 	}
-	PullStub        func(context.Context, logr.Logger, string, string, string, *v1b.Platform, *artifact.PullSignatureOptions) (*artifact.PullResult, error)
+	PullStub        func(context.Context, logr.Logger, string, string, string, *v1b.Platform, *artifact.PullOptions) (*artifact.PullResult, error)
 	pullMutex       sync.RWMutex
 	pullArgsForCall []struct {
 		arg1 context.Context
@@ -78,7 +78,7 @@ type FakeImpl struct {
 		arg4 string
 		arg5 string
 		arg6 *v1b.Platform
-		arg7 *artifact.PullSignatureOptions
+		arg7 *artifact.PullOptions
 	}
 	pullReturns struct {
 		result1 *artifact.PullResult
@@ -288,7 +288,7 @@ func (fake *FakeImpl) IncSeccompProfileErrorArgsForCall(i int) (*metrics.Metrics
 	return argsForCall.arg1, argsForCall.arg2
 }
 
-func (fake *FakeImpl) Pull(arg1 context.Context, arg2 logr.Logger, arg3 string, arg4 string, arg5 string, arg6 *v1b.Platform, arg7 *artifact.PullSignatureOptions) (*artifact.PullResult, error) {
+func (fake *FakeImpl) Pull(arg1 context.Context, arg2 logr.Logger, arg3 string, arg4 string, arg5 string, arg6 *v1b.Platform, arg7 *artifact.PullOptions) (*artifact.PullResult, error) {
 	fake.pullMutex.Lock()
 	ret, specificReturn := fake.pullReturnsOnCall[len(fake.pullArgsForCall)]
 	fake.pullArgsForCall = append(fake.pullArgsForCall, struct {
@@ -298,7 +298,7 @@ func (fake *FakeImpl) Pull(arg1 context.Context, arg2 logr.Logger, arg3 string, 
 		arg4 string
 		arg5 string
 		arg6 *v1b.Platform
-		arg7 *artifact.PullSignatureOptions
+		arg7 *artifact.PullOptions
 	}{arg1, arg2, arg3, arg4, arg5, arg6, arg7})
 	stub := fake.PullStub
 	fakeReturns := fake.pullReturns
@@ -319,13 +319,13 @@ func (fake *FakeImpl) PullCallCount() int {
 	return len(fake.pullArgsForCall)
 }
 
-func (fake *FakeImpl) PullCalls(stub func(context.Context, logr.Logger, string, string, string, *v1b.Platform, *artifact.PullSignatureOptions) (*artifact.PullResult, error)) {
+func (fake *FakeImpl) PullCalls(stub func(context.Context, logr.Logger, string, string, string, *v1b.Platform, *artifact.PullOptions) (*artifact.PullResult, error)) {
 	fake.pullMutex.Lock()
 	defer fake.pullMutex.Unlock()
 	fake.PullStub = stub
 }
 
-func (fake *FakeImpl) PullArgsForCall(i int) (context.Context, logr.Logger, string, string, string, *v1b.Platform, *artifact.PullSignatureOptions) {
+func (fake *FakeImpl) PullArgsForCall(i int) (context.Context, logr.Logger, string, string, string, *v1b.Platform, *artifact.PullOptions) {
 	fake.pullMutex.RLock()
 	defer fake.pullMutex.RUnlock()
 	argsForCall := fake.pullArgsForCall[i]

--- a/release-baseprofiles.md
+++ b/release-baseprofiles.md
@@ -25,9 +25,9 @@ recorded against as the tag:
 
 | Location | Purpose |
 | - | - |
-| `gcr.io/k8s-staging-sp-operator/base/<runtime>:<version>` | published on merge, anonymously readable, what the end-to-end tests read |
-| `gcr.io/k8s-staging-sp-operator/base/<runtime>:latest` | follows the newest recording, staging only, never promoted |
-| `registry.k8s.io/security-profiles-operator/base/<runtime>:<version>` | promoted from staging, what a cluster should reference |
+| `gcr.io/k8s-staging-sp-operator/base/<runtime>:<version>` | published on merge, anonymously readable, what the end-to-end tests read on `main` |
+| `gcr.io/k8s-staging-sp-operator/base/<runtime>:latest` | follows the newest recording, for manual pulls; staging only, never promoted |
+| `registry.k8s.io/security-profiles-operator/base/<runtime>:<version>` | promoted from staging, what a cluster should reference and what the end-to-end tests read on a release branch |
 
 They are published in the runtime format: a single layer holding the profile as
 OCI runtime-spec JSON, identified by the media type
@@ -60,10 +60,12 @@ repository has to change:
 
 - the end-to-end test that applies the profile reads `metadata.name` from the
   file
-- the end-to-end test that pulls the artifact uses the `latest` tag
+- the end-to-end test that pulls the artifact derives the tag from that name
 
-Merging publishes it: the staging build pushes the new version and repoints
-`latest`, so the next test run exercises the new recording.
+Merging publishes it: the staging build pushes the new version (and repoints
+`latest`), so the next test run exercises the new recording. Promote the new
+version before cutting a release, because `hack/release.sh` points the test at
+`registry.k8s.io`.
 
 ## Publishing by hand
 
@@ -78,11 +80,12 @@ registry or when the build cannot run:
 environments without an OIDC identity, and `SKIP_EXISTING=false` republishes a
 version that is already there.
 
-Versions that are already published are skipped, because an artifact carries a
-creation timestamp and republishing identical content only produces a new
-digest and a stray untagged one. Skipping is keyed on the version tag, so a
-profile that is re-recorded without the runtime version changing needs
-`SKIP_EXISTING=false` to reach the registry.
+Versions that are already published are skipped. Identical content yields the
+same digest (the manifest's creation timestamp is fixed unless
+`SOURCE_DATE_EPOCH` is set), so a republish would be a no-op for the registry;
+skipping only avoids the pushes and the `latest` repoint. Skipping is keyed on
+the version tag, so a profile that is re-recorded without the runtime version
+changing needs `SKIP_EXISTING=false` to reach the registry.
 
 ## Promoting to registry.k8s.io
 

--- a/test/spoc/e2e_spoc_pushpull_test.go
+++ b/test/spoc/e2e_spoc_pushpull_test.go
@@ -1,0 +1,180 @@
+//go:build linux && !no_bpf
+
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main_test
+
+import (
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/google/go-containerregistry/pkg/registry"
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/yaml"
+
+	seccompprofileapi "sigs.k8s.io/security-profiles-operator/api/seccompprofile/v1"
+)
+
+// pushPullTest exercises spoc push and pull against an in-process OCI
+// registry served over plain HTTP, so the round trip needs neither network
+// access nor a public registry. Signing is skipped on both sides because
+// keyless signing needs an OIDC identity.
+func pushPullTest(t *testing.T) {
+	server := httptest.NewServer(registry.New())
+	defer server.Close()
+
+	host := strings.TrimPrefix(server.URL, "http://")
+
+	t.Run("runtime-spec seccomp profile", func(t *testing.T) {
+		const profile = `{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "syscalls": [{"names": ["read", "write"], "action": "SCMP_ACT_ALLOW"}]
+}
+`
+
+		in := writeTempFile(t, "profile.json", profile)
+		ref := host + "/spoc/e2e/runtime:v1"
+
+		_, err := runSpoc(t, "push", "--plain-http", "--disable-signing", "-f", in, ref)
+		require.NoError(t, err, "push runtime-spec profile")
+
+		out := filepath.Join(t.TempDir(), "pulled.json")
+		_, err = runSpoc(t,
+			"pull", "--plain-http", "--disable-signature-verification", "-o", out, ref,
+		)
+		require.NoError(t, err, "pull runtime-spec profile")
+
+		pulled, err := os.ReadFile(out)
+		require.NoError(t, err)
+		require.JSONEq(t, profile, string(pulled),
+			"runtime format content must round trip unchanged")
+	})
+
+	t.Run("profile CRD", func(t *testing.T) {
+		crd := seccompprofileapi.SeccompProfile{
+			Spec: seccompprofileapi.SeccompProfileSpec{
+				DefaultAction: seccompprofileapi.ActErrno,
+				Syscalls: []seccompprofileapi.Syscall{
+					{Names: []string{"read", "write"}, Action: seccompprofileapi.ActAllow},
+				},
+			},
+		}
+		crd.APIVersion = seccompprofileapi.GroupVersion.String()
+		crd.Kind = "SeccompProfile"
+		crd.Name = "e2e"
+
+		content, err := yaml.Marshal(crd)
+		require.NoError(t, err)
+
+		in := writeTempFile(t, "profile.yaml", string(content))
+		ref := host + "/spoc/e2e/crd:v1"
+
+		_, err = runSpoc(t, "push", "--plain-http", "--disable-signing", "-f", in, ref)
+		require.NoError(t, err, "push profile CRD")
+
+		out := filepath.Join(t.TempDir(), "pulled.yaml")
+		_, err = runSpoc(t,
+			"pull", "--plain-http", "--disable-signature-verification", "-o", out, ref,
+		)
+		require.NoError(t, err, "pull profile CRD")
+
+		pulled, err := os.ReadFile(out)
+		require.NoError(t, err)
+
+		var got seccompprofileapi.SeccompProfile
+		require.NoError(t, yaml.Unmarshal(pulled, &got))
+		require.Equal(t, crd.Spec, got.Spec)
+	})
+
+	t.Run("push rejects what runtimes reject", func(t *testing.T) {
+		const invalid = `{
+  "defaultAction": "SCMP_ACT_ALLOW",
+  "listenerPath": "/run/seccomp-listener.sock",
+  "syscalls": [{"names": ["mount"], "action": "SCMP_ACT_NOTIFY"}]
+}
+`
+
+		in := writeTempFile(t, "invalid.json", invalid)
+		ref := host + "/spoc/e2e/invalid:v1"
+
+		_, err := runSpoc(t, "push", "--plain-http", "--disable-signing", "-f", in, ref)
+		require.Error(t, err, "a profile runtimes reject must not be pushed by default")
+
+		_, err = runSpoc(t,
+			"push", "--plain-http", "--disable-signing", "--disable-artifact-validation",
+			"-f", in, ref,
+		)
+		require.NoError(t, err, "the opt-out publishes it anyway")
+	})
+
+	t.Run("identical content gets the same digest", func(t *testing.T) {
+		const profile = `{"defaultAction": "SCMP_ACT_ERRNO"}` + "\n"
+
+		in := writeTempFile(t, "profile.json", profile)
+
+		first := pushAndDigest(t, in, host+"/spoc/e2e/stable:v1")
+		second := pushAndDigest(t, in, host+"/spoc/e2e/stable:v2")
+		require.Equal(t, first, second, "pushing the same content twice must not change the digest")
+	})
+}
+
+// pushAndDigest pushes the file and returns the digest spoc logged for it.
+func pushAndDigest(t *testing.T, file, ref string) string {
+	t.Helper()
+
+	out := runSpocOutput(t, "push", "--plain-http", "--disable-signing", "-f", file, ref)
+
+	// The line looks like: Pushed artifact (reference=host/repo@sha256:...)
+	const marker = "@sha256:"
+
+	idx := strings.LastIndex(out, marker)
+	require.NotEqual(t, -1, idx, "push output should log the pushed digest: %s", out)
+
+	digest := out[idx+1:]
+	if end := strings.IndexAny(digest, ")\" \n"); end != -1 {
+		digest = digest[:end]
+	}
+
+	require.Len(t, digest, len("sha256:")+64, "unexpected digest %q", digest)
+
+	return digest
+}
+
+// runSpocOutput runs spoc and returns its combined output.
+func runSpocOutput(t *testing.T, args ...string) string {
+	t.Helper()
+
+	args = append([]string{spocPath}, args...)
+	out, err := exec.Command("sudo", args...).CombinedOutput()
+	require.NoError(t, err, "failed to run spoc: %s", string(out))
+
+	return string(out)
+}
+
+func writeTempFile(t *testing.T, name, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), name)
+	// spoc runs as root and can read the owner-only file.
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o600))
+
+	return path
+}

--- a/test/spoc/e2e_spoc_test.go
+++ b/test/spoc/e2e_spoc_test.go
@@ -55,6 +55,7 @@ func TestSpoc(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("record", recordTest)
+	t.Run("push-pull", pushPullTest)
 }
 
 func recordTest(t *testing.T) {

--- a/test/tc_base_profiles_oci_runtime_test.go
+++ b/test/tc_base_profiles_oci_runtime_test.go
@@ -26,17 +26,27 @@ import (
 	"sigs.k8s.io/security-profiles-operator/internal/pkg/config"
 )
 
-// The recorded base profiles, one artifact per runtime. The test reads them
-// from the staging registry rather than from registry.k8s.io: staging is
-// anonymously readable, the staging build refreshes it on every merge, and it
-// carries a latest tag that follows the newest recording, so a runtime version
-// bump needs no edit here. registry.k8s.io only receives the versioned tags,
-// and only once a promotion lands.
-const (
-	baseProfileRegistry = "oci://gcr.io/k8s-staging-sp-operator/base/"
-	baseProfileRunc     = "runc:latest"
-	baseProfileCrun     = "crun:latest"
-)
+// The recorded base profiles live under this prefix, one artifact per runtime
+// with the recorded runtime version as the tag. On main this is the staging
+// registry, which the staging build refreshes on every merge, so a new
+// recording is available to the next test run without a promotion. The
+// release script points it at registry.k8s.io, so a release branch exercises
+// the promoted artifact, and the back-to-dev script switches it back.
+const baseProfileRegistry = "oci://gcr.io/k8s-staging-sp-operator/base/"
+
+// baseProfileArtifact returns the artifact reference of the recorded base
+// profile for the runtime. The tag is the version from the recorded profile's
+// metadata.name, so re-recording against a new runtime version needs no edit
+// here.
+func (e *e2e) baseProfileArtifact(runtime string) string {
+	name := e.recordedBaseProfileName(fmt.Sprintf("examples/baseprofile-%s.yaml", runtime))
+
+	version := strings.TrimPrefix(name, runtime+"-")
+	e.Require().NotEqual(name, version,
+		"recorded profile %q should be named <runtime>-<version>", name)
+
+	return baseProfileRegistry + runtime + ":" + version
+}
 
 // testCaseBaseProfileOCIRuntimeFormat verifies that a base profile referencing
 // an artifact in the runtime format, a single raw runtime-spec JSON layer with
@@ -67,12 +77,12 @@ func (e *e2e) testCaseBaseProfileOCIRuntimeFormat(nodes []string) {
 		e.waitInOperatorNSFor("condition=ready", "spod", "spod")
 	}()
 
-	artifact := baseProfileRunc
+	runtime := "runc"
 	if clusterType == clusterTypeVanilla && e.containerRuntime != containerRuntimeDocker {
-		artifact = baseProfileCrun
+		runtime = "crun"
 	}
 
-	baseProfileName := baseProfileRegistry + artifact
+	baseProfileName := e.baseProfileArtifact(runtime)
 
 	profileName := fmt.Sprintf("hello-oci-runtime-%v", time.Now().Unix())
 	profileYAML := fmt.Sprintf(`

--- a/vendor/github.com/google/go-containerregistry/internal/httptest/httptest.go
+++ b/vendor/github.com/google/go-containerregistry/internal/httptest/httptest.go
@@ -1,0 +1,104 @@
+// Copyright 2020 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package httptest provides a method for testing a TLS server a la net/http/httptest.
+package httptest
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"time"
+)
+
+// NewTLSServer returns an httptest server, with an http client that has been configured to
+// send all requests to the returned server. The TLS certs are generated for the given domain.
+// If you need a transport, Client().Transport is correctly configured.
+func NewTLSServer(domain string, handler http.Handler) (*httptest.Server, error) {
+	s := httptest.NewUnstartedServer(handler)
+
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		IPAddresses: []net.IP{
+			net.IPv4(127, 0, 0, 1),
+			net.IPv6loopback,
+		},
+		DNSNames: []string{domain},
+
+		KeyUsage:              x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	priv, err := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	if err != nil {
+		return nil, err
+	}
+
+	b, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		return nil, err
+	}
+
+	pc := &bytes.Buffer{}
+	if err := pem.Encode(pc, &pem.Block{Type: "CERTIFICATE", Bytes: b}); err != nil {
+		return nil, err
+	}
+
+	ek, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return nil, err
+	}
+
+	pk := &bytes.Buffer{}
+	if err := pem.Encode(pk, &pem.Block{Type: "EC PRIVATE KEY", Bytes: ek}); err != nil {
+		return nil, err
+	}
+
+	c, err := tls.X509KeyPair(pc.Bytes(), pk.Bytes())
+	if err != nil {
+		return nil, err
+	}
+	s.TLS = &tls.Config{
+		Certificates: []tls.Certificate{c},
+	}
+	s.StartTLS()
+
+	certpool := x509.NewCertPool()
+	certpool.AddCert(s.Certificate())
+
+	t := &http.Transport{
+		TLSClientConfig: &tls.Config{
+			RootCAs: certpool,
+		},
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			return net.Dial(s.Listener.Addr().Network(), s.Listener.Addr().String())
+		},
+	}
+	s.Client().Transport = t
+
+	return s, nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/README.md
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/README.md
@@ -1,0 +1,14 @@
+# `pkg/registry`
+
+This package implements a Docker v2 registry and the OCI distribution specification.
+
+It is designed to be used anywhere a low dependency container registry is needed, with an initial focus on tests.
+
+Its goal is to be standards compliant and its strictness will increase over time.
+
+This is currently a low flightmiles system. It's likely quite safe to use in tests; If you're using it in production, please let us know how and send us PRs for integration tests.
+
+Before sending a PR, understand that the expectation of this package is that it remain free of extraneous dependencies.
+This means that we expect `pkg/registry` to only have dependencies on Go's standard library, and other packages in `go-containerregistry`.
+
+You may be asked to change your code to reduce dependencies, and your PR might be rejected if this is deemed impossible.

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/blobs.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/blobs.go
@@ -1,0 +1,540 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"math/rand"
+	"net/http"
+	"path"
+	"strings"
+	"sync"
+
+	"github.com/google/go-containerregistry/internal/verify"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+// Returns whether this url should be handled by the blob handler
+// This is complicated because blob is indicated by the trailing path, not the leading path.
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pulling-a-layer
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pushing-a-layer
+func isBlob(req *http.Request) bool {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	if elem[len(elem)-1] == "" {
+		elem = elem[:len(elem)-1]
+	}
+	if len(elem) < 3 {
+		return false
+	}
+	return elem[len(elem)-2] == "blobs" || (elem[len(elem)-3] == "blobs" &&
+		elem[len(elem)-2] == "uploads")
+}
+
+// BlobHandler represents a minimal blob storage backend, capable of serving
+// blob contents.
+type BlobHandler interface {
+	// Get gets the blob contents, or errNotFound if the blob wasn't found.
+	Get(ctx context.Context, repo string, h v1.Hash) (io.ReadCloser, error)
+}
+
+// BlobStatHandler is an extension interface representing a blob storage
+// backend that can serve metadata about blobs.
+type BlobStatHandler interface {
+	// Stat returns the size of the blob, or errNotFound if the blob wasn't
+	// found, or RedirectError if the blob can be found elsewhere.
+	Stat(ctx context.Context, repo string, h v1.Hash) (int64, error)
+}
+
+// BlobPutHandler is an extension interface representing a blob storage backend
+// that can write blob contents.
+type BlobPutHandler interface {
+	// Put puts the blob contents.
+	//
+	// The contents will be verified against the expected size and digest
+	// as the contents are read, and an error will be returned if these
+	// don't match. Implementations should return that error, or a wrapper
+	// around that error, to return the correct error when these don't match.
+	Put(ctx context.Context, repo string, h v1.Hash, rc io.ReadCloser) error
+}
+
+// BlobDeleteHandler is an extension interface representing a blob storage
+// backend that can delete blob contents.
+type BlobDeleteHandler interface {
+	// Delete the blob contents.
+	Delete(ctx context.Context, repo string, h v1.Hash) error
+}
+
+// RedirectError represents a signal that the blob handler doesn't have the blob
+// contents, but that those contents are at another location which registry
+// clients should redirect to.
+type RedirectError struct {
+	// Location is the location to find the contents.
+	Location string
+
+	// Code is the HTTP redirect status code to return to clients.
+	Code int
+}
+
+type bytesCloser struct {
+	*bytes.Reader
+}
+
+func (r *bytesCloser) Close() error {
+	return nil
+}
+
+func (e RedirectError) Error() string { return fmt.Sprintf("redirecting (%d): %s", e.Code, e.Location) }
+
+// ErrNotFound represents an error locating the blob.
+var ErrNotFound = errors.New("not found")
+
+type memHandler struct {
+	m    map[string][]byte
+	lock sync.Mutex
+}
+
+func NewInMemoryBlobHandler() BlobHandler { return &memHandler{m: map[string][]byte{}} }
+
+func (m *memHandler) Stat(_ context.Context, _ string, h v1.Hash) (int64, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	b, found := m.m[h.String()]
+	if !found {
+		return 0, ErrNotFound
+	}
+	return int64(len(b)), nil
+}
+
+func (m *memHandler) Get(_ context.Context, _ string, h v1.Hash) (io.ReadCloser, error) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	b, found := m.m[h.String()]
+	if !found {
+		return nil, ErrNotFound
+	}
+	return &bytesCloser{bytes.NewReader(b)}, nil
+}
+
+func (m *memHandler) Put(_ context.Context, _ string, h v1.Hash, rc io.ReadCloser) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	defer rc.Close()
+	all, err := io.ReadAll(rc)
+	if err != nil {
+		return err
+	}
+	m.m[h.String()] = all
+	return nil
+}
+
+func (m *memHandler) Delete(_ context.Context, _ string, h v1.Hash) error {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	if _, found := m.m[h.String()]; !found {
+		return ErrNotFound
+	}
+
+	delete(m.m, h.String())
+	return nil
+}
+
+// blobs
+type blobs struct {
+	blobHandler BlobHandler
+
+	// Each upload gets a unique id that writes occur to until finalized.
+	uploads map[string][]byte
+	lock    sync.Mutex
+	log     *log.Logger
+}
+
+func (b *blobs) handle(resp http.ResponseWriter, req *http.Request) *regError {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	if elem[len(elem)-1] == "" {
+		elem = elem[:len(elem)-1]
+	}
+	// Must have a path of form /v2/{name}/blobs/{upload,sha256:}
+	if len(elem) < 4 {
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "NAME_INVALID",
+			Message: "blobs must be attached to a repo",
+		}
+	}
+	target := elem[len(elem)-1]
+	service := elem[len(elem)-2]
+	digest := req.URL.Query().Get("digest")
+	contentRange := req.Header.Get("Content-Range")
+	rangeHeader := req.Header.Get("Range")
+
+	repo := req.URL.Host + path.Join(elem[1:len(elem)-2]...)
+
+	switch req.Method {
+	case http.MethodHead:
+		h, err := v1.NewHash(target)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+
+		var size int64
+		if bsh, ok := b.blobHandler.(BlobStatHandler); ok {
+			size, err = bsh.Stat(req.Context(), repo, h)
+			if errors.Is(err, ErrNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr RedirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+				return regErrInternal(err)
+			}
+		} else {
+			rc, err := b.blobHandler.Get(req.Context(), repo, h)
+			if errors.Is(err, ErrNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr RedirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+				return regErrInternal(err)
+			}
+			defer rc.Close()
+			size, err = io.Copy(io.Discard, rc)
+			if err != nil {
+				return regErrInternal(err)
+			}
+		}
+
+		resp.Header().Set("Content-Length", fmt.Sprint(size))
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.WriteHeader(http.StatusOK)
+		return nil
+
+	case http.MethodGet:
+		h, err := v1.NewHash(target)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+
+		var size int64
+		var r io.Reader
+		if bsh, ok := b.blobHandler.(BlobStatHandler); ok {
+			size, err = bsh.Stat(req.Context(), repo, h)
+			if errors.Is(err, ErrNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr RedirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+				return regErrInternal(err)
+			}
+
+			rc, err := b.blobHandler.Get(req.Context(), repo, h)
+			if errors.Is(err, ErrNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr RedirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+
+				return regErrInternal(err)
+			}
+
+			defer rc.Close()
+			r = rc
+
+		} else {
+			tmp, err := b.blobHandler.Get(req.Context(), repo, h)
+			if errors.Is(err, ErrNotFound) {
+				return regErrBlobUnknown
+			} else if err != nil {
+				var rerr RedirectError
+				if errors.As(err, &rerr) {
+					http.Redirect(resp, req, rerr.Location, rerr.Code)
+					return nil
+				}
+
+				return regErrInternal(err)
+			}
+			defer tmp.Close()
+			var buf bytes.Buffer
+			io.Copy(&buf, tmp)
+			size = int64(buf.Len())
+			r = &buf
+		}
+
+		if rangeHeader != "" {
+			start, end := int64(0), int64(0)
+			if _, err := fmt.Sscanf(rangeHeader, "bytes=%d-%d", &start, &end); err != nil {
+				return &regError{
+					Status:  http.StatusRequestedRangeNotSatisfiable,
+					Code:    "BLOB_UNKNOWN",
+					Message: "We don't understand your Range",
+				}
+			}
+
+			n := (end + 1) - start
+			if ra, ok := r.(io.ReaderAt); ok {
+				if end+1 > size {
+					return &regError{
+						Status:  http.StatusRequestedRangeNotSatisfiable,
+						Code:    "BLOB_UNKNOWN",
+						Message: fmt.Sprintf("range end %d > %d size", end+1, size),
+					}
+				}
+				r = io.NewSectionReader(ra, start, n)
+			} else {
+				if _, err := io.CopyN(io.Discard, r, start); err != nil {
+					return &regError{
+						Status:  http.StatusRequestedRangeNotSatisfiable,
+						Code:    "BLOB_UNKNOWN",
+						Message: fmt.Sprintf("Failed to discard %d bytes", start),
+					}
+				}
+
+				r = io.LimitReader(r, n)
+			}
+
+			resp.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", start, end, size))
+			resp.Header().Set("Content-Length", fmt.Sprint(n))
+			resp.Header().Set("Docker-Content-Digest", h.String())
+			resp.WriteHeader(http.StatusPartialContent)
+		} else {
+			resp.Header().Set("Content-Length", fmt.Sprint(size))
+			resp.Header().Set("Docker-Content-Digest", h.String())
+			resp.WriteHeader(http.StatusOK)
+		}
+
+		io.Copy(resp, r)
+		return nil
+
+	case http.MethodPost:
+		bph, ok := b.blobHandler.(BlobPutHandler)
+		if !ok {
+			return regErrUnsupported
+		}
+
+		// It is weird that this is "target" instead of "service", but
+		// that's how the index math works out above.
+		if target != "uploads" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "METHOD_UNKNOWN",
+				Message: fmt.Sprintf("POST to /blobs must be followed by /uploads, got %s", target),
+			}
+		}
+
+		if digest != "" {
+			h, err := v1.NewHash(digest)
+			if err != nil {
+				return regErrDigestInvalid
+			}
+
+			vrc, err := verify.ReadCloser(req.Body, req.ContentLength, h)
+			if err != nil {
+				return regErrInternal(err)
+			}
+			defer vrc.Close()
+
+			if err = bph.Put(req.Context(), repo, h, vrc); err != nil {
+				if errors.As(err, &verify.Error{}) {
+					log.Printf("Digest mismatch: %v", err)
+					return regErrDigestMismatch
+				}
+				return regErrInternal(err)
+			}
+			resp.Header().Set("Docker-Content-Digest", h.String())
+			resp.WriteHeader(http.StatusCreated)
+			return nil
+		}
+
+		id := fmt.Sprint(rand.Int63())
+		resp.Header().Set("Location", "/"+path.Join("v2", path.Join(elem[1:len(elem)-2]...), "blobs/uploads", id))
+		resp.Header().Set("Range", "0-0")
+		resp.WriteHeader(http.StatusAccepted)
+		return nil
+
+	case http.MethodPatch:
+		if service != "uploads" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "METHOD_UNKNOWN",
+				Message: fmt.Sprintf("PATCH to /blobs must be followed by /uploads, got %s", service),
+			}
+		}
+
+		if contentRange != "" {
+			start, end := 0, 0
+			if _, err := fmt.Sscanf(contentRange, "%d-%d", &start, &end); err != nil {
+				return &regError{
+					Status:  http.StatusRequestedRangeNotSatisfiable,
+					Code:    "BLOB_UPLOAD_UNKNOWN",
+					Message: "We don't understand your Content-Range",
+				}
+			}
+			b.lock.Lock()
+			defer b.lock.Unlock()
+			if start != len(b.uploads[target]) {
+				return &regError{
+					Status:  http.StatusRequestedRangeNotSatisfiable,
+					Code:    "BLOB_UPLOAD_UNKNOWN",
+					Message: "Your content range doesn't match what we have",
+				}
+			}
+			l := bytes.NewBuffer(b.uploads[target])
+			io.Copy(l, req.Body)
+			b.uploads[target] = l.Bytes()
+			resp.Header().Set("Location", "/"+path.Join("v2", path.Join(elem[1:len(elem)-3]...), "blobs/uploads", target))
+			resp.Header().Set("Range", fmt.Sprintf("0-%d", len(l.Bytes())-1))
+			// OCI Distribution spec §10.5 requires 202 Accepted for chunk uploads.
+			resp.WriteHeader(http.StatusAccepted)
+			return nil
+		}
+
+		b.lock.Lock()
+		defer b.lock.Unlock()
+		if _, ok := b.uploads[target]; ok {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "BLOB_UPLOAD_INVALID",
+				Message: "Stream uploads after first write are not allowed",
+			}
+		}
+
+		l := &bytes.Buffer{}
+		io.Copy(l, req.Body)
+
+		b.uploads[target] = l.Bytes()
+		resp.Header().Set("Location", "/"+path.Join("v2", path.Join(elem[1:len(elem)-3]...), "blobs/uploads", target))
+		resp.Header().Set("Range", fmt.Sprintf("0-%d", len(l.Bytes())-1))
+		// OCI Distribution spec §10.5 requires 202 Accepted for chunk uploads.
+		resp.WriteHeader(http.StatusAccepted)
+		return nil
+
+	case http.MethodPut:
+		bph, ok := b.blobHandler.(BlobPutHandler)
+		if !ok {
+			return regErrUnsupported
+		}
+
+		if service != "uploads" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "METHOD_UNKNOWN",
+				Message: fmt.Sprintf("PUT to /blobs must be followed by /uploads, got %s", service),
+			}
+		}
+
+		if digest == "" {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "DIGEST_INVALID",
+				Message: "digest not specified",
+			}
+		}
+
+		b.lock.Lock()
+		defer b.lock.Unlock()
+
+		h, err := v1.NewHash(digest)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+
+		defer req.Body.Close()
+		in := io.NopCloser(io.MultiReader(bytes.NewBuffer(b.uploads[target]), req.Body))
+
+		size := int64(verify.SizeUnknown)
+		if req.ContentLength > 0 {
+			size = int64(len(b.uploads[target])) + req.ContentLength
+		}
+
+		vrc, err := verify.ReadCloser(in, size, h)
+		if err != nil {
+			return regErrInternal(err)
+		}
+		defer vrc.Close()
+
+		if err := bph.Put(req.Context(), repo, h, vrc); err != nil {
+			if errors.As(err, &verify.Error{}) {
+				log.Printf("Digest mismatch: %v", err)
+				return regErrDigestMismatch
+			}
+			return regErrInternal(err)
+		}
+
+		delete(b.uploads, target)
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.WriteHeader(http.StatusCreated)
+		return nil
+
+	case http.MethodDelete:
+		bdh, ok := b.blobHandler.(BlobDeleteHandler)
+		if !ok {
+			return regErrUnsupported
+		}
+
+		h, err := v1.NewHash(target)
+		if err != nil {
+			return &regError{
+				Status:  http.StatusBadRequest,
+				Code:    "NAME_INVALID",
+				Message: "invalid digest",
+			}
+		}
+		if err := bdh.Delete(req.Context(), repo, h); err != nil {
+			return regErrInternal(err)
+		}
+		resp.WriteHeader(http.StatusAccepted)
+		return nil
+
+	default:
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/blobs_disk.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/blobs_disk.go
@@ -1,0 +1,84 @@
+// Copyright 2023 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+)
+
+type diskHandler struct {
+	dir string
+}
+
+func NewDiskBlobHandler(dir string) BlobHandler { return &diskHandler{dir: dir} }
+
+func (m *diskHandler) blobHashPath(h v1.Hash) string {
+	return filepath.Join(m.dir, h.Algorithm, h.Hex)
+}
+
+func (m *diskHandler) Stat(_ context.Context, _ string, h v1.Hash) (int64, error) {
+	f, err := os.Open(m.blobHashPath(h))
+	if errors.Is(err, os.ErrNotExist) {
+		return 0, ErrNotFound
+	} else if err != nil {
+		return 0, err
+	}
+	defer f.Close()
+
+	got, size, err := v1.SHA256(f)
+	if err != nil {
+		return 0, err
+	}
+	if got != h {
+		return 0, fmt.Errorf("%w: blob %s has digest %s", ErrNotFound, h, got)
+	}
+	return size, nil
+}
+
+func (m *diskHandler) Get(_ context.Context, _ string, h v1.Hash) (io.ReadCloser, error) {
+	return os.Open(m.blobHashPath(h))
+}
+
+func (m *diskHandler) Put(_ context.Context, _ string, h v1.Hash, rc io.ReadCloser) error {
+	// Put the temp file in the same directory to avoid cross-device problems
+	// during the os.Rename.  The filenames cannot conflict.
+	f, err := os.CreateTemp(m.dir, "upload-*")
+	if err != nil {
+		return err
+	}
+
+	if err := func() error {
+		defer f.Close()
+		_, err := io.Copy(f, rc)
+		return err
+	}(); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Join(m.dir, h.Algorithm), os.ModePerm); err != nil {
+		return err
+	}
+	return os.Rename(f.Name(), m.blobHashPath(h))
+}
+
+func (m *diskHandler) Delete(_ context.Context, _ string, h v1.Hash) error {
+	return os.Remove(m.blobHashPath(h))
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/error.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/error.go
@@ -1,0 +1,79 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+type regError struct {
+	Status  int
+	Code    string
+	Message string
+}
+
+func (r *regError) Write(resp http.ResponseWriter) error {
+	resp.WriteHeader(r.Status)
+
+	type err struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}
+	type wrap struct {
+		Errors []err `json:"errors"`
+	}
+	return json.NewEncoder(resp).Encode(wrap{
+		Errors: []err{
+			{
+				Code:    r.Code,
+				Message: r.Message,
+			},
+		},
+	})
+}
+
+// regErrInternal returns an internal server error.
+func regErrInternal(err error) *regError {
+	return &regError{
+		Status:  http.StatusInternalServerError,
+		Code:    "INTERNAL_SERVER_ERROR",
+		Message: err.Error(),
+	}
+}
+
+var regErrBlobUnknown = &regError{
+	Status:  http.StatusNotFound,
+	Code:    "BLOB_UNKNOWN",
+	Message: "Unknown blob",
+}
+
+var regErrUnsupported = &regError{
+	Status:  http.StatusMethodNotAllowed,
+	Code:    "UNSUPPORTED",
+	Message: "Unsupported operation",
+}
+
+var regErrDigestMismatch = &regError{
+	Status:  http.StatusBadRequest,
+	Code:    "DIGEST_INVALID",
+	Message: "digest does not match contents",
+}
+
+var regErrDigestInvalid = &regError{
+	Status:  http.StatusBadRequest,
+	Code:    "NAME_INVALID",
+	Message: "invalid digest",
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/manifest.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/manifest.go
@@ -1,0 +1,446 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/types"
+)
+
+type catalog struct {
+	Repos []string `json:"repositories"`
+}
+
+type listTags struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags"`
+}
+
+type manifest struct {
+	contentType string
+	blob        []byte
+}
+
+type manifests struct {
+	// maps repo -> manifest tag/digest -> manifest
+	manifests map[string]map[string]manifest
+	lock      sync.RWMutex
+	log       *log.Logger
+}
+
+func isManifest(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 4 {
+		return false
+	}
+	return elems[len(elems)-2] == "manifests"
+}
+
+func isTags(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 4 {
+		return false
+	}
+	return elems[len(elems)-2] == "tags"
+}
+
+func isCatalog(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 2 {
+		return false
+	}
+
+	return elems[len(elems)-1] == "_catalog"
+}
+
+// Returns whether this url should be handled by the referrers handler
+func isReferrers(req *http.Request) bool {
+	elems := strings.Split(req.URL.Path, "/")
+	elems = elems[1:]
+	if len(elems) < 4 {
+		return false
+	}
+	return elems[len(elems)-2] == "referrers"
+}
+
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pulling-an-image-manifest
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#pushing-an-image
+func (m *manifests) handle(resp http.ResponseWriter, req *http.Request) *regError {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	target := elem[len(elem)-1]
+	repo := strings.Join(elem[1:len(elem)-2], "/")
+
+	switch req.Method {
+	case http.MethodGet:
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		c, ok := m.manifests[repo]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+		m, ok := c[target]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "MANIFEST_UNKNOWN",
+				Message: "Unknown manifest",
+			}
+		}
+
+		h, _, _ := v1.SHA256(bytes.NewReader(m.blob))
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.Header().Set("Content-Type", m.contentType)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(m.blob)))
+		resp.WriteHeader(http.StatusOK)
+		io.Copy(resp, bytes.NewReader(m.blob))
+		return nil
+
+	case http.MethodHead:
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		if _, ok := m.manifests[repo]; !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+		m, ok := m.manifests[repo][target]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "MANIFEST_UNKNOWN",
+				Message: "Unknown manifest",
+			}
+		}
+
+		h, _, _ := v1.SHA256(bytes.NewReader(m.blob))
+		resp.Header().Set("Docker-Content-Digest", h.String())
+		resp.Header().Set("Content-Type", m.contentType)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(m.blob)))
+		resp.WriteHeader(http.StatusOK)
+		return nil
+
+	case http.MethodPut:
+		b := &bytes.Buffer{}
+		io.Copy(b, req.Body)
+		h, _, _ := v1.SHA256(bytes.NewReader(b.Bytes()))
+		digest := h.String()
+		mf := manifest{
+			blob:        b.Bytes(),
+			contentType: req.Header.Get("Content-Type"),
+		}
+
+		// If the manifest is a manifest list, check that the manifest
+		// list's constituent manifests are already uploaded.
+		// This isn't strictly required by the registry API, but some
+		// registries require this.
+		if types.MediaType(mf.contentType).IsIndex() {
+			if err := func() *regError {
+				m.lock.RLock()
+				defer m.lock.RUnlock()
+
+				im, err := v1.ParseIndexManifest(b)
+				if err != nil {
+					return &regError{
+						Status:  http.StatusBadRequest,
+						Code:    "MANIFEST_INVALID",
+						Message: err.Error(),
+					}
+				}
+				for _, desc := range im.Manifests {
+					if !desc.MediaType.IsDistributable() {
+						continue
+					}
+					if desc.MediaType.IsIndex() || desc.MediaType.IsImage() {
+						if _, found := m.manifests[repo][desc.Digest.String()]; !found {
+							return &regError{
+								Status:  http.StatusNotFound,
+								Code:    "MANIFEST_UNKNOWN",
+								Message: fmt.Sprintf("Sub-manifest %q not found", desc.Digest),
+							}
+						}
+					} else {
+						// TODO: Probably want to do an existence check for blobs.
+						m.log.Printf("TODO: Check blobs for %q", desc.Digest)
+					}
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+
+		m.lock.Lock()
+		defer m.lock.Unlock()
+
+		if _, ok := m.manifests[repo]; !ok {
+			m.manifests[repo] = make(map[string]manifest, 2)
+		}
+
+		// Allow future references by target (tag) and immutable digest.
+		// See https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier.
+		m.manifests[repo][digest] = mf
+		m.manifests[repo][target] = mf
+		resp.Header().Set("Docker-Content-Digest", digest)
+		resp.WriteHeader(http.StatusCreated)
+		return nil
+
+	case http.MethodDelete:
+		m.lock.Lock()
+		defer m.lock.Unlock()
+		if _, ok := m.manifests[repo]; !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+
+		_, ok := m.manifests[repo][target]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "MANIFEST_UNKNOWN",
+				Message: "Unknown manifest",
+			}
+		}
+
+		delete(m.manifests[repo], target)
+		resp.WriteHeader(http.StatusAccepted)
+		return nil
+
+	default:
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+}
+
+func (m *manifests) handleTags(resp http.ResponseWriter, req *http.Request) *regError {
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	repo := strings.Join(elem[1:len(elem)-2], "/")
+
+	if req.Method == "GET" {
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		c, ok := m.manifests[repo]
+		if !ok {
+			return &regError{
+				Status:  http.StatusNotFound,
+				Code:    "NAME_UNKNOWN",
+				Message: "Unknown name",
+			}
+		}
+
+		var tags []string
+		for tag := range c {
+			if !strings.Contains(tag, "sha256:") {
+				tags = append(tags, tag)
+			}
+		}
+		sort.Strings(tags)
+
+		// https://github.com/opencontainers/distribution-spec/blob/b505e9cc53ec499edbd9c1be32298388921bb705/detail.md#tags-paginated
+		// Offset using last query parameter.
+		if last := req.URL.Query().Get("last"); last != "" {
+			for i, t := range tags {
+				if t > last {
+					tags = tags[i:]
+					break
+				}
+			}
+		}
+
+		// Limit using n query parameter.
+		if ns := req.URL.Query().Get("n"); ns != "" {
+			if n, err := strconv.Atoi(ns); err != nil {
+				return &regError{
+					Status:  http.StatusBadRequest,
+					Code:    "BAD_REQUEST",
+					Message: fmt.Sprintf("parsing n: %v", err),
+				}
+			} else if n < len(tags) {
+				tags = tags[:n]
+			}
+		}
+
+		tagsToList := listTags{
+			Name: repo,
+			Tags: tags,
+		}
+
+		msg, _ := json.Marshal(tagsToList)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(msg)))
+		resp.WriteHeader(http.StatusOK)
+		io.Copy(resp, bytes.NewReader([]byte(msg)))
+		return nil
+	}
+
+	return &regError{
+		Status:  http.StatusBadRequest,
+		Code:    "METHOD_UNKNOWN",
+		Message: "We don't understand your method + url",
+	}
+}
+
+func (m *manifests) handleCatalog(resp http.ResponseWriter, req *http.Request) *regError {
+	query := req.URL.Query()
+	nStr := query.Get("n")
+	n := 10000
+	if nStr != "" {
+		n, _ = strconv.Atoi(nStr)
+	}
+
+	if req.Method == "GET" {
+		m.lock.RLock()
+		defer m.lock.RUnlock()
+
+		var repos []string
+		countRepos := 0
+		// TODO: implement pagination
+		for key := range m.manifests {
+			if countRepos >= n {
+				break
+			}
+			countRepos++
+
+			repos = append(repos, key)
+		}
+
+		repositoriesToList := catalog{
+			Repos: repos,
+		}
+
+		msg, _ := json.Marshal(repositoriesToList)
+		resp.Header().Set("Content-Length", fmt.Sprint(len(msg)))
+		resp.WriteHeader(http.StatusOK)
+		io.Copy(resp, bytes.NewReader([]byte(msg)))
+		return nil
+	}
+
+	return &regError{
+		Status:  http.StatusBadRequest,
+		Code:    "METHOD_UNKNOWN",
+		Message: "We don't understand your method + url",
+	}
+}
+
+// TODO: implement handling of artifactType querystring
+func (m *manifests) handleReferrers(resp http.ResponseWriter, req *http.Request) *regError {
+	// Ensure this is a GET request
+	if req.Method != "GET" {
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+
+	elem := strings.Split(req.URL.Path, "/")
+	elem = elem[1:]
+	target := elem[len(elem)-1]
+	repo := strings.Join(elem[1:len(elem)-2], "/")
+
+	// Validate that incoming target is a valid digest
+	if _, err := v1.NewHash(target); err != nil {
+		return &regError{
+			Status:  http.StatusBadRequest,
+			Code:    "UNSUPPORTED",
+			Message: "Target must be a valid digest",
+		}
+	}
+
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	digestToManifestMap, repoExists := m.manifests[repo]
+	if !repoExists {
+		return &regError{
+			Status:  http.StatusNotFound,
+			Code:    "NAME_UNKNOWN",
+			Message: "Unknown name",
+		}
+	}
+
+	im := v1.IndexManifest{
+		SchemaVersion: 2,
+		MediaType:     types.OCIImageIndex,
+		Manifests:     []v1.Descriptor{},
+	}
+	for digest, manifest := range digestToManifestMap {
+		h, err := v1.NewHash(digest)
+		if err != nil {
+			continue
+		}
+		var refPointer struct {
+			Subject *v1.Descriptor `json:"subject"`
+		}
+		json.Unmarshal(manifest.blob, &refPointer)
+		if refPointer.Subject == nil {
+			continue
+		}
+		referenceDigest := refPointer.Subject.Digest
+		if referenceDigest.String() != target {
+			continue
+		}
+		// At this point, we know the current digest references the target
+		var imageAsArtifact struct {
+			Config struct {
+				MediaType string `json:"mediaType"`
+			} `json:"config"`
+			Annotations map[string]string `json:"annotations"`
+		}
+		json.Unmarshal(manifest.blob, &imageAsArtifact)
+		im.Manifests = append(im.Manifests, v1.Descriptor{
+			MediaType:    types.MediaType(manifest.contentType),
+			Size:         int64(len(manifest.blob)),
+			Digest:       h,
+			ArtifactType: imageAsArtifact.Config.MediaType,
+			Annotations:  imageAsArtifact.Annotations,
+		})
+	}
+	msg, _ := json.Marshal(&im)
+	resp.Header().Set("Content-Length", fmt.Sprint(len(msg)))
+	resp.Header().Set("Content-Type", string(types.OCIImageIndex))
+	resp.WriteHeader(http.StatusOK)
+	io.Copy(resp, bytes.NewReader([]byte(msg)))
+	return nil
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/registry.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/registry.go
@@ -1,0 +1,144 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package registry implements a docker V2 registry and the OCI distribution specification.
+//
+// It is designed to be used anywhere a low dependency container registry is needed, with an
+// initial focus on tests.
+//
+// Its goal is to be standards compliant and its strictness will increase over time.
+//
+// This is currently a low flightmiles system. It's likely quite safe to use in tests; If you're using it
+// in production, please let us know how and send us CL's for integration tests.
+package registry
+
+import (
+	"fmt"
+	"log"
+	"math/rand"
+	"net/http"
+	"os"
+)
+
+type registry struct {
+	log              *log.Logger
+	blobs            blobs
+	manifests        manifests
+	referrersEnabled bool
+	warnings         map[float64]string
+}
+
+// https://docs.docker.com/registry/spec/api/#api-version-check
+// https://github.com/opencontainers/distribution-spec/blob/master/spec.md#api-version-check
+func (r *registry) v2(resp http.ResponseWriter, req *http.Request) *regError {
+	if r.warnings != nil {
+		rnd := rand.Float64()
+		for prob, msg := range r.warnings {
+			if prob > rnd {
+				resp.Header().Add("Warning", fmt.Sprintf(`299 - "%s"`, msg))
+			}
+		}
+	}
+
+	if isBlob(req) {
+		return r.blobs.handle(resp, req)
+	}
+	if isManifest(req) {
+		return r.manifests.handle(resp, req)
+	}
+	if isTags(req) {
+		return r.manifests.handleTags(resp, req)
+	}
+	if isCatalog(req) {
+		return r.manifests.handleCatalog(resp, req)
+	}
+	if r.referrersEnabled && isReferrers(req) {
+		return r.manifests.handleReferrers(resp, req)
+	}
+	resp.Header().Set("Docker-Distribution-API-Version", "registry/2.0")
+	if req.URL.Path != "/v2/" && req.URL.Path != "/v2" {
+		return &regError{
+			Status:  http.StatusNotFound,
+			Code:    "METHOD_UNKNOWN",
+			Message: "We don't understand your method + url",
+		}
+	}
+	resp.WriteHeader(200)
+	return nil
+}
+
+func (r *registry) root(resp http.ResponseWriter, req *http.Request) {
+	if rerr := r.v2(resp, req); rerr != nil {
+		r.log.Printf("%s %s %d %s %s", req.Method, req.URL, rerr.Status, rerr.Code, rerr.Message)
+		rerr.Write(resp)
+		return
+	}
+	r.log.Printf("%s %s", req.Method, req.URL)
+}
+
+// New returns a handler which implements the docker registry protocol.
+// It should be registered at the site root.
+func New(opts ...Option) http.Handler {
+	r := &registry{
+		log: log.New(os.Stderr, "", log.LstdFlags),
+		blobs: blobs{
+			blobHandler: &memHandler{m: map[string][]byte{}},
+			uploads:     map[string][]byte{},
+			log:         log.New(os.Stderr, "", log.LstdFlags),
+		},
+		manifests: manifests{
+			manifests: map[string]map[string]manifest{},
+			log:       log.New(os.Stderr, "", log.LstdFlags),
+		},
+	}
+	for _, o := range opts {
+		o(r)
+	}
+	return http.HandlerFunc(r.root)
+}
+
+// Option describes the available options
+// for creating the registry.
+type Option func(r *registry)
+
+// Logger overrides the logger used to record requests to the registry.
+func Logger(l *log.Logger) Option {
+	return func(r *registry) {
+		r.log = l
+		r.manifests.log = l
+		r.blobs.log = l
+	}
+}
+
+// WithReferrersSupport enables the referrers API endpoint (OCI 1.1+)
+func WithReferrersSupport(enabled bool) Option {
+	return func(r *registry) {
+		r.referrersEnabled = enabled
+	}
+}
+
+func WithWarning(prob float64, msg string) Option {
+	return func(r *registry) {
+		if r.warnings == nil {
+			r.warnings = map[float64]string{}
+		}
+		r.warnings[prob] = msg
+	}
+}
+
+func WithBlobHandler(h BlobHandler) Option {
+	return func(r *registry) {
+		r.blobs.blobHandler = h
+	}
+}

--- a/vendor/github.com/google/go-containerregistry/pkg/registry/tls.go
+++ b/vendor/github.com/google/go-containerregistry/pkg/registry/tls.go
@@ -1,0 +1,29 @@
+// Copyright 2018 Google LLC All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package registry
+
+import (
+	"net/http/httptest"
+
+	ggcrtest "github.com/google/go-containerregistry/internal/httptest"
+)
+
+// TLS returns an httptest server, with an http client that has been configured to
+// send all requests to the returned server. The TLS certs are generated for the given domain
+// which should correspond to the domain the image is stored in.
+// If you need a transport, Client().Transport is correctly configured.
+func TLS(domain string) (*httptest.Server, error) {
+	return ggcrtest.NewTLSServer(domain, New())
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -752,6 +752,7 @@ github.com/google/go-cmp/cmp/internal/value
 github.com/google/go-containerregistry/internal/and
 github.com/google/go-containerregistry/internal/compression
 github.com/google/go-containerregistry/internal/gzip
+github.com/google/go-containerregistry/internal/httptest
 github.com/google/go-containerregistry/internal/ipaddr
 github.com/google/go-containerregistry/internal/limit
 github.com/google/go-containerregistry/internal/redact
@@ -764,6 +765,7 @@ github.com/google/go-containerregistry/pkg/authn/github
 github.com/google/go-containerregistry/pkg/compression
 github.com/google/go-containerregistry/pkg/logs
 github.com/google/go-containerregistry/pkg/name
+github.com/google/go-containerregistry/pkg/registry
 github.com/google/go-containerregistry/pkg/v1
 github.com/google/go-containerregistry/pkg/v1/empty
 github.com/google/go-containerregistry/pkg/v1/google


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it:

Four follow-ups from the KEP-6061 artifact work.

**Reproducible digests.** ORAS stamps `org.opencontainers.image.created` with the current time, so pushing identical content produced a new digest every time and left untagged manifests behind in staging. The annotation is now fixed to `1970-01-01T00:00:00Z` unless `--annotations` sets it or `SOURCE_DATE_EPOCH` is exported (the reproducible-builds convention; a non-integer value is an error). `--annotations` now splits on the first colon only, so a timestamp value keeps its own colons. The publishing scripts' skip logic stays, but as an optimization rather than a necessity, and the docs say so.

**Hermetic spoc tests.** `spoc push` and `spoc pull` gain `--plain-http` for registries without TLS (cosign's sign and verify get the matching HTTP allowance). The spoc e2e suite, which only exercised `record` so far, now runs a push and pull round trip against an in-process registry (`go-containerregistry/pkg/registry` over `httptest`): the runtime-spec format, the profile CRD format, the push-time rejection of what runtimes reject together with `--disable-artifact-validation`, and digest stability across two pushes of the same content. None of it needs network access.

**AppArmor e2e race.** After `enableAppArmor` is patched, the operator updates the spod daemonset twice, and `rollout status` could return between the two updates; the test pod was then created before the restarted spod's recorder was up, nothing was recorded, and the merged profile never appeared (seen on the first run of #3432). `wait_for_spod` waits until the daemonset's generation stays unchanged across a rollout before the script continues.

**Release flip for the base-profile e2e.** `hack/release.sh` and `hack/back-to-dev.sh` rewrite `test/e2e_test.go` between staging and `registry.k8s.io`, but the runtime-format base profile test hardcoded the staging-only `latest` tag, so a release branch kept testing staging. The test now derives the tag from the recorded profile's `metadata.name` (`runc-v1.5.1`), the way the seccomp e2e script already does, and the two scripts flip only the registry prefix; on `main` it reads the versioned staging artifact, on a release branch the promoted one. `latest` in staging stays for manual pulls.

`PullSignatureOptions` is renamed to `PullOptions` since it carries the transport option now.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Unit tests for the `created` annotation (default, explicit annotation, `SOURCE_DATE_EPOCH`, invalid value), for plain HTTP reaching the repository, and for annotation values with colons. The new spoc e2e subtests run in the existing `e2e-spoc` job.

#### Special notes for your reviewer:

The vendor tree gains `github.com/google/go-containerregistry/pkg/registry`, used by the e2e test only.

#### Does this PR introduce a user-facing change?

```release-note
`spoc push` now fixes the manifest's `org.opencontainers.image.created` annotation to `1970-01-01T00:00:00Z` unless `--annotations` sets it or `SOURCE_DATE_EPOCH` is exported, so identical content yields the same digest. `spoc push` and `spoc pull` gain `--plain-http` for registries without TLS.
```
