### PR TITLE
Harden the artifact pull path

### DIFF
--- a/cli.md
+++ b/cli.md
@@ -236,6 +236,12 @@ The manifest's `org.opencontainers.image.created` annotation is fixed to
 builds convention). Pushing identical content again therefore yields the
 same digest instead of a new, untagged manifest.
 
+`spoc pull` refuses to fetch any artifact blob larger than 16 MiB, so a
+registry cannot make the client read arbitrary amounts of data. The
+credentials given via `--username` and `$PASSWORD` are used for the registry
+access of the signature as well, both when signing on push and when verifying
+on pull.
+
 `--plain-http` on `spoc push` and `spoc pull` reaches the registry over HTTP
 instead of HTTPS, for local registries in tests and other registries without
 TLS.

--- a/hack/ci/install-spo.sh
+++ b/hack/ci/install-spo.sh
@@ -31,8 +31,25 @@ k_wait() {
 # stayed unchanged for a grace period. A spec change makes the operator update
 # the daemonset more than once, and "rollout status" can return between two of
 # those updates, so a test that continues right away races the next restart.
+# With a daemonset generation as argument it first waits for the operator to
+# move the daemonset past that generation, because until then the unchanged
+# daemonset counts as rolled out, and fails if that does not happen.
 wait_for_spod() {
-  local generation previous=""
+  local generation previous="${1:-}"
+  if [[ -n "$previous" ]]; then
+    for ((i = 0; i < 30; i++)); do
+      generation=$(k get ds spod -o jsonpath='{.metadata.generation}')
+      if [[ "$generation" != "$previous" ]]; then
+        break
+      fi
+      sleep 2
+    done
+    if [[ "$generation" == "$previous" ]]; then
+      echo "spod daemonset generation $previous did not change"
+      return 1
+    fi
+  fi
+  previous=""
   for ((i = 0; i < 30; i++)); do
     k rollout status ds spod --timeout 360s
     generation=$(k get ds spod -o jsonpath='{.metadata.generation}')
@@ -128,10 +145,9 @@ install_operator() {
       echo "Error: DaemonSet 'spod' not found or could not get its status."
       exit 1
   fi
+  INITIAL_SPOD_DS_GENERATION=$(k get ds spod -o jsonpath='{.metadata.generation}')
   k patch spod spod --type=merge -p '{"spec":{"enricher":{"enableBpfRecorder":true}}}'
-  # Wait for security profiles operator to modify the spod daemonset
-  sleep 5
-  k rollout status ds spod --timeout 360s
+  wait_for_spod "$INITIAL_SPOD_DS_GENERATION"
   PATCHED_SPOD_DS_VERSION=$(k get controllerrevision -l name=spod --sort-by=.revision -o=jsonpath='{.items[-1].revision}' 2>/dev/null)
 
   if [ "$PATCHED_SPOD_DS_VERSION" -gt "$INITIAL_SPOD_DS_VERSION" ]; then
@@ -140,5 +156,4 @@ install_operator() {
       echo "Failure. The DaemonSet version did not change. It is still $PATCHED_SPOD_DS_VERSION."
       exit 1
   fi
-  k_wait spod spod
 }

--- a/internal/pkg/artifact/artifact.go
+++ b/internal/pkg/artifact/artifact.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/opencontainers/go-digest"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	specs "github.com/opencontainers/runtime-spec/specs-go"
@@ -137,6 +138,20 @@ type PullOptions struct {
 	//
 	// As with AllowedIdentityRegexp, the default ".*" matches every issuer.
 	AllowedOidcIssuerRegexp string
+
+	// MaxBlobSize is the largest blob of the artifact, in bytes, the pull
+	// copies from the registry. Bigger blobs fail the pull before they are
+	// fetched. Zero means DefaultMaxBlobSize.
+	MaxBlobSize int64
+}
+
+// maxBlobSize returns the blob size limit to apply on pull.
+func (p *PullOptions) maxBlobSize() int64 {
+	if p.MaxBlobSize > 0 {
+		return p.MaxBlobSize
+	}
+
+	return DefaultMaxBlobSize
 }
 
 // PushOptions are the options for pushing an OCI artifact.
@@ -343,7 +358,7 @@ func (a *Artifact) Push(
 		Upload:           true,
 		TlogUpload:       true,
 		SkipConfirmation: true,
-		Registry:         options.RegistryOptions{AllowHTTPRegistry: plainHTTP},
+		Registry:         registryOptions(username, password, plainHTTP),
 		Rekor:            options.RekorOptions{URL: options.DefaultRekorURL},
 		Fulcio:           options.FulcioOptions{URL: options.DefaultFulcioURL},
 		OIDC: options.OIDCOptions{
@@ -435,7 +450,7 @@ func (a *Artifact) Pull(
 		}
 
 		v := verify.VerifyCommand{
-			RegistryOptions: options.RegistryOptions{AllowHTTPRegistry: plainHTTP},
+			RegistryOptions: registryOptions(username, password, plainHTTP),
 			CertVerifyOptions: options.CertVerifyOptions{
 				CertIdentityRegexp:   signOpts.AllowedIdentityRegexp,
 				CertOidcIssuerRegexp: signOpts.AllowedOidcIssuerRegexp,
@@ -473,8 +488,11 @@ func (a *Artifact) Pull(
 	a.logger.Info("Copying profile from repository")
 	a.logger.Info("Source image", "image", from)
 
+	copyOptions := oras.DefaultCopyOptions
+	copyOptions.PreCopy = blobSizeLimit(signOpts.maxBlobSize())
+
 	manifestDescriptor, err := a.Copy(
-		ctx, repo, sha.String(), store, sha.String(), oras.DefaultCopyOptions,
+		ctx, repo, sha.String(), store, sha.String(), copyOptions,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("copy from repository: %w", err)
@@ -565,6 +583,36 @@ func (a *Artifact) imageWithDigest(
 
 	return fmt.Sprintf("%s@%s", ref.Context().Name(),
 		desc.Digest.String()), repo, desc.Digest, nil
+}
+
+// registryOptions returns the cosign registry options matching the registry
+// access ORAS uses, so that signing and verification reach the signature of
+// a private artifact with the caller's credentials instead of only the
+// ambient keychain.
+func registryOptions(username, password string, plainHTTP bool) options.RegistryOptions {
+	return options.RegistryOptions{
+		AllowHTTPRegistry: plainHTTP,
+		AuthConfig:        authn.AuthConfig{Username: username, Password: password},
+	}
+}
+
+// blobSizeLimit returns the ORAS PreCopy hook which rejects every blob of the
+// artifact larger than limit before it is fetched. ORAS reads the manifest
+// first to find the blobs, bounded by its own metadata limit, and runs the
+// hook on the manifest as well before storing it. The store then enforces the
+// descriptor sizes while copying, so nothing bigger reaches the profile
+// decoding either.
+func blobSizeLimit(limit int64) func(context.Context, v1.Descriptor) error {
+	return func(_ context.Context, desc v1.Descriptor) error {
+		if desc.Size > limit {
+			return fmt.Errorf(
+				"%w: blob %s (%s) has %d bytes, limit is %d",
+				ErrBlobTooLarge, desc.Digest, desc.MediaType, desc.Size, limit,
+			)
+		}
+
+		return nil
+	}
 }
 
 // profileEntry is a profile to be added to the artifact store on push.
@@ -769,7 +817,9 @@ func (a *Artifact) manifest(
 	return manifest, nil
 }
 
-// blobContent returns the content of a blob from the store.
+// blobContent returns the content of a blob from the store. The read is
+// bounded by the size limit of the pull: the store verified every blob
+// against its descriptor on copy, and the descriptors passed blobSizeLimit.
 func (a *Artifact) blobContent(
 	ctx context.Context, store *file.Store, descriptor *v1.Descriptor,
 ) ([]byte, error) {
@@ -859,12 +909,12 @@ func (a *Artifact) validateRuntimeSpec(
 		)
 	}
 
-	if len(content) > maxProfileSize {
+	if int64(len(content)) > MaxRuntimeProfileSize {
 		a.logger.Info(
 			"Profile is larger than container runtimes accept by default",
 			"file", path,
 			"size", len(content),
-			"limit", maxProfileSize,
+			"limit", MaxRuntimeProfileSize,
 		)
 	}
 

--- a/internal/pkg/artifact/artifact_test.go
+++ b/internal/pkg/artifact/artifact_test.go
@@ -1227,13 +1227,13 @@ func TestValidateRuntimeSpec(t *testing.T) {
 		{
 			name:        "oversized profile",
 			runtimeSpec: &specs.LinuxSeccomp{DefaultAction: specs.ActErrno},
-			content:     make([]byte, maxProfileSize+1),
+			content:     make([]byte, MaxRuntimeProfileSize+1),
 			wantLogs:    []string{"larger than container runtimes accept"},
 		},
 		{
 			name:        "profile at the size limit",
 			runtimeSpec: &specs.LinuxSeccomp{DefaultAction: specs.ActErrno},
-			content:     make([]byte, maxProfileSize),
+			content:     make([]byte, MaxRuntimeProfileSize),
 		},
 		{
 			name: "many distinct syscalls are fine",
@@ -1369,4 +1369,171 @@ func TestPushPlainHTTP(t *testing.T) {
 	)
 	require.NoError(t, err)
 	require.True(t, repo.PlainHTTP, "the repository must use plain HTTP when asked")
+}
+
+// TestPullBlobSizeLimit verifies that the pull refuses to copy blobs above
+// the size limit before fetching them, and that the limit defaults when the
+// options do not set one.
+func TestPullBlobSizeLimit(t *testing.T) {
+	t.Parallel()
+
+	testRef, err := name.ParseReference("docker.io/foo/bar:v1")
+	require.NoError(t, err)
+
+	for _, tc := range []struct {
+		name      string
+		opts      *PullOptions
+		limit     int64
+		blobSize  int64
+		expectErr bool
+	}{
+		{
+			name:     "default limit accepts blob at the limit",
+			opts:     &PullOptions{},
+			limit:    DefaultMaxBlobSize,
+			blobSize: DefaultMaxBlobSize,
+		},
+		{
+			name:      "default limit rejects blob above the limit",
+			opts:      &PullOptions{},
+			limit:     DefaultMaxBlobSize,
+			blobSize:  DefaultMaxBlobSize + 1,
+			expectErr: true,
+		},
+		{
+			name:     "custom limit accepts blob at the limit",
+			opts:     &PullOptions{MaxBlobSize: 512},
+			limit:    512,
+			blobSize: 512,
+		},
+		{
+			name:      "custom limit rejects blob above the limit",
+			opts:      &PullOptions{MaxBlobSize: 512},
+			limit:     512,
+			blobSize:  513,
+			expectErr: true,
+		},
+		{
+			name:      "nil options use the default limit",
+			limit:     DefaultMaxBlobSize,
+			blobSize:  DefaultMaxBlobSize + 1,
+			expectErr: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			mock := &artifactfakes.FakeImpl{}
+			mock.NewRepositoryReturns(&remote.Repository{}, nil)
+			mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+			mock.ParseReferenceReturns(testRef, nil)
+			mock.VerifyCmdReturns(nil)
+			mock.ReadFileReturns([]byte{}, nil)
+			mock.ReadProfileReturns(&seccompprofileapi.SeccompProfile{}, nil)
+			stubManifest(mock, &ocispec.Manifest{}, nil)
+
+			// Run the size check the way ORAS does for every node of the
+			// artifact and fail the copy on its error.
+			mock.CopyStub = func(
+				ctx context.Context, _ oras.ReadOnlyTarget, _ string,
+				_ oras.Target, _ string, opts oras.CopyOptions,
+			) (ocispec.Descriptor, error) {
+				require.NotNil(t, opts.PreCopy)
+
+				descriptor := testLayer("")
+				descriptor.Size = tc.blobSize
+
+				if err := opts.PreCopy(ctx, descriptor); err != nil {
+					return ocispec.Descriptor{}, err
+				}
+
+				return ocispec.Descriptor{}, nil
+			}
+
+			sut := New(logr.Discard())
+			sut.impl = mock
+
+			res, err := sut.Pull(t.Context(), "", "", "", nil, tc.opts)
+			if tc.expectErr {
+				require.ErrorIs(t, err, ErrBlobTooLarge)
+				require.ErrorContains(t, err, strconv.FormatInt(tc.limit, 10))
+				require.Nil(t, res)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, res)
+		})
+	}
+}
+
+// TestRegistryOptions verifies that signing and verification get the registry
+// credentials of the push or pull, so that signatures of private artifacts
+// are reachable with the same login as the artifact itself.
+func TestRegistryOptions(t *testing.T) {
+	t.Parallel()
+
+	testRef, err := name.ParseReference("docker.io/foo/bar:v1")
+	require.NoError(t, err)
+
+	t.Run("push", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &artifactfakes.FakeImpl{}
+		mock.ReadFileReturns([]byte(`{"defaultAction":"SCMP_ACT_ERRNO"}`), nil)
+		mock.StoreAddReturns(defaultDescriptor(), nil)
+		mock.ParseReferenceReturns(testRef, nil)
+		mock.NewRepositoryReturns(&remote.Repository{}, nil)
+
+		sut := New(logr.Discard())
+		sut.impl = mock
+
+		err := sut.Push(
+			map[*ocispec.Platform]string{nil: "profile.json"},
+			"", "user", "secret", nil, &PushOptions{PlainHTTP: true},
+		)
+		require.NoError(t, err)
+		require.Equal(t, 1, mock.SignCmdCallCount())
+
+		_, _, signOpts, _ := mock.SignCmdArgsForCall(0)
+		require.True(t, signOpts.Registry.AllowHTTPRegistry)
+		require.Equal(t, "user", signOpts.Registry.AuthConfig.Username)
+		require.Equal(t, "secret", signOpts.Registry.AuthConfig.Password)
+	})
+
+	t.Run("pull", func(t *testing.T) {
+		t.Parallel()
+
+		mock := &artifactfakes.FakeImpl{}
+		mock.NewRepositoryReturns(&remote.Repository{}, nil)
+		mock.ResolveRepositoryReturns(ocispec.Descriptor{}, nil)
+		mock.ParseReferenceReturns(testRef, nil)
+		mock.ReadFileReturns([]byte{}, nil)
+		mock.ReadProfileReturns(&seccompprofileapi.SeccompProfile{}, nil)
+		stubManifest(mock, &ocispec.Manifest{}, nil)
+
+		sut := New(logr.Discard())
+		sut.impl = mock
+
+		_, err := sut.Pull(
+			t.Context(), "", "user", "secret", nil, &PullOptions{PlainHTTP: true},
+		)
+		require.NoError(t, err)
+		require.Equal(t, 1, mock.VerifyCmdCallCount())
+
+		_, verifyCmd, _ := mock.VerifyCmdArgsForCall(0)
+		require.True(t, verifyCmd.AllowHTTPRegistry)
+		require.Equal(t, "user", verifyCmd.AuthConfig.Username)
+		require.Equal(t, "secret", verifyCmd.AuthConfig.Password)
+	})
+
+	t.Run("anonymous", func(t *testing.T) {
+		t.Parallel()
+
+		opts := registryOptions("", "", false)
+		require.False(t, opts.AllowHTTPRegistry)
+		require.Empty(t, opts.AuthConfig.Username)
+		require.Empty(t, opts.AuthConfig.Password)
+	})
 }

--- a/internal/pkg/artifact/consts.go
+++ b/internal/pkg/artifact/consts.go
@@ -48,12 +48,20 @@ const (
 	// layerMediaTypeJSON is the layer media type of raw JSON profiles.
 	layerMediaTypeJSON = "application/json"
 
-	// maxProfileSize is the artifact size limit container runtimes apply by
-	// default when they validate a KEP-6061 artifact. It is runtime
+	// MaxRuntimeProfileSize is the artifact size limit container runtimes
+	// apply by default when they validate a KEP-6061 artifact. It is runtime
 	// configuration rather than part of the format, so exceeding it is a
 	// warning on push and not an error. Everything else runtimes reject is
 	// checked with the merge library's ValidateArtifact and fails the push.
-	maxProfileSize = 1 << 20
+	// The operator daemon uses it as the blob size limit for base profiles,
+	// since a bigger base profile could not be used by a runtime either.
+	MaxRuntimeProfileSize int64 = 1 << 20
+
+	// DefaultMaxBlobSize is the largest blob Pull copies from a registry
+	// unless PullOptions.MaxBlobSize sets a limit. Pulled profiles are read
+	// into memory, so the registry must not decide how much gets allocated.
+	// The default is far above any real profile.
+	DefaultMaxBlobSize int64 = 16 << 20
 
 	// defaultTimeout is the default timeout for push and pull operations.
 	defaultTimeout = 5 * time.Minute
@@ -130,6 +138,10 @@ var (
 	// ErrNoSingleLayer is returned when an artifact without a known profile
 	// layer name does not have exactly one layer to fall back to.
 	ErrNoSingleLayer = errors.New("artifact has no single layer to read the profile from")
+
+	// ErrBlobTooLarge is returned when a blob of the pulled artifact exceeds
+	// the size limit of the pull.
+	ErrBlobTooLarge = errors.New("artifact blob exceeds the size limit")
 
 	// ErrPlatformMismatch is returned when the only layer of an artifact is
 	// bound to another platform than the requested one.

--- a/internal/pkg/artifact/fuzz_test.go
+++ b/internal/pkg/artifact/fuzz_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package artifact
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// FuzzDecodeRuntimeSpecSeccompProfile feeds arbitrary artifact content into
+// the runtime format decoding, which handles registry content before any
+// signature constraint is applied by default. Accepted content has to be
+// stable: encoding and decoding it again must not change it.
+func FuzzDecodeRuntimeSpecSeccompProfile(f *testing.F) {
+	for _, seed := range []string{
+		rawSeccompJSON,
+		rawSeccompArgJSON,
+		`{"defaultAction":"SCMP_ACT_ERRNO"}`,
+		`{"defaultAction":"SCMP_ACT_ERRNO","defaultErrnoRet":1,"flags":["SCMP_FLTFLG_LOG"]}`,
+		`{"defaultAction":"SCMP_ACT_ERRNO","listenerPath":"/run/notify.sock"}`,
+		`{"defaultAction":"SCMP_ACT_ERRNO"} {}`,
+		`{"defaultAction":"SCMP_ACT_ERRNO","unknown":true}`,
+		`{"syscalls":[]}`,
+		`{}`,
+		`[]`,
+		`null`,
+		``,
+	} {
+		f.Add([]byte(seed))
+	}
+
+	f.Fuzz(func(t *testing.T, content []byte) {
+		profile, err := decodeRuntimeSpecSeccompProfile(content)
+		if err != nil {
+			require.Nil(t, profile)
+
+			return
+		}
+
+		require.NotEmpty(t, profile.DefaultAction)
+
+		encoded, err := json.Marshal(profile)
+		require.NoError(t, err)
+
+		decoded, err := decodeRuntimeSpecSeccompProfile(encoded)
+		require.NoError(t, err)
+
+		again, err := json.Marshal(decoded)
+		require.NoError(t, err)
+		require.JSONEq(t, string(encoded), string(again))
+
+		// The CRD conversion may reject values the CRD cannot hold, but has
+		// to agree on the default action otherwise.
+		spec, err := runtimeSpecSeccompProfileSpec(content)
+		if err == nil {
+			require.Equal(t, string(profile.DefaultAction), string(spec.DefaultAction))
+		}
+	})
+}
+
+// FuzzNameFromReference verifies that every reference results in a usable
+// object name: not empty, only lower case alphanumerics, dots and dashes, and
+// not starting or ending with a separator. The derivation is idempotent.
+func FuzzNameFromReference(f *testing.F) {
+	for _, seed := range []string{
+		"",
+		"registry.k8s.io/security-profiles-operator/base/runc:v1.5.1",
+		"localhost:5000/Profile@sha256:0123456789abcdef",
+		"ghcr.io/org/my__profile",
+		"-.-",
+		"a/b/c:d@e",
+		"ÜBER/profile",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, ref string) {
+		profileName := nameFromReference(ref)
+		require.NotEmpty(t, profileName)
+		require.Regexp(t, `^[a-z0-9]([a-z0-9.-]*[a-z0-9])?$`, profileName)
+		require.Equal(t, profileName, nameFromReference(profileName))
+	})
+}

--- a/internal/pkg/daemon/seccompprofile/seccompprofile.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile.go
@@ -97,6 +97,11 @@ func NewController() controller.Controller {
 		baseProfiles: ttlcache.New(
 			ttlcache.WithTTL[string, *seccompprofileapi.SeccompProfile](defaultCacheTimeout),
 			ttlcache.WithCapacity[string, *seccompprofileapi.SeccompProfile](maxCacheItems),
+			// A base profile referenced by tag has to be pulled again after
+			// the TTL to pick up a new version, no matter how often it is
+			// used in between. Touching on hit would keep a busy profile
+			// stale forever.
+			ttlcache.WithDisableTouchOnHit[string, *seccompprofileapi.SeccompProfile](),
 		),
 	}
 }
@@ -415,25 +420,32 @@ func (r *Reconciler) resolveSyscallsForProfile(
 				spod.Spec.Security.AllowedOidcIssuerRegexp = allowedAllRegexp
 			}
 
-			signOpts := &artifact.PullOptions{
+			pullOpts := &artifact.PullOptions{
 				DisableSignatureVerification: ptr.Deref(
 					spod.Spec.Security.DisableOCIArtifactSignatureVerification,
 					false,
 				),
 				AllowedIdentityRegexp:   spod.Spec.Security.AllowedIdentityRegexp,
 				AllowedOidcIssuerRegexp: spod.Spec.Security.AllowedOidcIssuerRegexp,
+				// A base profile bigger than what container runtimes accept
+				// is of no use, and the registry must not decide how much
+				// memory the daemon allocates on every node.
+				MaxBlobSize: artifact.MaxRuntimeProfileSize,
 			}
 			l.Info(
 				"Pulling base profile: "+from,
-				"disableOCIArtifactSignatureVerification", signOpts.DisableSignatureVerification,
-				"allowedIdentityRegexp", signOpts.AllowedIdentityRegexp,
-				"allowedOidcIssuerRegexp", signOpts.AllowedOidcIssuerRegexp,
+				"disableOCIArtifactSignatureVerification", pullOpts.DisableSignatureVerification,
+				"allowedIdentityRegexp", pullOpts.AllowedIdentityRegexp,
+				"allowedOidcIssuerRegexp", pullOpts.AllowedOidcIssuerRegexp,
+				"maxBlobSize", pullOpts.MaxBlobSize,
 			)
 
+			// The pull is anonymous: the daemon has no registry credentials,
+			// so base profiles have to be publicly readable.
 			res, err := r.Pull(ctx, l, from, "", "", &v1.Platform{
 				Architecture: runtime.GOARCH,
 				OS:           runtime.GOOS,
-			}, signOpts)
+			}, pullOpts)
 			if err != nil {
 				l.Error(err, "cannot pull base profile", "profile", baseProfileName)
 				r.IncSeccompProfileError(r.metrics, reasonCannotPullProfile)

--- a/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
+++ b/internal/pkg/daemon/seccompprofile/seccompprofile_test.go
@@ -783,3 +783,57 @@ func TestResolveSyscallsForProfile(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveSyscallsForProfileBaseProfileCache verifies that a remote base
+// profile is pulled once, anonymously and with the runtime size limit, and
+// that later resolutions of the same reference use the cache.
+func TestResolveSyscallsForProfileBaseProfileCache(t *testing.T) {
+	t.Parallel()
+
+	mock := &seccompprofilefakes.FakeImpl{}
+	mock.GetSPODReturns(&spodapi.SecurityProfilesOperatorDaemon{}, nil)
+	mock.PullResultTypeReturns(artifact.PullResultTypeSeccompProfile)
+	mock.PullResultSeccompProfileReturns(&seccompprofileapi.SeccompProfile{
+		Spec: seccompprofileapi.SeccompProfileSpec{
+			Syscalls: []seccompprofileapi.Syscall{
+				{Names: []string{"second"}, Action: seccompprofileapi.ActAllow},
+			},
+		},
+	})
+
+	sut, ok := NewController().(*Reconciler)
+	require.True(t, ok)
+
+	sut.impl = mock
+
+	sp := &seccompprofileapi.SeccompProfile{
+		Spec: seccompprofileapi.SeccompProfileSpec{
+			BaseProfileName: config.OCIProfilePrefix + "registry/base:v1",
+			Syscalls: []seccompprofileapi.Syscall{
+				{Names: []string{"first"}, Action: seccompprofileapi.ActAllow},
+			},
+		},
+	}
+
+	for range 3 {
+		syscalls, err := sut.resolveSyscallsForProfile(
+			t.Context(), sp, sp.Spec.Syscalls, logr.Discard(), 0,
+		)
+		require.NoError(t, err)
+		require.Len(t, syscalls, 1)
+		require.Equal(t, []string{"first", "second"}, syscalls[0].Names)
+	}
+
+	require.Equal(t, 1, mock.PullCallCount(), "later resolutions must use the cache")
+	require.Equal(t, 1, mock.GetSPODCallCount())
+
+	_, _, from, username, password, platform, opts := mock.PullArgsForCall(0)
+	require.Equal(t, "registry/base:v1", from)
+	require.Empty(t, username)
+	require.Empty(t, password)
+	require.NotNil(t, platform)
+	require.Equal(t, artifact.MaxRuntimeProfileSize, opts.MaxBlobSize)
+	require.False(t, opts.DisableSignatureVerification)
+	require.Equal(t, allowedAllRegexp, opts.AllowedIdentityRegexp)
+	require.Equal(t, allowedAllRegexp, opts.AllowedOidcIssuerRegexp)
+}

--- a/profiles.md
+++ b/profiles.md
@@ -1196,9 +1196,25 @@ ignored, including the ones the CRD cannot express such as `defaultErrnoRet`.
 
 The operator internally caches pulled artifacts up to 24 hours for 1000
 profiles, means that they will be refreshed after that time period, if the stack
-is full or the operator daemon gets restarted. It is also possible to define
+is full or the operator daemon gets restarted. Using a cached profile does not
+extend its cache time, so a base profile referenced by tag picks up a new
+version within 24 hours no matter how often it is used. Reference the base
+profile by digest to pin the exact content. It is also possible to define
 additional `baseProfileName` for existing base profiles, so the operator will
 recursively resolve them up to a level of 15 stacked profiles.
+
+A few limits apply to base profiles pulled by the operator:
+
+- The pull is anonymous. The operator daemon has no registry credentials, so
+  the artifact and its signature have to be publicly readable.
+- Every blob of the artifact has to be at most 1 MiB, the size limit container
+  runtimes apply to seccomp profile artifacts. Bigger blobs fail the pull
+  before they are fetched.
+- Signature verification accepts any valid signature by default, see the
+  [security model](security-model.md#oci-artifact-signature-verification) for
+  how to constrain it to the signers you trust. Disabling verification via
+  `disableOciArtifactSignatureVerification` makes the operator use whatever the
+  registry serves.
 
 Because the resulting syscalls may be hidden from the user, we additionally annotate
 the seccomp profile with the final results:


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it:

Follow-ups from a review of the artifact pull path.

**Blob size limit on pull.** The copy from the registry used the ORAS defaults and the profile blob was read into memory without a bound, so whoever controls a referenced registry decided how much memory every spod node allocated for an `oci://` base profile, and any user able to create a `SeccompProfile` could point spod at such an artifact. `Pull` now rejects every blob above `PullOptions.MaxBlobSize` in an ORAS `PreCopy` hook, before it is fetched. `spoc pull` uses 16 MiB, the daemon 1 MiB, which is the limit container runtimes apply to seccomp profile artifacts, so a bigger base profile would be of no use anyway.

**Registry credentials for signatures.** `--username` and `$PASSWORD` reached ORAS only; cosign signed and verified with the ambient keychain, so a private artifact could neither be signed on push nor verified on pull. Both now get the same credentials.

**Base profile cache.** The ttlcache extended the 24h TTL on every hit, so a base profile referenced by tag and used regularly was never pulled again. Touch on hit is disabled; digests remain the way to pin content.

**CI rollout race.** `install-spo.sh` slept 5 seconds after patching `enableBpfRecorder` and then waited for a rollout that may not have started, or that was between the operator's two daemonset updates. `wait_for_spod` now takes the pre-patch daemonset generation, waits for the operator to move past it and fails if that does not happen, and then waits for the generation to settle.

**Docs.** profiles.md states that base profile pulls are anonymous, size limited and verified with the defaults described in security-model.md, and that digests pin content. cli.md documents the limit and the credential reuse.

#### Which issue(s) this PR fixes:

None

#### Does this PR have test?

Unit tests for the size limit (default and custom, at and above the limit), for the registry options of sign and verify, and for the daemon pulling a base profile once and serving later resolutions from the cache. Fuzz targets for the runtime-spec decoding (accepted content has to survive a round trip) and for the profile name derivation; they run with their seeds as part of the unit tests.

#### Special notes for your reviewer:

A blob above 1 MiB now fails an `oci://` base profile pull in the daemon. Container runtimes reject such artifacts as well and no published base profile comes close, so existing users should not be affected.

#### Does this PR introduce a user-facing change?

```release-note
`spoc pull` and the operator's `oci://` base profile pulls reject artifact blobs above a size limit (16 MiB for `spoc pull`, 1 MiB for base profiles) before fetching them. `spoc push` and `spoc pull` use the registry credentials for signing and signature verification as well. The operator re-resolves base profile tags after 24 hours regardless of how often they are used.
```
